### PR TITLE
Chore/maintenance bundle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,162 @@
+# Contributing to WxAlert / SPCBot
+
+This document covers the bot's internal architecture, slash command reference,
+channel configuration, and operational behavior for contributors and operators.
+
+---
+
+## Channel Configuration
+
+Two channel IDs are required in `.env`:
+
+| Variable | Purpose |
+|---|---|
+| `SPC_CHANNEL_ID` | Receives all severe weather alerts — SPC outlooks (Days 1–3), Day 4–8 outlooks, mesoscale discussions, watch alerts and cancellations, and bot health alerts from the watchdog |
+| `MODELS_CHANNEL_ID` | Receives model/forecast graphics — SCP twice-daily posts, CSU-MLP daily forecasts, and NCAR WxNext2 daily forecasts |
+
+Slash commands can be used from any channel — they always respond ephemerally
+or inline where invoked, not into the configured channels.
+
+---
+
+## Slash Command Reference
+
+### SPC Outlooks
+| Command | Description |
+|---|---|
+| `/spc1` | Fetch and display the latest SPC Day 1 outlook graphics |
+| `/spc2` | Fetch and display the latest SPC Day 2 outlook graphics |
+| `/spc3` | Fetch and display the latest SPC Day 3 outlook graphics |
+| `/spc48` | Fetch and display the latest SPC Day 4–8 outlook graphics |
+
+### Watches & Mesoscale Discussions
+| Command | Description |
+|---|---|
+| `/watches` | Show all currently active SPC watches with details and probabilities |
+| `/ww` | Alias for `/watches` |
+| `/md` | Show the latest active SPC mesoscale discussion |
+
+### Model Forecasts
+| Command | Description |
+|---|---|
+| `/scp` | Show the latest NIU/Gensini SCP forecast graphics |
+| `/csu1` – `/csu8` | Show CSU-MLP ML severe weather forecast for Days 1–8 |
+| `/csupanel12` | Show CSU-MLP 6-panel summary for Days 1–2 |
+| `/csupanel38` | Show CSU-MLP 6-panel summary for Days 3–8 |
+| `/wxnext` | Show the latest NCAR WxNext2 Mean AI convective hazard forecast |
+
+### Radar
+| Command | Description |
+|---|---|
+| `/radar` | Open the NEXRAD Level 2 radar downloader UI (site selection, time range, ZIP download) |
+
+### Status
+| Command | Description |
+|---|---|
+| `/status` | Show bot health: task states, last auto-post times, partial update state, tracked MD/watch counts. Ephemeral. |
+
+---
+
+## How Auto-Posting Works
+
+### SPC Outlooks (Days 1–3): Normal and Aggressive Check Mode
+
+The outlook cog runs two loops concurrently:
+
+**`auto_post_spc` (every 30 seconds)** — the normal loop. For each day (1, 2, 3)
+it scrapes the SPC HTML page to resolve the current issuance-time PNG URLs, then
+checks if the URLs have changed since the last post. If they have, it downloads
+the images and posts them to `SPC_CHANNEL_ID`.
+
+**Partial update detection** — sometimes the SPC page updates its tab URLs before
+all images are actually available (returning placeholder content). When this
+happens, the cog enters *partial update state* for that day: it records the new
+URLs and the time it first saw them, but does not post yet.
+
+**`aggressive_check_spc` (every 20 seconds)** — only runs when `partial_update_state`
+is non-empty. It re-checks the affected days more frequently, attempting to
+download the images until they are all non-placeholder. Once all images are
+confirmed real, it posts and clears partial update state. If partial update state
+persists beyond a timeout, the cog posts whatever it has and resets.
+
+You can see which days are in partial update state via `/status`.
+
+### SPC Day 4–8 Outlooks
+
+Posted once daily when the SPC updates the Day 4–8 graphic. Uses HEAD-based
+change detection on the static URL rather than HTML scraping.
+
+### Mesoscale Discussions
+
+The MD cog polls the SPC mesoscale discussion index every 60 seconds. It tracks
+posted MD numbers in a persistent set and posts new ones as they appear. When an
+MD is no longer listed on the index, it posts a cancellation embed.
+
+### Watches
+
+The watch cog runs every 2 minutes. It calls the NWS Alerts API as the primary
+source. The return value has three distinct states:
+
+- `None` — API call failed (HTTP error or bad JSON). The cycle is skipped
+  entirely. `active_watches` is not modified, preventing false cancellations
+  during a transient outage.
+- `{}` — API succeeded and returned zero active watches. Normal processing
+  continues — any watches in `active_watches` that are missing or expired will
+  have cancellation embeds posted.
+- `{...}` — one or more active watches. New ones are posted; expired or missing
+  ones get cancellation embeds.
+
+If the NWS API returns `None`, the `/watches` slash command falls back to
+scraping the SPC watch index HTML directly.
+
+### SCP Graphics
+
+Posted at 6am and 6pm Pacific daily, but only if the images have actually
+changed (hash-based detection). Uses `MODELS_CHANNEL_ID`.
+
+### CSU-MLP and NCAR WxNext2
+
+Both poll once daily around model update time. State is persisted to a JSON file
+in `CACHE_DIR` so restarts don't cause duplicate posts.
+
+---
+
+## Watchdog
+
+A `watchdog_task` loop runs every 2 minutes. It:
+
+1. Probes the HTTP session with a lightweight request and recreates it if dead.
+2. Checks every registered task. If a task has stopped, it restarts it.
+3. After a threshold number of failures, posts a health alert embed to
+   `SPC_CHANNEL_ID`. Watch and MD task failures are flagged as critical.
+
+Tasks are registered with the watchdog in `main.py` after cogs load.
+
+---
+
+## Persistence
+
+All persistent state lives in `CACHE_DIR` (default: `cache/`):
+
+| File | Contents |
+|---|---|
+| `auto_posted_records.json` | Hashes of auto-posted images, used for change detection |
+| `posted_records.json` | Hashes of manually-fetched images |
+| `watch_posted.json` | Set of posted watch numbers (pruned to last 50) |
+| `csu_mlp_posted.json` | Date and set of CSU-MLP days posted today |
+| `ncar_posted.json` | Date and hash of last posted NCAR image |
+
+All writes go through `atomic_json_dump` which writes to a temp file then renames,
+preventing corruption on sudden shutdown.
+
+---
+
+## Running Tests
+
+```bash
+pip install pytest pytest-asyncio
+python -m pytest tests/ -v
+```
+
+Tests use monkeypatched HTTP helpers and fixture payloads — no network access or
+Discord connection required.

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -34,7 +34,7 @@ from utils.persistence import save_set
 logger = logging.getLogger("spc_bot")
 
 
-async def fetch_active_watches_nws() -> Dict[str, dict]:
+async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
     """
     Fetch active SPC watches from the NWS Alerts API.
     Returns dict: watch_num -> {"type": "SVR"|"TORNADO", "expires": datetime}
@@ -45,12 +45,12 @@ async def fetch_active_watches_nws() -> Dict[str, dict]:
         logger.warning(
             f"[WATCH] NWS API returned status {status} — will retry next cycle"
         )
-        return {}
+        return None
     try:
         data = _json.loads(content)
     except Exception as e:
         logger.warning(f"[WATCH] NWS API JSON parse error: {e}")
-        return {}
+        return None
 
     result = {}
     for feature in data.get("features", []):
@@ -90,6 +90,9 @@ async def fetch_latest_watch_numbers() -> List[Tuple[str, str]]:
     falls back to SPC HTML scrape if API fails.
     """
     nws = await fetch_active_watches_nws()
+    if nws is None:
+        logger.warning("[WATCH] NWS API fetch failed — skipping, no fallback for auto loop")
+        return []
     if nws:
         return [(num, info["type"]) for num, info in nws.items()]
 
@@ -424,7 +427,7 @@ async def _execute_watches(interaction: discord.Interaction):
     """Shared implementation for /watches and /ww slash commands."""
     await interaction.response.defer()
     nws_watches = await fetch_active_watches_nws()
-    if not nws_watches:
+    if nws_watches is None or not nws_watches:
         entries = await fetch_latest_watch_numbers()
         nws_watches = {
             num: {"type": wtype, "expires": None} for num, wtype in entries
@@ -494,6 +497,11 @@ class WatchesCog(commands.Cog):
 
         try:
             nws_watches = await fetch_active_watches_nws()
+            if nws_watches is None:
+                logger.warning(
+                    "[WATCH] NWS API fetch failed — skipping cycle, active set unchanged"
+                )
+                return
             now_utc = datetime.now(timezone.utc)
 
             # ── Cancellations ──────────────────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ from discord.ext import commands, tasks
 
 from config import CACHE_DIR, GUILD_ID, TOKEN, CONFIG
 from utils.http import close_session, ensure_session
-from utils.spc_urls import cig_migration
 from utils.cache import (
     auto_cache,
     last_post_times,
@@ -90,8 +89,6 @@ async def on_ready():
     logger.info(f"Logged in as {bot.user} (id={bot.user.id})")
 
     await ensure_session()
-    await cig_migration()
-
     # Startup cleanup: remove cached files older than 7 days
     cache_age_limit = timedelta(days=7)
     now = datetime.now()

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -1,0 +1,197 @@
+# tests/test_watches.py
+"""
+Unit tests for watches VTEC parsing and API failure handling.
+
+Run with: python -m pytest tests/ -v
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestFetchActiveWatchesNWS:
+    """Tests for fetch_active_watches_nws() parsing and failure handling."""
+
+    def _make_response(self, features):
+        """Build a minimal NWS API response payload."""
+        return json.dumps({"features": features}).encode()
+
+    def _make_feature(self, vtec, expires=None):
+        """Build a minimal NWS alert feature with a VTEC string."""
+        return {
+            "properties": {
+                "parameters": {"VTEC": [vtec]},
+                "expires": expires,
+                "ends": None,
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_valid_tornado_watch(self):
+        """Valid TO.A VTEC string is parsed as TORNADO watch."""
+        from cogs.watches import fetch_active_watches_nws
+
+        feature = self._make_feature(
+            "/O.NEW.KWNS.TO.A.0042.260409T1800Z-260410T0000Z/",
+            expires="2026-04-09T18:00:00+00:00",
+        )
+        payload = self._make_response([feature])
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(payload, 200),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert result is not None
+        assert "0042" in result
+        assert result["0042"]["type"] == "TORNADO"
+        assert result["0042"]["expires"] is not None
+
+    @pytest.mark.asyncio
+    async def test_valid_severe_watch(self):
+        """Valid SV.A VTEC string is parsed as SVR watch."""
+        from cogs.watches import fetch_active_watches_nws
+
+        feature = self._make_feature(
+            "/O.NEW.KWNS.SV.A.0101.260409T1800Z-260410T0000Z/",
+        )
+        payload = self._make_response([feature])
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(payload, 200),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert result is not None
+        assert "0101" in result
+        assert result["0101"]["type"] == "SVR"
+
+    @pytest.mark.asyncio
+    async def test_watch_number_zero_padded(self):
+        """Watch numbers are zero-padded to 4 digits."""
+        from cogs.watches import fetch_active_watches_nws
+
+        feature = self._make_feature(
+            "/O.NEW.KWNS.SV.A.0007.260409T1800Z-260410T0000Z/",
+        )
+        payload = self._make_response([feature])
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(payload, 200),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert "0007" in result
+
+    @pytest.mark.asyncio
+    async def test_duplicate_watch_number_deduplicated(self):
+        """Duplicate watch numbers from multiple features are deduplicated."""
+        from cogs.watches import fetch_active_watches_nws
+
+        vtec = "/O.NEW.KWNS.TO.A.0042.260409T1800Z-260410T0000Z/"
+        payload = self._make_response([
+            self._make_feature(vtec),
+            self._make_feature(vtec),
+        ])
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(payload, 200),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert result is not None
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_vtec_skipped(self):
+        """Features with unparseable VTEC strings are skipped gracefully."""
+        from cogs.watches import fetch_active_watches_nws
+
+        feature = self._make_feature("not-a-vtec-string")
+        payload = self._make_response([feature])
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(payload, 200),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_missing_expires_still_returns_entry(self):
+        """Watch with no expires field is still returned with expires=None."""
+        from cogs.watches import fetch_active_watches_nws
+
+        feature = self._make_feature(
+            "/O.NEW.KWNS.SV.A.0055.260409T1800Z-260410T0000Z/",
+            expires=None,
+        )
+        payload = self._make_response([feature])
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(payload, 200),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert "0055" in result
+        assert result["0055"]["expires"] is None
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_none(self):
+        """HTTP non-200 response returns None, not empty dict."""
+        from cogs.watches import fetch_active_watches_nws
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(None, 500),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_json_parse_error_returns_none(self):
+        """Unparseable JSON response returns None, not empty dict."""
+        from cogs.watches import fetch_active_watches_nws
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(b"not json {{{", 200),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_features_returns_empty_dict(self):
+        """API success with zero features returns {} not None."""
+        from cogs.watches import fetch_active_watches_nws
+
+        payload = self._make_response([])
+
+        with patch(
+            "cogs.watches.http_get_bytes",
+            new_callable=AsyncMock,
+            return_value=(payload, 200),
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert result == {}
+        assert result is not None

--- a/utils/spc_urls.py
+++ b/utils/spc_urls.py
@@ -1,23 +1,14 @@
 # utils/spc_urls.py
 import logging
-import os
 import re
 from typing import List
 
 from config import (
-    AUTO_CACHE_FILE,
-    CACHE_DIR,
-    MANUAL_CACHE_FILE,
     SPC_OUTLOOK_BASE,
-    SPC_URLS_FALLBACK,
 )
-from utils.change_detection import get_cache_path_for_url
 from utils.http import http_get_bytes
-from utils.persistence import atomic_json_dump
 
 logger = logging.getLogger("spc_bot")
-
-CIG_MIGRATION_FLAG = os.path.join(CACHE_DIR, ".cig_migration_done")
 
 
 async def get_spc_urls(day: int) -> List[str]:
@@ -98,59 +89,3 @@ async def get_spc_urls(day: int) -> List[str]:
         )
 
     return fallback
-
-
-async def cig_migration():
-    """
-    One-time cache bust for the CIG PNG format rollout on March 3, 2026.
-    Removes stale GIF caches and hash entries so the bot re-downloads fresh PNGs.
-    """
-    if os.path.exists(CIG_MIGRATION_FLAG):
-        return
-
-    # Lazy import to avoid circular import at module level
-    from utils.cache import auto_cache, manual_cache
-
-    logger.info(
-        "[CIG MIGRATION] Running one-time cache bust for CIG PNG format rollout"
-    )
-
-    all_spc_urls = []
-    for day in (1, 2, 3):
-        all_spc_urls.extend(SPC_URLS_FALLBACK[day])
-
-    removed_files = 0
-    for url in all_spc_urls:
-        path = get_cache_path_for_url(url)
-        if os.path.exists(path):
-            try:
-                os.remove(path)
-                removed_files += 1
-                logger.info(f"[CIG MIGRATION] Removed stale cache file: {path}")
-            except Exception as e:
-                logger.warning(f"[CIG MIGRATION] Could not remove {path}: {e}")
-        auto_cache.pop(url, None)
-        manual_cache.pop(url, None)
-
-    spc_keys = [
-        k
-        for k in list(auto_cache.keys())
-        if "spc.noaa.gov/products/outlook" in k
-    ]
-    spc_keys += [
-        k
-        for k in list(manual_cache.keys())
-        if "spc.noaa.gov/products/outlook" in k
-    ]
-    for k in spc_keys:
-        auto_cache.pop(k, None)
-        manual_cache.pop(k, None)
-
-    atomic_json_dump(auto_cache, AUTO_CACHE_FILE)
-    atomic_json_dump(manual_cache, MANUAL_CACHE_FILE)
-
-    open(CIG_MIGRATION_FLAG, "w").close()
-    logger.info(
-        f"[CIG MIGRATION] Done. Removed {removed_files} cached files "
-        f"and cleared hash entries."
-    )


### PR DESCRIPTION
## Summary
Four independent improvements bundled into one maintenance PR.

## Changes

### 1. Remove `cig_migration()` dead code
The one-time migration for the March 2026 CIG PNG rollout has run.
Removes the function, flag constant, and startup call. No behavior change.

### 2. Fix watch API failure handling
`fetch_active_watches_nws()` now returns `None` on failure vs `{}` on
genuine empty. The watch loop skips the cycle on `None`, leaving
`active_watches` untouched and preventing a transient NWS outage from
triggering false cancellation posts.

### 3. Watch VTEC unit tests
9 new tests covering `fetch_active_watches_nws()` — valid VTEC parsing,
zero-padding, deduplication, malformed strings, missing expiry, HTTP
failure, JSON parse failure, and genuine empty response. All 56 tests pass.

### 4. CONTRIBUTING.md
Slash command inventory, channel ID configuration, partial update mode,
aggressive check loop, watch cycle state machine, watchdog behavior,
and persistence file reference.

## Testing
`python -m pytest tests/ -v` — 56 passed, 0 failed.