### PR TITLE
fix: add missing post_md_now and post_watch_now methods

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -222,6 +222,47 @@ class MesoscaleCog(commands.Cog):
     def cog_unload(self):
         self.auto_post_md.cancel()
 
+    async def post_md_now(self, md_num: str):
+        """
+        Immediately post a specific MD if it hasn't been posted yet.
+        Called by IEMBotCog when it detects a new MD from the real-time feed.
+        """
+        md_num = md_num.zfill(4)
+        if md_num in self.bot.state.posted_mds:
+            return
+        channel = self.bot.get_channel(SPC_CHANNEL_ID)
+        if not channel:
+            return
+
+        self.bot.state.active_mds.add(md_num)
+        logger.info(f"[MD] iembot-triggered post for #{md_num}")
+        image_url, summary, from_cache = await fetch_md_details(md_num)
+        if not image_url:
+            logger.warning(f"[MD] iembot trigger: could not resolve image for #{md_num}")
+            return
+
+        cache_path, _, _ = await download_single_image(
+            image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
+        )
+        md_page_url = f"https://www.spc.noaa.gov/products/md/mcd{md_num}.html"
+        header = f"**🌩️ SPC Mesoscale Discussion #{md_num}**"
+        if summary:
+            header += f"\n{summary}"
+        header += f"\n<{md_page_url}>"
+
+        try:
+            if cache_path:
+                await channel.send(header, files=[discord.File(cache_path)])
+            else:
+                await channel.send(header)
+            self.bot.state.posted_mds.add(md_num)
+            asyncio.create_task(add_posted_md(str(md_num)))
+            asyncio.create_task(prune_posted_mds())
+            self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
+            logger.info(f"[MD] iembot-triggered: posted MD #{md_num}")
+        except discord.HTTPException as e:
+            logger.error(f"[MD] iembot-triggered send failed for #{md_num}: {e}")
+
     @tasks.loop(seconds=30)
     async def auto_post_md(self):
         await self.bot.wait_until_ready()

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -575,6 +575,75 @@ class WatchesCog(commands.Cog):
     def cog_unload(self):
         self.auto_post_watches.cancel()
 
+    async def post_watch_now(self, watch_num: str, nws_info: dict):
+        """
+        Immediately post a specific watch if it hasn't been posted yet.
+        Called by IEMBotCog when it detects a new watch from the real-time feed.
+        """
+        watch_num = watch_num.zfill(4)
+        if watch_num in self.bot.state.posted_watches:
+            return
+        channel = self.bot.get_channel(SPC_CHANNEL_ID)
+        if not channel:
+            return
+
+        wtype = nws_info.get("type", "SVR") if isinstance(nws_info, dict) else "SVR"
+        expires = nws_info.get("expires") if isinstance(nws_info, dict) else None
+        is_tornado = wtype == "TORNADO"
+        watch_label = "Tornado Watch" if is_tornado else "Severe Thunderstorm Watch"
+        color = discord.Color.red() if is_tornado else discord.Color.orange()
+        now_utc = datetime.now(timezone.utc)
+
+        logger.info(f"[WATCH] iembot-triggered post for #{watch_num} ({wtype})")
+        image_url, text_summary, probs = await fetch_watch_details(watch_num)
+        cache_path = None
+        if image_url:
+            cache_path, _, _ = await download_single_image(
+                image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
+            )
+
+        embed = discord.Embed(
+            title=(
+                f"{'🌪️' if is_tornado else '⛈️'}  "
+                f"{watch_label} #{int(watch_num)}"
+            ),
+            color=color,
+            timestamp=now_utc,
+        )
+        if expires:
+            embed.add_field(
+                name="Expires",
+                value=f"<t:{int(expires.timestamp())}:R>",
+                inline=True,
+            )
+        if text_summary:
+            embed.add_field(name="Details", value=text_summary[:1024], inline=False)
+        if probs:
+            embed.add_field(name="Probabilities", value=probs[:1024], inline=False)
+        embed.set_footer(text="SPC Watch Monitor")
+        if cache_path:
+            embed.set_image(url=f"attachment://watch_{watch_num}.gif")
+
+        try:
+            files = (
+                [discord.File(cache_path, filename=f"watch_{watch_num}.gif")]
+                if cache_path else []
+            )
+            await channel.send(embed=embed, files=files)
+            self.bot.state.active_watches[watch_num] = nws_info
+            self.bot.state.posted_watches.add(watch_num)
+            asyncio.create_task(add_posted_watch(str(watch_num)))
+            asyncio.create_task(prune_posted_watches())
+            self.bot.state.last_post_times["watch"] = now_utc
+            logger.info(f"[WATCH] iembot-triggered: posted watch #{watch_num}")
+            sounding_cog = self.bot.cogs.get("SoundingCog")
+            if sounding_cog and isinstance(nws_info, dict) and nws_info.get("affected_zones"):
+                asyncio.create_task(
+                    sounding_cog.post_soundings_for_watch(watch_num, nws_info, channel)
+                )
+        except discord.HTTPException as e:
+            logger.error(f"[WATCH] iembot-triggered send failed for #{watch_num}: {e}")
+
     @tasks.loop(minutes=2)
     async def auto_post_watches(self):
         await self.bot.wait_until_ready()


### PR DESCRIPTION
These were patched locally in v4.9.12 but not staged in the commit.
- MesoscaleCog.post_md_now(): immediately posts a specific MD when signaled by IEMBotCog, skips if already posted
- WatchesCog.post_watch_now(): immediately posts a specific watch when signaled, fires post_soundings_for_watch if zones available