### PR TITLE
fix: test hangs, resource cleanup, and double-post prevention

### DIFF
--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -745,6 +745,10 @@ class WatchesCog(commands.Cog):
     @tasks.loop(minutes=2)
     async def auto_post_watches(self):
         await self.bot.wait_until_ready()
+
+        if not self.bot.state.is_primary:
+            return
+
         if self._watches_backoff.should_skip():
             return
         channel = self.bot.get_channel(SPC_CHANNEL_ID)

--- a/config.py
+++ b/config.py
@@ -101,7 +101,7 @@ else:
 # Exported constants used by cogs
 SPC_SCHEDULE = {int(k): v for k, v in _P["spc_schedule"].items()}
 SPC_OUTLOOK_BASE = _P.get("spc_outlook_base")
-SPC_URLS_FALLBACK = {int(k) if k.isdigit() else k: v for k, v in _P["spc_urls_fallback"].items()}
+SPC_URLS_FALLBACK = {str(k): v for k, v in _P["spc_urls_fallback"].items()}
 SPC_URLS = SPC_URLS_FALLBACK
 SCP_IMAGE_URLS = _P["scp_image_urls"]
 WPC_IMAGE_URLS = _P["wpc_image_urls"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+log_cli = true
+log_cli_level = INFO

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ Pytest configuration — set up environment variables before config.py imports.
 
 import os
 import sys
+import asyncio
+import pytest
+from unittest.mock import MagicMock, AsyncMock
 
 # Ensure the project root is on the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -16,3 +19,28 @@ os.environ.setdefault("MODELS_CHANNEL_ID", "987654321")
 os.environ.setdefault("GUILD_ID", "111222333")
 os.environ.setdefault("CACHE_DIR", "/tmp/spc_bot_test_cache")
 os.environ.setdefault("LOG_FILE", "/tmp/spc_bot_test.log")
+
+@pytest.fixture(autouse=True)
+async def cleanup_resources():
+    """Ensure DB and HTTP sessions are closed after every test."""
+    yield
+    try:
+        from utils.db import close_db
+        from utils.http import close_session
+        
+        await close_db()
+        await close_session()
+    except Exception:
+        pass
+    
+    # Let any pending callbacks run
+    await asyncio.sleep(0.01)
+
+@pytest.fixture(autouse=True)
+def patch_task_backoff(monkeypatch):
+    """Patch TaskBackoff to prevent it from starting background watchdog tasks during tests."""
+    mock_backoff = MagicMock()
+    mock_backoff.failure = AsyncMock()
+    mock_backoff.success = MagicMock()
+    mock_backoff.should_skip = MagicMock(return_value=False)
+    monkeypatch.setattr("utils.backoff.TaskBackoff", MagicMock(return_value=mock_backoff))

--- a/tests/test_hodograph.py
+++ b/tests/test_hodograph.py
@@ -49,7 +49,6 @@ class TestRadarValidation:
 
 
 class TestGenerateHodograph:
-    @pytest.mark.asyncio
     async def test_timeout_sends_ephemeral_message(self):
         from cogs.hodograph import generate_hodograph
 
@@ -74,7 +73,6 @@ class TestGenerateHodograph:
         assert call_kwargs.kwargs["ephemeral"] is True
         assert "Timed out" in call_kwargs.args[0]
 
-    @pytest.mark.asyncio
     async def test_nonzero_returncode_sends_error(self):
         from cogs.hodograph import generate_hodograph
 
@@ -95,7 +93,6 @@ class TestGenerateHodograph:
         assert call_kwargs.kwargs.get("ephemeral") is True
         assert "Could not generate" in call_kwargs.args[0]
 
-    @pytest.mark.asyncio
     async def test_missing_output_file_sends_error(self):
         from cogs.hodograph import generate_hodograph
 

--- a/tests/test_iem_races.py
+++ b/tests/test_iem_races.py
@@ -125,6 +125,8 @@ class TestPostSoundingsForWatch:
         bot = MagicMock()
         bot.state = MagicMock()
         bot.state.active_watches = {}
+        # Use a real dict for cogs so .get() works normally
+        bot.cogs = {}
         return bot
 
     @pytest.mark.asyncio
@@ -167,13 +169,13 @@ class TestPostSoundingsForWatch:
         from cogs.watches import WatchesCog
 
         bot = self._make_bot()
+        bot.state.is_primary = True # MUST be primary to run task
         bot.wait_until_ready = AsyncMock()
         bot.get_channel = MagicMock(return_value=AsyncMock())
 
         mock_sounding_cog = MagicMock()
         mock_sounding_cog.post_soundings_for_watch = AsyncMock()
-        bot.cogs = {"SoundingCog": mock_sounding_cog}
-
+        bot.cogs["SoundingCog"] = mock_sounding_cog
         nws_result = {
             "0102": {
                 "type": "SVR",
@@ -192,7 +194,8 @@ class TestPostSoundingsForWatch:
             cog.auto_post_watches.cancel()
             await cog.auto_post_watches()
 
-        await asyncio.sleep(0)
-        mock_sounding_cog.post_soundings_for_watch.assert_called_once()
+            await asyncio.sleep(0.1)
+            mock_sounding_cog.post_soundings_for_watch.assert_called_once()
+
         call_args = mock_sounding_cog.post_soundings_for_watch.call_args[0]
         assert call_args[0] == "0102"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,6 +17,7 @@ def make_mock_bot():
     bot.latency = 0.05
     bot.guilds = []
     bot.wait_until_ready = AsyncMock()
+    bot.cogs = {}
     return bot
 
 
@@ -70,7 +71,6 @@ class TestBotStateInit:
 # ── Watches cog ───────────────────────────────────────────────────────────────
 
 class TestWatchesCogIntegration:
-    @pytest.mark.asyncio
     async def test_auto_post_watches_no_nameerror_on_new_watch(self):
         """
         Simulate a new watch being detected. Ensures the full auto_post_watches
@@ -91,13 +91,14 @@ class TestWatchesCogIntegration:
         with patch("cogs.watches.fetch_active_watches_nws", new=AsyncMock(return_value=nws_result)), \
              patch("cogs.watches.fetch_watch_details", new=AsyncMock(return_value=(None, None, None))), \
              patch("cogs.watches.download_single_image", new=AsyncMock(return_value=(None, False, None))), \
-             patch("cogs.watches.add_posted_watch", new=AsyncMock()):
+             patch("cogs.watches.add_posted_watch", new=AsyncMock()), \
+             patch("cogs.sounding.SoundingCog.post_soundings_for_watch", new=AsyncMock()):
 
             cog = WatchesCog(bot)
+            bot.cogs["SoundingCog"] = MagicMock() # Ensure it's 'found'
             cog.auto_post_watches.cancel()
             await cog.auto_post_watches()
 
-    @pytest.mark.asyncio
     async def test_execute_watches_no_nameerror_on_slash_command(self):
         """
         Simulate /watches being invoked. Ensures _execute_watches executes
@@ -122,7 +123,6 @@ class TestWatchesCogIntegration:
 
             await _execute_watches(interaction, bot)
 
-    @pytest.mark.asyncio
     async def test_execute_watches_no_active_watches(self):
         """
         When NWS API and SPC scrape both return empty, /watches should
@@ -138,7 +138,6 @@ class TestWatchesCogIntegration:
             await _execute_watches(interaction, bot)
             interaction.followup.send.assert_called_once_with("No active watches found.")
 
-    @pytest.mark.asyncio
     async def test_auto_post_watches_skips_already_posted(self):
         """
         If a watch is already in posted_watches, it should not be posted again.
@@ -157,9 +156,11 @@ class TestWatchesCogIntegration:
         }
 
         with patch("cogs.watches.fetch_active_watches_nws", new=AsyncMock(return_value=nws_result)), \
-             patch("cogs.watches.fetch_watch_details", new=AsyncMock()) as mock_details:
+             patch("cogs.watches.fetch_watch_details", new=AsyncMock()) as mock_details, \
+             patch("cogs.sounding.SoundingCog.post_soundings_for_watch", new=AsyncMock()):
 
             cog = WatchesCog(bot)
+            bot.cogs["SoundingCog"] = MagicMock()
             cog.auto_post_watches.cancel()
             await cog.auto_post_watches()
             mock_details.assert_not_called()
@@ -168,7 +169,6 @@ class TestWatchesCogIntegration:
 # ── Outlooks cog ──────────────────────────────────────────────────────────────
 
 class TestOutlooksCogIntegration:
-    @pytest.mark.asyncio
     async def test_check_and_post_day_no_urls_returned(self):
         """
         If get_spc_urls returns empty, check_and_post_day should return
@@ -181,7 +181,6 @@ class TestOutlooksCogIntegration:
         with patch("cogs.outlooks.get_spc_urls", new=AsyncMock(return_value=[])):
             await check_and_post_day(channel, 1, bot.state)
 
-    @pytest.mark.asyncio
     async def test_outlooks_cog_instantiates(self):
         from cogs.outlooks import OutlooksCog
         bot = make_mock_bot()
@@ -189,12 +188,12 @@ class TestOutlooksCogIntegration:
         assert cog.bot.state is not None
         cog.auto_post_spc.cancel()
         cog.aggressive_check_spc.cancel()
+        cog.auto_post_spc48.cancel()
 
 
 # ── Mesoscale cog ─────────────────────────────────────────────────────────────
 
 class TestMesoscaleCogIntegration:
-    @pytest.mark.asyncio
     async def test_mesoscale_cog_instantiates(self):
         from cogs.mesoscale import MesoscaleCog
         bot = make_mock_bot()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,7 +134,6 @@ class TestRadarS3:
 # ── spc_urls tests ───────────────────────────────────────────────────────────
 
 class TestSpcUrls:
-    @pytest.mark.asyncio
     async def test_get_spc_urls_day1_with_tabs(self):
         """Test URL resolution when SPC page has the expected tab structure."""
         from utils.spc_urls import get_spc_urls
@@ -160,7 +159,6 @@ class TestSpcUrls:
         assert "probotlk_1200_wind" in urls[2]
         assert "probotlk_1200_hail" in urls[3]
 
-    @pytest.mark.asyncio
     async def test_get_spc_urls_day3_with_tabs(self):
         from utils.spc_urls import get_spc_urls
 
@@ -181,7 +179,6 @@ class TestSpcUrls:
         assert "day3otlk_0730.png" in urls[0]
         assert "day3prob_0730.png" in urls[1]
 
-    @pytest.mark.asyncio
     async def test_get_spc_urls_fetch_failure(self):
         from utils.spc_urls import get_spc_urls
 
@@ -194,7 +191,6 @@ class TestSpcUrls:
 
         assert urls == []
 
-    @pytest.mark.asyncio
     async def test_get_spc_urls_no_tabs_found(self):
         from utils.spc_urls import get_spc_urls
 
@@ -313,25 +309,23 @@ class TestCSUMLPUrls:
         url = _build_panel_url("severe_fcst_6panel", date)
         assert "severe_fcst_6panel_040812.png" in url
 
-    def test_load_posted_today_missing_file(self):
+    async def test_load_posted_today_missing_file(self):
         from unittest.mock import AsyncMock, patch
         with patch("cogs.csu_mlp.get_state", new=AsyncMock(return_value=None)):
             from cogs.csu_mlp import _load_posted_today
-            import asyncio
-            result = asyncio.run(_load_posted_today())
+            result = await _load_posted_today()
         assert result == set()
 
-    def test_load_posted_today_stale_date(self):
+    async def test_load_posted_today_stale_date(self):
         import json
         from unittest.mock import AsyncMock, patch
         value = json.dumps({"date": "2020-01-01", "days": [1, 2, 3]})
         with patch("cogs.csu_mlp.get_state", new=AsyncMock(return_value=value)):
             from cogs.csu_mlp import _load_posted_today
-            import asyncio
-            result = asyncio.run(_load_posted_today())
+            result = await _load_posted_today()
         assert result == set()
 
-    def test_load_posted_today_current_date(self):
+    async def test_load_posted_today_current_date(self):
         import json
         from datetime import datetime, timezone
         from unittest.mock import AsyncMock, patch
@@ -339,8 +333,7 @@ class TestCSUMLPUrls:
         value = json.dumps({"date": today, "days": [1, 2, "panel12"]})
         with patch("cogs.csu_mlp.get_state", new=AsyncMock(return_value=value)):
             from cogs.csu_mlp import _load_posted_today
-            import asyncio
-            result = asyncio.run(_load_posted_today())
+            result = await _load_posted_today()
         assert 1 in result
         assert 2 in result
         assert "panel12" in result
@@ -367,39 +360,35 @@ class TestNCARWxNext:
         url = _wxnext_url(date)
         assert "2026010100.png" in url
 
-    def test_load_state_missing_file(self):
+    async def test_load_state_missing_file(self):
         from unittest.mock import AsyncMock, patch
         with patch("cogs.ncar.get_state", new=AsyncMock(return_value=None)):
             from cogs.ncar import _load_state
-            import asyncio
-            result = asyncio.run(_load_state())
+            result = await _load_state()
         assert result == {}
 
-    def test_load_state_valid(self):
+    async def test_load_state_valid(self):
         import json
         from unittest.mock import AsyncMock, patch
         value = json.dumps({"date": "2026-04-08", "hash": "abc123"})
         with patch("cogs.ncar.get_state", new=AsyncMock(return_value=value)):
             from cogs.ncar import _load_state
-            import asyncio
-            result = asyncio.run(_load_state())
+            result = await _load_state()
         assert result["date"] == "2026-04-08"
         assert result["hash"] == "abc123"
 
-    def test_load_state_corrupt(self):
+    async def test_load_state_corrupt(self):
         from unittest.mock import AsyncMock, patch
         with patch("cogs.ncar.get_state", new=AsyncMock(return_value="not json {{{")):
             from cogs.ncar import _load_state
-            import asyncio
-            result = asyncio.run(_load_state())
+            result = await _load_state()
         assert result == {}
 
-    def test_save_state(self):
+    async def test_save_state(self):
         from unittest.mock import AsyncMock, patch
         with patch("cogs.ncar.set_state", new=AsyncMock()):
             from cogs.ncar import _save_state
-            import asyncio
-            asyncio.run(_save_state("2026-04-08", "hashvalue123"))
+            await _save_state("2026-04-08", "hashvalue123")
         assert True
 
 # ── sounding_utils tests ──────────────────────────────────────────────────────
@@ -467,21 +456,18 @@ class TestSoundingUtils:
             assert len(month) == 2
             assert len(day) == 2
 
-    def test_user_dark_mode_prefs(self):
+    async def test_user_dark_mode_prefs(self):
         from unittest.mock import AsyncMock, patch
         from cogs.sounding_utils import get_user_dark_mode
         # Default (no entry) should be False
         with patch("cogs.sounding_utils.get_state", new=AsyncMock(return_value=None)):
-            import asyncio
-            assert asyncio.run(get_user_dark_mode(12345)) is False
+            assert await get_user_dark_mode(12345) is False
         # Entry "1" should be True
         with patch("cogs.sounding_utils.get_state", new=AsyncMock(return_value="1")):
-            import asyncio
-            assert asyncio.run(get_user_dark_mode(12345)) is True
+            assert await get_user_dark_mode(12345) is True
         # Entry "0" should be False
         with patch("cogs.sounding_utils.get_state", new=AsyncMock(return_value="0")):
-            import asyncio
-            assert asyncio.run(get_user_dark_mode(12345)) is False
+            assert await get_user_dark_mode(12345) is False
 
     def test_plot_path_format(self):
         from cogs.sounding_views import _plot_path


### PR DESCRIPTION
Resolves consistent test hangs by adding global async resource cleanup, fixing broken TaskBackoff mocks, and ensuring only the primary instance auto-posts watches.