### PR TITLE
feat: IEM iembot real-time feed for instant watch/MD text pre-caching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,10 @@ source. The return value has three distinct states:
 If the NWS API returns `None`, the `/watches` slash command falls back to
 scraping the SPC watch index HTML directly.
 
+### IEMBot Real-Time Feed
+
+`IEMBotCog` polls `weather.im/iembot-json/room/spcchat` every 15 seconds. When a new SEL (watch) or SWOMCD (MD) product appears, the full text is fetched from `mesonet.agron.iastate.edu/api/1/nwstext/{product_id}` and cached in memory for 10 minutes. `fetch_watch_details` and `fetch_md_details` check this cache first, ensuring embeds are populated within seconds of issuance. The last-seen seqnum is persisted to SQLite. The cache is ephemeral and not synced between failover instances.
+
 ### SCP Graphics
 
 Posted at 6am and 6pm Pacific daily, but only if the images have actually
@@ -121,7 +125,7 @@ changed (hash-based detection). Uses `MODELS_CHANNEL_ID`.
 
 ### Sounding Plots
 
-The `/sounding` command geocodes the location, finds nearby RAOB stations that have verified data in the Wyoming archive, and presents an interactive station and time picker. Plots are generated headlessly via SounderPy and posted to the channel where the command was used. Per-user dark mode preference is persisted to the local SQLite database. Auto-posting of soundings is active — when a new 00z or 12z sounding cycle becomes available, the bot checks for active SPC watches and posts soundings for up to 3 nearby RAOB stations per watch to `SPC_CHANNEL_ID`.
+The `/sounding` command geocodes the location, finds nearby RAOB stations that have verified data in the Wyoming archive, and presents an interactive station and time picker. Plots are generated headlessly via SounderPy and posted to the channel where the command was used. Per-user dark mode preference is persisted to the local SQLite database. Auto-posting of soundings is active in two modes: (1) immediately on watch issuance, using the most recent IEM-available sounding time (any hour); (2) at 00z/12z for all active watches. Up to 3 RAOB stations and 2 ACARS profiles per watch. At 00z/12z, Wyoming and IEM are raced simultaneously — whichever returns data first wins.
 
 ### CSU-MLP and NCAR WxNext2
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A Discord bot for severe weather enthusiasts. Auto-posts SPC convective outlooks
 
 * SPC convective outlooks (Day 1, 2, 3, Day 4-8) with dynamic URL resolution
 * SPC mesoscale discussions with cancellation tracking
-* Tornado and severe thunderstorm watch alerts via NWS API
+* Tornado and severe thunderstorm watch alerts via NWS API with IEM iembot real-time feed for sub-second text pre-caching
 * NIU/Gensini CFSv2/GEFS supercell composite parameter (SCP) graphics, twice daily
 * CSU-MLP machine learning severe weather forecasts (Days 1-8 + 6-panel summaries), auto-posted daily with `/csu1`-`/csu8`, `/csupanel12`, and `/csupanel38` slash commands
 * NCAR WxNext2 Mean AI convective hazard forecast (Days 1-8), auto-posted daily with `/wxnext` slash command
 * Observed RAOB sounding plots via SounderPy with `/sounding` — supports city names, radar site codes, and station IDs with interactive station and time selection
-* Auto-posts soundings for RAOB stations near active SPC watches at 00z/12z sounding cycles
+* Auto-posts soundings for RAOB stations near active SPC watches — immediately on watch issuance (any hour via IEM) and at 00z/12z synoptic cycles
 * VWP hodograph generation for any NEXRAD or TDWR site (200 sites) via `/hodograph`, with auto ASOS surface wind and storm parameter table
 * NEXRAD Level 2 radar downloader from NOAA AWS S3
   * Single or multi-site downloads with per-site ZIP packaging
@@ -109,6 +109,7 @@ spc-bot/
 ├── cogs/
 │   ├── outlooks.py          # SPC Day 1-3 and Day 4-8 auto-posting
 │   ├── mesoscale.py         # SPC Mesoscale Discussion monitoring
+│   ├── iembot.py            # IEM iembot feed poller — real-time watch/MD text pre-cache
 │   ├── watches.py           # SPC watch monitoring via NWS API (stores affected_zones)
 │   ├── scp.py               # NIU/Gensini SCP graphics, twice daily
 │   ├── csu_mlp.py           # CSU-MLP consolidated /csu command with Choice dropdown
@@ -138,7 +139,8 @@ spc-bot/
     ├── test_utils.py        # Unit tests for utilities and sounding parsing
     ├── test_watches.py      # Unit tests for watch VTEC parsing
     ├── test_integration.py  # Integration tests: BotState, cog instantiation, function signatures
-    └── test_hodograph.py    # Unit tests for hodograph cog
+    ├── test_hodograph.py    # Unit tests for hodograph cog
+    └── test_iem_races.py    # Tests for IEM/SPC race logic and watch-triggered soundings
 ```
 
 ## Status

--- a/cogs/iembot.py
+++ b/cogs/iembot.py
@@ -1,0 +1,210 @@
+# cogs/iembot.py
+"""
+IEMBot feed poller — fetches SPC watch and MD text products in real-time
+from the IEM iembot JSON feed (weather.im/iembot-json/room/spcchat).
+
+Provides a fast-path data source delivering watch/MD text within seconds
+of issuance, before SPC website or NWS API have caught up.
+
+Cache is ephemeral (10-min TTL), not persisted — only bridges the gap
+between issuance and SPC/IEM REST API availability.
+Only the last-seen seqnum is persisted to DB to avoid reprocessing on restart.
+"""
+import asyncio
+import logging
+import re
+import time
+from typing import Optional, Dict, Tuple
+
+from discord.ext import commands, tasks
+
+from utils.db import get_state, set_state
+from utils.http import http_get_bytes
+
+logger = logging.getLogger("spc_bot")
+
+IEMBOT_FEED_URL = "https://weather.im/iembot-json/room/spcchat"
+IEM_NWSTEXT_URL = "https://mesonet.agron.iastate.edu/api/1/nwstext/{product_id}"
+CACHE_TTL = 600  # 10 minutes
+
+# Module-level caches: padded_num -> (text, monotonic_timestamp)
+_watch_text_cache: Dict[str, Tuple[str, float]] = {}
+_md_text_cache: Dict[str, Tuple[str, float]] = {}
+
+
+def get_cached_watch_text(watch_number: str) -> Optional[str]:
+    """Return cached watch text if available and not expired."""
+    padded = watch_number.zfill(4)
+    entry = _watch_text_cache.get(padded)
+    if entry and (time.monotonic() - entry[1]) < CACHE_TTL:
+        return entry[0]
+    return None
+
+
+def get_cached_md_text(md_number: str) -> Optional[str]:
+    """Return cached MD text if available and not expired."""
+    padded = md_number.zfill(4)
+    entry = _md_text_cache.get(padded)
+    if entry and (time.monotonic() - entry[1]) < CACHE_TTL:
+        return entry[0]
+    return None
+
+
+def _parse_watch_text(raw: str) -> Optional[str]:
+    """Parse SEL product text into a formatted summary string."""
+    lines = [l.strip() for l in raw.splitlines() if l.strip()]
+    parts = []
+    for i, line in enumerate(lines):
+        if re.search(r"Watch for portions of", line, re.IGNORECASE):
+            area_lines = []
+            for ll in lines[i+1:i+6]:
+                if re.search(r"Effective|until|Primary", ll, re.IGNORECASE):
+                    break
+                area_lines.append(ll)
+            if area_lines:
+                parts.append("**Areas:** " + ", ".join(area_lines))
+        if re.search(r"Effective this", line, re.IGNORECASE):
+            combined = " ".join(lines[i:i+3])
+            parts.append("**Time:** " + re.sub(r"\s+", " ", combined).strip())
+        if re.search(r"Primary threats", line, re.IGNORECASE):
+            threats = []
+            for ll in lines[i+1:i+6]:
+                if re.search(r"SUMMARY|PRECAUTIONARY|ATTN", ll, re.IGNORECASE):
+                    break
+                threats.append(ll)
+            if threats:
+                parts.append("**Threats:**\n" + "\n".join(f"• {t}" for t in threats))
+        if re.search(r"^SUMMARY\.\.\.", line, re.IGNORECASE):
+            summary_lines = []
+            for ll in lines[i:i+4]:
+                if re.search(r"^DISCUSSION\.\.\.", ll, re.IGNORECASE):
+                    break
+                summary_lines.append(ll)
+            if summary_lines:
+                parts.append("**Summary:** " + " ".join(summary_lines)[:300])
+    return "\n".join(parts) if parts else None
+
+
+def _parse_md_text(raw: str) -> Optional[str]:
+    """Parse SWOMCD product text into a formatted summary string."""
+    concerning = re.search(r"(CONCERNING[^\n]{10,120})", raw, re.IGNORECASE)
+    if concerning:
+        return concerning.group(1).strip()
+    lines = [l.strip() for l in raw.splitlines() if l.strip()]
+    return " ".join(lines[:3])[:200] if lines else None
+
+
+async def _fetch_product_text(product_id: str) -> Optional[str]:
+    """Fetch raw NWS product text from IEM archive."""
+    url = IEM_NWSTEXT_URL.format(product_id=product_id)
+    content, status = await http_get_bytes(url, retries=2, timeout=10)
+    if not content or status != 200:
+        return None
+    text = content.decode("utf-8", errors="ignore")
+    if "not found" in text.lower() and len(text) < 100:
+        return None
+    return text
+
+
+class IEMBotCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._last_seqnum: int = 0
+        self._seqnum_loaded = False
+        self.poll_iembot_feed.start()
+
+    def cog_unload(self):
+        self.poll_iembot_feed.cancel()
+
+    @tasks.loop(seconds=15)
+    async def poll_iembot_feed(self):
+        await self.bot.wait_until_ready()
+
+        if not self._seqnum_loaded:
+            try:
+                val = await get_state("iembot_last_seqnum")
+                if val:
+                    self._last_seqnum = int(val)
+                    logger.info(f"[IEMBOT] Resuming from seqnum {self._last_seqnum}")
+            except Exception as e:
+                logger.warning(f"[IEMBOT] Could not load seqnum: {e}")
+            self._seqnum_loaded = True
+
+        try:
+            import json as _json
+            url = f"{IEMBOT_FEED_URL}?seqnum={self._last_seqnum}"
+            content, status = await http_get_bytes(url, retries=2, timeout=10)
+            if not content or status != 200:
+                return
+
+            data = _json.loads(content)
+            messages = data.get("messages", [])
+            if not messages:
+                return
+
+            new_seqnum = self._last_seqnum
+            for msg in messages:
+                seqnum = msg.get("seqnum", 0)
+                if seqnum <= self._last_seqnum:
+                    continue
+                new_seqnum = max(new_seqnum, seqnum)
+
+                product_id = msg.get("product_id", "")
+                if not product_id:
+                    continue
+
+                if "WWUS20-SEL" in product_id or "WWUS40-SEL" in product_id:
+                    asyncio.create_task(self._handle_watch(product_id))
+                elif "ACUS11-SWOMCD" in product_id:
+                    asyncio.create_task(self._handle_md(product_id))
+
+            if new_seqnum > self._last_seqnum:
+                self._last_seqnum = new_seqnum
+                asyncio.create_task(set_state("iembot_last_seqnum", str(new_seqnum)))
+
+        except Exception as e:
+            logger.warning(f"[IEMBOT] Poll error: {e}")
+
+    async def _handle_watch(self, product_id: str):
+        raw = await _fetch_product_text(product_id)
+        if not raw:
+            logger.warning(f"[IEMBOT] Could not fetch watch text for {product_id}")
+            return
+        m = re.search(r"(?:Tornado|Severe Thunderstorm)\s+Watch\s+Number\s+(\d+)", raw, re.IGNORECASE)
+        if not m:
+            return
+        watch_num = m.group(1).zfill(4)
+        text = _parse_watch_text(raw)
+        if text:
+            _watch_text_cache[watch_num] = (text, time.monotonic())
+            logger.info(f"[IEMBOT] Cached watch text for #{watch_num}")
+
+    async def _handle_md(self, product_id: str):
+        raw = await _fetch_product_text(product_id)
+        if not raw:
+            logger.warning(f"[IEMBOT] Could not fetch MD text for {product_id}")
+            return
+        m = re.search(r"Mesoscale Discussion\s+(\d+)", raw, re.IGNORECASE)
+        if not m:
+            return
+        md_num = m.group(1).zfill(4)
+        text = _parse_md_text(raw)
+        if text:
+            _md_text_cache[md_num] = (text, time.monotonic())
+            logger.info(f"[IEMBOT] Cached MD text for #{md_num}")
+
+    @poll_iembot_feed.after_loop
+    async def after_poll_loop(self):
+        if self.poll_iembot_feed.is_being_cancelled():
+            return
+        task = self.poll_iembot_feed.get_task()
+        exc = task.exception() if task else None
+        if exc:
+            logger.error(
+                f"[TASK] poll_iembot_feed stopped: {type(exc).__name__}: {exc}",
+                exc_info=exc,
+            )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(IEMBotCog(bot))

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -188,19 +188,27 @@ async def fetch_md_details(
         image_url = f"https://www.spc.noaa.gov/products/md/mcd{md_number}.png"
 
     summary = None
-    concerning = re.search(r"(CONCERNING[^\n<]{10,120})", html, re.IGNORECASE)
-    if concerning:
-        summary = concerning.group(1).strip()
-    else:
-        text_blocks = re.findall(
-            r"<pre[^>]*>(.*?)</pre>", html, re.DOTALL | re.IGNORECASE
-        )
-        for block in text_blocks:
-            clean = re.sub(r"<[^>]+>", "", block).strip()
-            lines = [line.strip() for line in clean.splitlines() if line.strip()]
-            if lines:
-                summary = " ".join(lines[:3])[:200]
-                break
+
+    # Check iembot real-time cache first (populated within seconds of issuance)
+    from cogs.iembot import get_cached_md_text
+    summary = get_cached_md_text(md_number)
+    if summary:
+        logger.info(f"[MD] Got summary from iembot cache for #{md_number}")
+
+    if not summary:
+        concerning = re.search(r"(CONCERNING[^\n<]{10,120})", html, re.IGNORECASE)
+        if concerning:
+            summary = concerning.group(1).strip()
+        else:
+            text_blocks = re.findall(
+                r"<pre[^>]*>(.*?)</pre>", html, re.DOTALL | re.IGNORECASE
+            )
+            for block in text_blocks:
+                clean = re.sub(r"<[^>]+>", "", block).strip()
+                lines = [line.strip() for line in clean.splitlines() if line.strip()]
+                if lines:
+                    summary = " ".join(lines[:3])[:200]
+                    break
 
     return image_url, summary, False
 

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -362,6 +362,13 @@ async def fetch_watch_details(
                 f"[WATCH] No prob pairs parsed for #{watch_number}"
             )
 
+    # Check iembot real-time cache first (populated within seconds of issuance)
+    from cogs.iembot import get_cached_watch_text
+    cached_text = get_cached_watch_text(watch_number)
+    if cached_text and not text_summary:
+        text_summary = cached_text
+        logger.info(f"[WATCH] Got text from iembot cache for #{watch_number}")
+
     # IEM fallback: if SPC page was unreachable, try IEM watches API
     if not html:
         logger.warning(f"[WATCH] SPC unreachable for #{watch_number} — using IEM data")

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ IS_PRIMARY = os.getenv("IS_PRIMARY", "true").lower() == "true"
 bot.state.is_primary = IS_PRIMARY
 
 ALL_EXTENSIONS = [
-    "cogs.scp", "cogs.outlooks", "cogs.mesoscale", "cogs.watches",
+    "cogs.iembot", "cogs.scp", "cogs.outlooks", "cogs.mesoscale", "cogs.watches",
     "cogs.status", "cogs.radar", "cogs.csu_mlp", "cogs.ncar",
     "cogs.sounding", "cogs.hodograph",
 ]


### PR DESCRIPTION
- add cogs/iembot.py: polls weather.im/iembot-json/room/spcchat every 15s, detects SEL (watch) and SWOMCD (MD) products, fetches full text from mesonet.agron.iastate.edu/api/1/nwstext/{product_id} immediately and caches parsed text for 10 minutes
- watches: check iembot cache before SPC/IEM fallback in fetch_watch_details
- mesoscale: check iembot cache before SPC HTML parse in fetch_md_details
- last-seen seqnum persisted to SQLite via set_state/get_state
- cache is ephemeral module-level only, not synced to failover standby
- register IEMBotCog in main.py extension list
- update README and CONTRIBUTING with new cog, architecture, and sounding changes