### PR TITLE
feat: watch-triggered soundings and IEM/SPC/Wyoming race fetching

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -114,25 +114,66 @@ async def fetch_md_details(
 ) -> Tuple[Optional[str], Optional[str], bool]:
     """
     Fetch an individual MD page and return (image_url, summary_text, from_cache).
-    Falls back to cached image if SPC is unreachable.
+    Races SPC and IEM simultaneously — whichever returns first wins.
+    Falls back to cache if both fail.
     """
     page_url = f"https://www.spc.noaa.gov/products/md/md{md_number}.html"
-    html = await http_get_text(page_url)
+
+    async def _fetch_spc():
+        return await http_get_text(page_url)
+
+    async def _fetch_iem_early():
+        import cogs.mesoscale as _self
+        iem_img, iem_summary = await _self.fetch_md_details_iem(md_number)
+        return (iem_img, iem_summary)
+
+    spc_task = asyncio.create_task(_fetch_spc())
+    iem_task = asyncio.create_task(_fetch_iem_early())
+
+    done, pending = await asyncio.wait(
+        [spc_task, iem_task],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    html = None
+    iem_result = None
+
+    first = done.pop()
+    if first is spc_task:
+        html = first.result()
+        if html:
+            logger.debug(f"[MD] SPC won race for #{md_number}")
+            for t in pending:
+                t.cancel()
+        else:
+            logger.warning(f"[MD] SPC page failed for #{md_number} — waiting for IEM")
+            if pending:
+                try:
+                    iem_result = await pending.pop()
+                except Exception:
+                    pass
+    else:
+        iem_result = first.result()
+        try:
+            html = await asyncio.wait_for(asyncio.shield(spc_task), timeout=5.0)
+            if html:
+                logger.debug(f"[MD] SPC caught up for #{md_number}")
+                iem_result = None
+        except asyncio.TimeoutError:
+            logger.warning(f"[MD] SPC timed out for #{md_number} — using IEM")
+            spc_task.cancel()
 
     if not html:
         fallback_url = f"https://www.spc.noaa.gov/products/md/mcd{md_number}.png"
         cached_path = get_cache_path_for_url(fallback_url)
         if os.path.exists(cached_path):
-            logger.info(
-                f"[MD] SPC unreachable for #{md_number}, serving from cache"
-            )
+            logger.info(f"[MD] SPC unreachable for #{md_number}, serving from cache")
             return fallback_url, None, True
-        # Try IEM before giving up entirely
-        logger.warning(f"[MD] SPC unreachable for #{md_number} — trying IEM fallback")
-        iem_img, iem_summary = await fetch_md_details_iem(md_number)
-        if iem_img:
-            logger.info(f"[MD] Got MD #{md_number} image from IEM")
-            return iem_img, iem_summary, True
+        if iem_result:
+            iem_img, iem_summary = iem_result
+            if iem_img:
+                logger.info(f"[MD] Got MD #{md_number} from IEM")
+                return iem_img, iem_summary, True
         logger.warning(f"[MD] SPC unreachable for #{md_number} and no cache or IEM available")
         return None, None, False
 

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -42,6 +42,113 @@ class SoundingCog(commands.Cog):
     def cog_unload(self):
         self.auto_sounding_watches.cancel()
 
+    async def post_soundings_for_watch(self, watch_num: str, nws_info: dict, channel):
+        """
+        Triggered immediately when a new watch is posted.
+        Finds nearest RAOB stations using the most recent IEM-available sounding
+        time (any hour, not locked to 00z/12z), posts up to 3 RAOB + 2 ACARS.
+        """
+        from config import CACHE_DIR
+        affected_zones = nws_info.get("affected_zones", []) if isinstance(nws_info, dict) else []
+        if not affected_zones:
+            logger.warning(f"[SOUNDING-AUTO] No affected zones for watch #{watch_num} — skipping")
+            return
+
+        wtype = nws_info.get("type", "SVR") if isinstance(nws_info, dict) else "SVR"
+        watch_label = "Tornado Watch" if wtype == "TORNADO" else "SVR Watch"
+
+        centroid = await get_watch_area_centroid(affected_zones)
+        if not centroid:
+            logger.warning(f"[SOUNDING-AUTO] Could not get centroid for watch #{watch_num}")
+            return
+        lat, lon = centroid
+
+        try:
+            stations_df = await get_raob_stations()
+        except Exception as e:
+            logger.error(f"[SOUNDING-AUTO] Failed to load station list: {e}")
+            return
+
+        candidates = find_nearest_stations(lat, lon, stations_df, n=6)
+        candidates = [s for s in candidates if s.get("icao") or s.get("wmo")]
+        verified = await filter_stations_with_data(candidates)
+
+        for station in verified[:3]:
+            station_id = station.get("icao") or station.get("wmo")
+
+            avail = await get_available_sounding_times_iem(station_id, hours_back=24, skip_cache=True)
+            if not avail:
+                logger.info(f"[SOUNDING-AUTO] No IEM times for {station_id} near watch #{watch_num}")
+                continue
+            year, month, day, hour = avail[0]
+            time_key = f"{year}-{month}-{day}_{hour}z"
+            post_key = f"{watch_num}:{station_id}:{time_key}"
+            if post_key in self._posted_watch_soundings:
+                continue
+
+            logger.info(f"[SOUNDING-AUTO] Posting {station_id} {hour}z near {watch_label} #{watch_num}")
+            self._posted_watch_soundings.add(post_key)
+
+            clean_data = await fetch_sounding(
+                station_id, year, month, day, hour,
+                station_name=station["name"],
+                lat=station["lat"], lon=station["lon"],
+            )
+            if not clean_data:
+                logger.warning(f"[SOUNDING-AUTO] No data for {station_id} at {time_key}")
+                continue
+
+            output_path = os.path.join(CACHE_DIR, f"sounding_{station_id}_{year}{month}{day}_{hour}z")
+            success = await generate_plot(clean_data, output_path)
+            png_path = output_path + ".png"
+            if not success or not os.path.exists(png_path):
+                continue
+
+            caption = (
+                f"**Auto Sounding — {station['name']} ({station_id})**\n"
+                f"Valid: {month}-{day}-{year} {hour}z | Near active {watch_label} #{watch_num}"
+            )
+            try:
+                await channel.send(caption, files=[discord.File(png_path)])
+                logger.info(f"[SOUNDING-AUTO] Posted {station_id} for watch #{watch_num}")
+            except Exception as e:
+                logger.error(f"[SOUNDING-AUTO] Failed to post {station_id}: {e}")
+
+        acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
+        for profile in acars_profiles[:2]:
+            post_key = f"acars:{watch_num}:{profile['airport']}:{profile['year']}{profile['month']}{profile['day']}_{profile['acars_hour']}z"
+            if post_key in self._posted_watch_soundings:
+                continue
+
+            logger.info(f"[SOUNDING-AUTO] Posting ACARS {profile['airport']} near {watch_label} #{watch_num}")
+            self._posted_watch_soundings.add(post_key)
+
+            clean_data = await fetch_acars_sounding(
+                profile["profile_id"], profile["year"], profile["month"],
+                profile["day"], profile["acars_hour"]
+            )
+            if not clean_data:
+                continue
+
+            output_path = os.path.join(
+                CACHE_DIR,
+                f"acars_{profile['airport']}_{profile['year']}{profile['month']}{profile['day']}_{profile['acars_hour']}z"
+            )
+            success = await generate_plot(clean_data, output_path)
+            png_path = output_path + ".png"
+            if not success or not os.path.exists(png_path):
+                continue
+
+            caption = (
+                f"**Auto ACARS — {profile['airport']}**\n"
+                f"Valid: {profile['time_label']} | Near active {watch_label} #{watch_num}"
+            )
+            try:
+                await channel.send(caption, files=[discord.File(png_path)])
+                logger.info(f"[SOUNDING-AUTO] Posted ACARS {profile['airport']} for watch #{watch_num}")
+            except Exception as e:
+                logger.error(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
+
     @tasks.loop(minutes=30)
     async def auto_sounding_watches(self):
         """Post soundings for RAOB stations near active watches at 00z/12z."""
@@ -50,7 +157,6 @@ class SoundingCog(commands.Cog):
 
         now = datetime.now(timezone.utc)
         hour = now.hour
-        minute = now.minute
 
         # Only run within 30 minutes after 00z or 12z
         if not ((0 <= hour < 1) or (12 <= hour < 13)):
@@ -136,40 +242,40 @@ class SoundingCog(commands.Cog):
                     logger.error(f"[SOUNDING-AUTO] Failed to post: {e}")
 
         # ── ACARS auto-posting ────────────────────────────────────────────
-        acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
-        for profile in acars_profiles[:2]:
-            post_key = f"acars:{watch_num}:{profile['airport']}:{time_key}"
-            if post_key in self._posted_watch_soundings:
-                continue
+            acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
+            for profile in acars_profiles[:2]:
+                post_key = f"acars:{watch_num}:{profile['airport']}:{time_key}"
+                if post_key in self._posted_watch_soundings:
+                    continue
 
-            logger.info(f"[SOUNDING-AUTO] Posting ACARS {profile['airport']} near {watch_label} #{watch_num}")
-            self._posted_watch_soundings.add(post_key)
+                logger.info(f"[SOUNDING-AUTO] Posting ACARS {profile['airport']} near {watch_label} #{watch_num}")
+                self._posted_watch_soundings.add(post_key)
 
-            clean_data = await fetch_acars_sounding(
-                profile["profile_id"], profile["year"], profile["month"],
-                profile["day"], profile["acars_hour"]
-            )
-            if not clean_data:
-                continue
+                clean_data = await fetch_acars_sounding(
+                    profile["profile_id"], profile["year"], profile["month"],
+                    profile["day"], profile["acars_hour"]
+                )
+                if not clean_data:
+                    continue
 
-            output_path = __import__("os").path.join(
-                __import__("config").CACHE_DIR,
-                f"acars_{profile['airport']}_{profile['year']}{profile['month']}{profile['day']}_{profile['acars_hour']}z"
-            )
-            success = await generate_plot(clean_data, output_path)
-            png_path = output_path + ".png"
-            if not success or not __import__("os").path.exists(png_path):
-                continue
+                output_path = os.path.join(
+                    __import__("config").CACHE_DIR,
+                    f"acars_{profile['airport']}_{profile['year']}{profile['month']}{profile['day']}_{profile['acars_hour']}z"
+                )
+                success = await generate_plot(clean_data, output_path)
+                png_path = output_path + ".png"
+                if not success or not os.path.exists(png_path):
+                    continue
 
-            caption = (
-                f"**Auto ACARS \u2014 {profile['airport']}**\n"
-                f"Valid: {profile['time_label']} | Near active {watch_label} #{watch_num}"
-            )
-            try:
-                await channel.send(caption, files=[discord.File(png_path)])
-                logger.info(f"[SOUNDING-AUTO] Posted ACARS {profile['airport']} for watch #{watch_num}")
-            except Exception as e:
-                logger.error(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
+                caption = (
+                    f"**Auto ACARS \u2014 {profile['airport']}**\n"
+                    f"Valid: {profile['time_label']} | Near active {watch_label} #{watch_num}"
+                )
+                try:
+                    await channel.send(caption, files=[discord.File(png_path)])
+                    logger.info(f"[SOUNDING-AUTO] Posted ACARS {profile['airport']} for watch #{watch_num}")
+                except Exception as e:
+                    logger.error(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
 
     @discord.app_commands.command(
         name="sounding",

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -617,18 +617,58 @@ async def fetch_sounding(
     loop = asyncio.get_running_loop()
 
     if hour in ("00", "12"):
-        # Try Wyoming first for standard times — better data quality
-        try:
-            clean_data = await loop.run_in_executor(
-                None,
-                lambda: spy.get_obs_data(station_id, year, month, day, hour)
-            )
-            if clean_data:
-                return clean_data
-        except Exception as e:
-            logger.debug(f"[SOUNDING] Wyoming failed for {station_id} {hour}z, trying IEM: {e}")
+        # Race Wyoming and IEM simultaneously — whichever returns valid data first wins.
+        # Wyoming has quality preference: if both succeed, Wyoming result is used.
+        async def _try_wyoming():
+            try:
+                data = await loop.run_in_executor(
+                    None,
+                    lambda: spy.get_obs_data(station_id, year, month, day, hour)
+                )
+                return data
+            except Exception as e:
+                logger.debug(f"[SOUNDING] Wyoming failed for {station_id} {hour}z: {e}")
+                return None
 
-    # IEM for special soundings or Wyoming fallback
+        async def _try_iem():
+            return await fetch_iem_sounding(
+                station_id, year, month, day, hour,
+                station_name=station_name, lat=lat, lon=lon, elev=elev
+            )
+
+        wyoming_task = asyncio.create_task(_try_wyoming())
+        iem_task = asyncio.create_task(_try_iem())
+
+        done, pending = await asyncio.wait(
+            [wyoming_task, iem_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        # Check first result
+        first = done.pop()
+        result = first.result()
+        if result:
+            # Cancel the slower one and return
+            for t in pending:
+                t.cancel()
+            source = "Wyoming" if first is wyoming_task else "IEM"
+            logger.debug(f"[SOUNDING] {source} won race for {station_id} {hour}z")
+            return result
+
+        # First result was None — wait for the second
+        if pending:
+            second = pending.pop()
+            try:
+                result = await second
+                if result:
+                    source = "Wyoming" if second is wyoming_task else "IEM"
+                    logger.debug(f"[SOUNDING] {source} fallback for {station_id} {hour}z")
+                    return result
+            except Exception:
+                pass
+        return None
+
+    # Non-standard hours: IEM only (Wyoming doesn't carry special soundings)
     iem_data = await fetch_iem_sounding(
         station_id, year, month, day, hour,
         station_name=station_name, lat=lat, lon=lon, elev=elev

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -124,7 +124,7 @@ async def fetch_latest_watch_numbers() -> List[Tuple[str, str]]:
 
 
 
-async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Optional[str]]:
+async def fetch_watch_details_iem(watch_number: str, prefetched_raw: Optional[bytes] = None) -> Tuple[Optional[str], Optional[str]]:
     """
     Fallback: fetch watch text and image from IEM when SPC is unreachable.
     Returns (text_summary, image_url).
@@ -140,10 +140,13 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
     # IEM nwstext API for SEL (watch issuance) text
     text_summary = None
     try:
-        content, status = await http_get_bytes(
-            f"{IEM_WATCH_TEXT_URL}?product=SEL&limit=20", retries=2, timeout=15
-        )
-        if content and status == 200:
+        content = prefetched_raw
+        if content is None:
+            content, status = await http_get_bytes(
+                f"{IEM_WATCH_TEXT_URL}?product=SEL&limit=20", retries=2, timeout=15
+            )
+            content = content if (content and status == 200) else None
+        if content:
             import json as _json_iem
             data = _json_iem.loads(content)
             for entry in data.get("data", []):
@@ -185,9 +188,66 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
 async def fetch_watch_details(
     watch_number: str,
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
-    """Fetch an individual watch page and return (image_url, text_summary, probs)."""
+    """Fetch an individual watch page and return (image_url, text_summary, probs).
+    Races SPC and IEM page fetches simultaneously — whichever returns first wins.
+    """
     page_url = f"https://www.spc.noaa.gov/products/watch/ww{watch_number}.html"
-    html = await http_get_text(page_url)
+    iem_text_url = f"{IEM_WATCH_TEXT_URL}?product=SEL&limit=20"
+
+    async def _fetch_spc():
+        import cogs.watches as _self
+        return await _self.http_get_text(page_url)
+
+    async def _fetch_iem_early():
+        import cogs.watches as _self
+        try:
+            content, status = await _self.http_get_bytes(iem_text_url, retries=2, timeout=15)
+            return content if (content and status == 200) else None
+        except Exception:
+            return None
+
+    spc_task = asyncio.create_task(_fetch_spc())
+    iem_task = asyncio.create_task(_fetch_iem_early())
+
+    # Wait for SPC first with a short timeout — if it wins, use it as before
+    done, pending = await asyncio.wait(
+        [spc_task, iem_task],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    html = None
+    iem_raw = None
+
+    first = done.pop()
+    if first is spc_task:
+        html = first.result()
+        if html:
+            logger.debug(f"[WATCH] SPC won race for #{watch_number}")
+            # Cancel IEM task — we don't need it
+            for t in pending:
+                t.cancel()
+        else:
+            # SPC lost — wait for IEM
+            logger.warning(f"[WATCH] SPC page failed for #{watch_number} — waiting for IEM")
+            if pending:
+                iem_done = pending.pop()
+                try:
+                    iem_raw = await iem_done
+                except Exception:
+                    pass
+    else:
+        # IEM finished first
+        iem_raw = first.result()
+        # Still wait briefly for SPC
+        if pending:
+            try:
+                html = await asyncio.wait_for(asyncio.shield(spc_task), timeout=5.0)
+                if html:
+                    logger.debug(f"[WATCH] SPC caught up for #{watch_number}")
+                    iem_raw = None  # prefer SPC html path
+            except asyncio.TimeoutError:
+                logger.warning(f"[WATCH] SPC timed out for #{watch_number} — using IEM")
+                spc_task.cancel()
 
     image_url = None
     if html:
@@ -203,11 +263,11 @@ async def fetch_watch_details(
                     f"https://www.spc.noaa.gov/products/watch/{fname}"
                 )
                 break
-    if not image_url:
-        image_url = (
-            f"https://www.spc.noaa.gov/products/watch/"
-            f"ww{watch_number}_overview.gif"
-        )
+        if not image_url:
+            image_url = (
+                f"https://www.spc.noaa.gov/products/watch/"
+                f"ww{watch_number}_overview.gif"
+            )
 
     text_summary = None
     if html:
@@ -360,10 +420,10 @@ async def fetch_watch_details(
                 f"[WATCH] No prob pairs parsed for #{watch_number}"
             )
 
-    # IEM fallback: if SPC page was unreachable, try IEM for missing pieces
+    # IEM fallback: use pre-fetched IEM raw or fetch fresh if needed
     if not html:
-        logger.warning(f"[WATCH] SPC unreachable for #{watch_number} details — trying IEM fallback")
-        iem_summary, iem_img = await fetch_watch_details_iem(watch_number)
+        logger.warning(f"[WATCH] SPC unreachable for #{watch_number} — using IEM data")
+        iem_summary, iem_img = await fetch_watch_details_iem(watch_number, prefetched_raw=iem_raw)
         if iem_summary and not text_summary:
             text_summary = iem_summary
             logger.info(f"[WATCH] Got text from IEM for #{watch_number}")
@@ -713,6 +773,11 @@ class WatchesCog(commands.Cog):
                     asyncio.create_task(prune_posted_watches())
                     self.bot.state.last_post_times["watch"] = datetime.now(timezone.utc)
                     logger.info(f"[WATCH] Posted watch #{watch_num}")
+                    sounding_cog = self.bot.cogs.get("SoundingCog")
+                    if sounding_cog:
+                        asyncio.create_task(
+                            sounding_cog.post_soundings_for_watch(watch_num, nws_info, channel)
+                        )
                 except discord.HTTPException as e:
                     logger.error(
                         f"[WATCH] Discord send failed for #{watch_num}: {e}"

--- a/tests/test_iem_races.py
+++ b/tests/test_iem_races.py
@@ -1,0 +1,181 @@
+# tests/test_iem_races.py
+"""
+Tests for IEM/SPC race logic in fetch_watch_details, fetch_md_details,
+and the watch-triggered sounding auto-post.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ── fetch_watch_details ───────────────────────────────────────────────────────
+
+class TestFetchWatchDetailsRace:
+
+    @pytest.mark.asyncio
+    async def test_returns_tuple_of_three(self):
+        """fetch_watch_details always returns a 3-tuple regardless of outcome."""
+        with patch("cogs.watches.http_get_text", new_callable=AsyncMock) as mt, \
+             patch("cogs.watches.http_get_bytes", new_callable=AsyncMock) as mb, \
+             patch("cogs.watches.fetch_watch_details_iem", new_callable=AsyncMock) as mi:
+            mt.return_value = None
+            mb.return_value = (None, 404)
+            mi.return_value = (None, None)
+            from cogs.watches import fetch_watch_details
+            result = await fetch_watch_details("0102")
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_iem_text_used_when_spc_fails(self):
+        """When SPC page fails, IEM text summary is surfaced in the result."""
+        with patch("cogs.watches.http_get_text", new_callable=AsyncMock) as mt, \
+             patch("cogs.watches.http_get_bytes", new_callable=AsyncMock) as mb, \
+             patch("cogs.watches.fetch_watch_details_iem", new_callable=AsyncMock) as mi:
+            mt.return_value = None
+            mb.return_value = (None, 404)
+            mi.return_value = ("IEM summary", "http://iem.example/img.png")
+            from cogs.watches import fetch_watch_details
+            image_url, text_summary, probs = await fetch_watch_details("0102")
+        assert text_summary == "IEM summary"
+
+    @pytest.mark.asyncio
+    async def test_both_fail_no_crash(self):
+        """When both SPC and IEM fail, function returns without raising."""
+        with patch("cogs.watches.http_get_text", new_callable=AsyncMock) as mt, \
+             patch("cogs.watches.http_get_bytes", new_callable=AsyncMock) as mb, \
+             patch("cogs.watches.fetch_watch_details_iem", new_callable=AsyncMock) as mi:
+            mt.return_value = None
+            mb.return_value = (None, 404)
+            mi.return_value = (None, None)
+            from cogs.watches import fetch_watch_details
+            result = await fetch_watch_details("0102")
+        assert result == (None, None, None)
+
+
+# ── fetch_md_details race ────────────────────────────────────────────────────
+
+class TestFetchMdDetailsRace:
+
+    @pytest.mark.asyncio
+    async def test_spc_wins_returns_image(self):
+        """fetch_md_details returns image URL from SPC when available."""
+        fake_html = '<img src="mcd0398.png">'
+        with patch("cogs.mesoscale.http_get_text", new_callable=AsyncMock) as mt, \
+             patch("cogs.mesoscale.fetch_md_details_iem", new_callable=AsyncMock) as mi:
+            mt.return_value = fake_html
+            mi.return_value = (None, None)
+            from cogs.mesoscale import fetch_md_details
+            image_url, summary, from_cache = await fetch_md_details("0398")
+        assert "mcd0398" in image_url
+        assert from_cache is False
+
+    @pytest.mark.asyncio
+    async def test_iem_image_used_when_spc_fails(self):
+        """When SPC fails and no cache, IEM image URL is returned."""
+        with patch("cogs.mesoscale.http_get_text", new_callable=AsyncMock) as mt, \
+             patch("cogs.mesoscale.fetch_md_details_iem", new_callable=AsyncMock) as mi, \
+             patch("cogs.mesoscale.os.path.exists", return_value=False):
+            mt.return_value = None
+            mi.return_value = ("http://iem.example/mcd0398.png", "IEM summary")
+            from cogs.mesoscale import fetch_md_details
+            image_url, summary, from_cache = await fetch_md_details("0398")
+        assert image_url == "http://iem.example/mcd0398.png"
+        assert from_cache is True
+
+    @pytest.mark.asyncio
+    async def test_cache_returned_when_both_fail(self):
+        """When SPC fails and IEM returns nothing, cached file is used."""
+        with patch("cogs.mesoscale.http_get_text", new_callable=AsyncMock) as mt, \
+             patch("cogs.mesoscale.fetch_md_details_iem", new_callable=AsyncMock) as mi, \
+             patch("cogs.mesoscale.os.path.exists", return_value=True):
+            mt.return_value = None
+            mi.return_value = (None, None)
+            from cogs.mesoscale import fetch_md_details
+            image_url, summary, from_cache = await fetch_md_details("0398")
+        assert from_cache is True
+        assert image_url is not None
+
+
+# ── post_soundings_for_watch ─────────────────────────────────────────────────
+
+class TestPostSoundingsForWatch:
+
+    def _make_bot(self):
+        bot = MagicMock()
+        bot.state = MagicMock()
+        bot.state.active_watches = {}
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_affected_zones(self):
+        """If nws_info has no affected_zones, method returns early without posting."""
+        from cogs.sounding import SoundingCog
+
+        bot = self._make_bot()
+        cog = SoundingCog.__new__(SoundingCog)
+        cog.bot = bot
+        cog._posted_watch_soundings = set()
+
+        channel = AsyncMock()
+        nws_info = {"type": "SVR", "expires": None, "affected_zones": []}
+
+        await cog.post_soundings_for_watch("0102", nws_info, channel)
+        channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_centroid_fails(self):
+        """If centroid resolution fails, method returns without posting."""
+        from cogs.sounding import SoundingCog
+
+        bot = self._make_bot()
+        cog = SoundingCog.__new__(SoundingCog)
+        cog.bot = bot
+        cog._posted_watch_soundings = set()
+
+        channel = AsyncMock()
+        nws_info = {"type": "SVR", "expires": None, "affected_zones": ["https://api.weather.gov/zones/county/IAC001"]}
+
+        with patch("cogs.sounding.get_watch_area_centroid", new=AsyncMock(return_value=None)):
+            await cog.post_soundings_for_watch("0102", nws_info, channel)
+
+        channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fires_after_watch_posted(self):
+        """SoundingCog.post_soundings_for_watch is called after a new watch is posted."""
+        from cogs.watches import WatchesCog
+
+        bot = self._make_bot()
+        bot.wait_until_ready = AsyncMock()
+        bot.get_channel = MagicMock(return_value=AsyncMock())
+
+        mock_sounding_cog = MagicMock()
+        mock_sounding_cog.post_soundings_for_watch = AsyncMock()
+        bot.cogs = {"SoundingCog": mock_sounding_cog}
+
+        nws_result = {
+            "0102": {
+                "type": "SVR",
+                "expires": datetime(2026, 4, 14, 2, 0, tzinfo=timezone.utc),
+                "affected_zones": ["https://api.weather.gov/zones/county/IAC001"],
+            }
+        }
+
+        with patch("cogs.watches.fetch_active_watches_nws", new=AsyncMock(return_value=nws_result)), \
+             patch("cogs.watches.fetch_watch_details", new=AsyncMock(return_value=(None, None, None))), \
+             patch("cogs.watches.download_single_image", new=AsyncMock(return_value=(None, False, None))), \
+             patch("cogs.watches.add_posted_watch", new=AsyncMock()), \
+             patch("cogs.watches.prune_posted_watches", new=AsyncMock()):
+
+            cog = WatchesCog(bot)
+            cog.auto_post_watches.cancel()
+            await cog.auto_post_watches()
+
+        await asyncio.sleep(0)
+        mock_sounding_cog.post_soundings_for_watch.assert_called_once()
+        call_args = mock_sounding_cog.post_soundings_for_watch.call_args[0]
+        assert call_args[0] == "0102"


### PR DESCRIPTION
- sounding: add post_soundings_for_watch() — fires immediately on new watch, uses most recent IEM-available time (any hour, not locked to 00z/12z), posts up to 3 RAOB soundings and 2 ACARS profiles per watch
- sounding: fix ACARS auto-post scope bug — block was outside the for loop
- sounding: remove unused minute = now.minute variable
- watches: race SPC page fetch vs IEM simultaneously in fetch_watch_details — whichever returns first wins, IEM pre-fetched raw passed to fallback
- watches: fire post_soundings_for_watch as background task after new watch posted
- mesoscale: race SPC page fetch vs IEM simultaneously in fetch_md_details
- sounding_utils: race Wyoming vs IEM simultaneously in fetch_sounding for 00z/12z — whichever returns valid data first wins, Wyoming preferred on tie
- tests: add test_iem_races.py covering race outcomes and sounding trigger