### PR TITLE
chore: remove dead legacy globals from utils/cache.py

### DIFF
--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -13,8 +13,6 @@ from discord.ext import commands, tasks
 from config import MANUAL_CACHE_FILE, MODELS_CHANNEL_ID
 from utils.cache import (
     download_single_image,
-    last_post_times,
-    manual_cache,
 )
 
 logger = logging.getLogger("spc_bot")
@@ -162,7 +160,7 @@ class CSUMLPCog(commands.Cog):
             return
 
         cache_path, _, _ = await download_single_image(
-            url, MANUAL_CACHE_FILE, manual_cache
+            url, MANUAL_CACHE_FILE
         )
         if not cache_path:
             msg = f"Failed to download CSU-MLP Day {day} image."
@@ -208,7 +206,7 @@ class CSUMLPCog(commands.Cog):
             if not url:
                 await interaction.followup.send("CSU-MLP Days 1-2 6-panel isn't available yet. Try after ~11am MT.")
                 return
-            cache_path, _, _ = await download_single_image(url, MANUAL_CACHE_FILE, manual_cache)
+            cache_path, _, _ = await download_single_image(url, MANUAL_CACHE_FILE)
             if not cache_path:
                 await interaction.followup.send("Failed to download CSU-MLP Days 1-2 6-panel.")
                 return
@@ -221,7 +219,7 @@ class CSUMLPCog(commands.Cog):
             if not url:
                 await interaction.followup.send("CSU-MLP Days 3-8 6-panel isn't available yet. Try after ~11am MT.")
                 return
-            cache_path, _, _ = await download_single_image(url, MANUAL_CACHE_FILE, manual_cache)
+            cache_path, _, _ = await download_single_image(url, MANUAL_CACHE_FILE)
             if not cache_path:
                 await interaction.followup.send("Failed to download CSU-MLP Days 3-8 6-panel.")
                 return
@@ -278,7 +276,7 @@ class CSUMLPCog(commands.Cog):
                 )
 
             cache_path, _, _ = await download_single_image(
-                url, MANUAL_CACHE_FILE, manual_cache
+                url, MANUAL_CACHE_FILE
             )
             if not cache_path:
                 logger.warning(f"[CSU-MLP] Download failed for Day {day}")
@@ -293,7 +291,7 @@ class CSUMLPCog(commands.Cog):
                 )
                 _posted_today.add(day)
                 await _save_posted_today(_posted_today)
-                last_post_times[f"csu_day{day}"] = now_utc
+                self.bot.state.last_post_times[f"csu_day{day}"] = now_utc
                 logger.info(f"[CSU-MLP] Auto-posted Day {day} ({label})")
             except Exception as e:
                 logger.error(
@@ -314,7 +312,7 @@ class CSUMLPCog(commands.Cog):
                 first_seen = now_utc.strftime("%Y-%m-%d %H:%MZ")
                 _availability_log[state_key] = first_seen
                 logger.info(f"[CSU-MLP] 📊 TIMING LOG — {label_name} first available at {first_seen} ({label})")
-            cache_path, _, _ = await download_single_image(url, MANUAL_CACHE_FILE, manual_cache)
+            cache_path, _, _ = await download_single_image(url, MANUAL_CACHE_FILE)
             if not cache_path:
                 logger.warning(f"[CSU-MLP] Download failed for {label_name}")
                 continue
@@ -325,7 +323,7 @@ class CSUMLPCog(commands.Cog):
                 )
                 _posted_today.add(state_key)
                 await _save_posted_today(_posted_today)
-                last_post_times[f"csu_{state_key}"] = now_utc
+                self.bot.state.last_post_times[f"csu_{state_key}"] = now_utc
                 logger.info(f"[CSU-MLP] Auto-posted {label_name} ({label})")
             except Exception as e:
                 logger.error(f"[CSU-MLP] Failed to post {label_name}: {e}", exc_info=True)

--- a/cogs/ncar.py
+++ b/cogs/ncar.py
@@ -11,8 +11,6 @@ from config import MANUAL_CACHE_FILE, MODELS_CHANNEL_ID
 from utils.cache import (
     calculate_hash_bytes,
     download_single_image,
-    last_post_times,
-    manual_cache,
 )
 from utils.db import delete_state, get_state, set_state
 from utils.http import ensure_session
@@ -109,7 +107,7 @@ class NCARCog(commands.Cog):
             )
             return
         cache_path, _, _ = await download_single_image(
-            url, MANUAL_CACHE_FILE, manual_cache
+            url, MANUAL_CACHE_FILE
         )
         if not cache_path:
             await interaction.followup.send(
@@ -175,7 +173,7 @@ class NCARCog(commands.Cog):
             return
 
         cache_path, _, _ = await download_single_image(
-            url, MANUAL_CACHE_FILE, manual_cache
+            url, MANUAL_CACHE_FILE
         )
         if not cache_path:
             logger.warning("[NCAR] Download failed for WxNext2")
@@ -188,7 +186,7 @@ class NCARCog(commands.Cog):
             )
             _posted_state = {"date": today_str, "hash": h}
             await _save_state(today_str, h)
-            last_post_times["wxnext"] = now_utc
+            self.bot.state.last_post_times["wxnext"] = now_utc
             logger.info("[NCAR] Auto-posted WxNext2")
         except Exception as e:
             logger.error(f"[NCAR] Failed to post WxNext2: {e}", exc_info=True)

--- a/cogs/scp.py
+++ b/cogs/scp.py
@@ -7,10 +7,7 @@ from discord.ext import commands, tasks
 
 from config import AUTO_CACHE_FILE, MANUAL_CACHE_FILE, PACIFIC, MODELS_CHANNEL_ID, SCP_IMAGE_URLS
 from utils.cache import (
-    auto_cache,
     download_images_parallel,
-    last_post_times,
-    manual_cache,
 )
 
 logger = logging.getLogger("spc_bot")
@@ -67,7 +64,6 @@ class SCPCog(commands.Cog):
             files = await download_images_parallel(
                 SCP_IMAGE_URLS,
                 MANUAL_CACHE_FILE,
-                manual_cache,
                 use_cached=False,
             )
             if files:
@@ -76,7 +72,7 @@ class SCPCog(commands.Cog):
                     "Supercell Composite Parameter — NIU/Gensini CFSv2",
                     files=[discord.File(fp) for fp in files],
                 )
-                last_post_times["scp"] = datetime.now(timezone.utc)
+                self.bot.state.last_post_times["scp"] = datetime.now(timezone.utc)
                 logger.info(f"[SCP_DAILY] Posted {len(files)} SCP images")
             else:
                 logger.info("[SCP_DAILY] No SCP images could be downloaded")

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -38,17 +38,7 @@ from utils.persistence import (
 
 logger = logging.getLogger("spc_bot")
 
-# Re-export for backward compatibility
 __all__ = [
-    "auto_cache",
-    "manual_cache",
-    "partial_update_state",
-    "posted_mds",
-    "posted_watches",
-    "active_mds",
-    "active_watches",
-    "last_post_times",
-    "last_posted_urls",
     "save_set",
     "atomic_json_dump",
     "get_cache_path_for_url",
@@ -62,37 +52,14 @@ __all__ = [
     "format_timedelta",
     "MD_CACHE_FILE",
     "WATCH_CACHE_FILE",
+    "MAX_TRACKED_MDS",
+    "MAX_TRACKED_WATCHES",
+    "prune_tracked_set",
 ]
 
-# ── In-memory state ──────────────────────────────────────────────────────────
-manual_cache: Dict[str, str] = {}
-auto_cache: Dict[str, str] = {}
-partial_update_state: Dict[str, Dict] = {}
-
+# ── Cache file paths ─────────────────────────────────────────────────────────
 MD_CACHE_FILE = os.path.join(CACHE_DIR, "posted_mds.json")
 WATCH_CACHE_FILE = os.path.join(CACHE_DIR, "posted_watches.json")
-
-posted_mds: Set[str] = set()
-posted_watches: Set[str] = set()
-active_mds: Set[str] = set()
-active_watches: Dict[str, dict] = {}
-
-last_post_times: Dict[str, Optional[datetime]] = {
-    "day1": None,
-    "day2": None,
-    "day3": None,
-    "day48": None,
-    "scp": None,
-    "md": None,
-    "watch": None,
-    "csu_day1": None, "csu_day2": None, "csu_day3": None,
-    "csu_day4": None, "csu_day5": None, "csu_day6": None,
-    "csu_day7": None, "csu_day8": None,
-    "csu_panel12": None, "csu_panel38": None,
-    "wxnext": None,
-    "sounding": None,
-}
-last_posted_urls: Dict[str, List[str]] = {}
 
 # Max tracked items before pruning
 MAX_TRACKED_MDS = 200
@@ -343,6 +310,4 @@ def prune_tracked_set(s: Set[str], max_size: int, cache_file: str):
     save_set(s, cache_file)
 
 
-# ── Legacy module-level globals (deprecated — use bot.state instead) ─────────
-# Kept for backward compatibility with any remaining direct imports.
-# New code should access state via bot.state (BotState instance).
+


### PR DESCRIPTION
- remove module-level state globals (posted_mds, posted_watches, active_mds, active_watches, last_post_times, last_posted_urls, manual_cache, auto_cache, partial_update_state) — all superseded by BotState in utils/state.py
- update csu_mlp, ncar, scp cogs to use self.bot.state.manual_cache, self.bot.state.auto_cache, self.bot.state.last_post_times instead of legacy cache globals
- clean up __all__ to only export what is actually used
- remove legacy backward-compat comment at bottom of file