### PR TITLE
fix: resolve db deadlock, slow shutdown, and duplicate IEM fetch

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -125,7 +125,6 @@ class FailoverCog(commands.Cog):
     # ── Cloudflare tunnel ─────────────────────────────────────────────────
 
     async def _start_tunnel(self):
-        loop = asyncio.get_event_loop()
         try:
             self._tunnel_proc = await asyncio.create_subprocess_exec(
                 "cloudflared", "tunnel", "--url", f"http://localhost:{STATE_PORT}",

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -134,6 +134,7 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
     year = datetime.now(timezone.utc).year
 
     text_summary = None
+    probs = None
     try:
         url = f"https://mesonet.agron.iastate.edu/json/watches.py?year={year}"
         content, status = await http_get_bytes(url, retries=2, timeout=15)
@@ -145,18 +146,17 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
                     state_list = ", ".join(states.split(",")) if states else "Unknown"
                     is_pds = event.get("is_pds", False)
 
-                    parts = [f"**Areas:** {state_list}"]
-                    if is_pds:
-                        parts.append("⚠️ **Particularly Dangerous Situation (PDS)**")
-
-                    # Build probabilities from IEM structured fields
-                    prob_lines = []
                     tor_pct = event.get("tornadoes_1m_strong", 0)
                     hail_pct = event.get("hail_1m_2inch", 0)
                     max_hail = event.get("max_hail_size", 0)
                     max_wind = event.get("max_wind_gust_knots", 0)
                     max_wind_mph = round(max_wind * 1.15078) if max_wind else 0
 
+                    parts = [f"**Areas:** {state_list}"]
+                    if is_pds:
+                        parts.append("⚠️ **Particularly Dangerous Situation (PDS)**")
+
+                    prob_lines = []
                     if tor_pct:
                         prob_lines.append(f"🔴 **Tornado**")
                         prob_lines.append(f"🔴 Sig. tornado (EF2+): **{tor_pct}%**")
@@ -171,42 +171,22 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
                         parts.append("**Probabilities (IEM)**\n" + "\n".join(prob_lines))
 
                     text_summary = "\n".join(parts)
+
+                    # Build preliminary probs from same event data
+                    prelim_lines = ["**Probabilities (preliminary — will update)**"]
+                    if tor_pct:
+                        prelim_lines.append(f"🔴 Sig. tornado (EF2+): **{tor_pct}%**")
+                    if hail_pct:
+                        prelim_lines.append(f"🟢 2\"+ hail: **{hail_pct}%** | Max: **{max_hail}\"**")
+                    if max_wind_mph:
+                        prelim_lines.append(f"🔵 Max gusts: **{max_wind_mph} mph ({int(max_wind)} kt)**")
+                    if len(prelim_lines) > 1:
+                        probs = "\n".join(prelim_lines)
+
                     logger.info(f"[WATCH] Got details from IEM watches API for #{watch_number}")
                     break
     except Exception as e:
         logger.warning(f"[WATCH] IEM watches API failed for #{watch_number}: {e}")
-
-    # Build preliminary probs from IEM watches JSON
-    probs = None
-    try:
-        import json as _json_iem2
-        from datetime import datetime, timezone
-        year = datetime.now(timezone.utc).year
-        content2, status2 = await http_get_bytes(
-            f"https://mesonet.agron.iastate.edu/json/watches.py?year={year}",
-            retries=2, timeout=15
-        )
-        if content2 and status2 == 200:
-            data2 = _json_iem2.loads(content2)
-            for event in data2.get("events", []):
-                if event.get("num") == int(watch_number):
-                    prob_lines = ["**Probabilities (preliminary — will update)**"]
-                    tor = event.get("tornadoes_1m_strong", 0)
-                    hail_pct = event.get("hail_1m_2inch", 0)
-                    max_hail = event.get("max_hail_size", 0)
-                    max_wind = event.get("max_wind_gust_knots", 0)
-                    max_wind_mph = round(max_wind * 1.15078) if max_wind else 0
-                    if tor:
-                        prob_lines.append(f"🔴 Sig. tornado (EF2+): **{tor}%**")
-                    if hail_pct:
-                        prob_lines.append(f"🟢 2\"+ hail: **{hail_pct}%** | Max: **{max_hail}\"**")
-                    if max_wind_mph:
-                        prob_lines.append(f"🔵 Max gusts: **{max_wind_mph} mph ({int(max_wind)} kt)**")
-                    if len(prob_lines) > 1:
-                        probs = "\n".join(prob_lines)
-                    break
-    except Exception as e:
-        logger.warning(f"[WATCH] IEM probs fetch failed for #{watch_number}: {e}")
 
     # No image available from IEM — SPC image will be retried separately
     return text_summary, None, probs

--- a/main.py
+++ b/main.py
@@ -299,22 +299,31 @@ async def watchdog_task():
 # ── Graceful shutdown ────────────────────────────────────────────────────────
 async def _shutdown():
     logger.info("Shutting down bot gracefully...")
-    
-    # 1. Cancel all managed and background tasks immediately
+
+    # 1. Stop managed task loops (cog loops, watchdog, periodic sync)
     for task, name in MANAGED_TASKS:
         task.cancel()
     watchdog_task.cancel()
-    
-    # Also cancel any other pending tasks in the loop
-    all_tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    for t in all_tasks:
-        t.cancel()
-        
-    if all_tasks:
-        # Wait a very short time for tasks to acknowledges cancellation
-        await asyncio.wait(all_tasks, timeout=2.0)
+    if periodic_sync.is_running():
+        periodic_sync.cancel()
 
-    # 2. Close connections in parallel
+    # 2. Close the bot — lets Discord.py send the WebSocket close frame
+    #    using its own internal tasks (which are still alive at this point)
+    try:
+        await asyncio.wait_for(bot.close(), timeout=5.0)
+    except asyncio.TimeoutError:
+        logger.warning("bot.close() timed out after 5s")
+    except Exception as e:
+        logger.warning(f"Error while closing bot: {e}")
+
+    # 3. Cancel any remaining background tasks (e.g. _upgrade_watch_embed sleeps)
+    remaining = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    for t in remaining:
+        t.cancel()
+    if remaining:
+        await asyncio.wait(remaining, timeout=1.0)
+
+    # 4. Close DB and HTTP session
     try:
         await asyncio.wait_for(
             asyncio.gather(close_session(), close_db(), return_exceptions=True),
@@ -324,12 +333,6 @@ async def _shutdown():
         logger.warning("Shutdown timed out while closing connections")
     except Exception as e:
         logger.warning(f"Error during resource cleanup: {e}")
-
-    # 3. Close the bot
-    try:
-        await asyncio.wait_for(bot.close(), timeout=2.0)
-    except Exception as e:
-        logger.warning(f"Error while closing bot: {e}")
 
 
 def _setup_signal_handlers(loop: asyncio.AbstractEventLoop):

--- a/utils/db.py
+++ b/utils/db.py
@@ -141,8 +141,8 @@ async def get_hash(url: str) -> Optional[str]:
 async def set_hash(url: str, hash_val: str, cache_type: str = "auto"):
     """Store or update hash for a URL."""
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute(
                 """INSERT INTO image_hashes (url, hash, cache_type)
                    VALUES (?, ?, ?)
@@ -180,8 +180,8 @@ async def set_hashes_batch(hashes: dict, cache_type: str = "auto"):
     if not hashes:
         return
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.executemany(
                 """INSERT INTO image_hashes (url, hash, cache_type)
                    VALUES (?, ?, ?)
@@ -210,8 +210,8 @@ async def get_posted_mds() -> set:
 async def add_posted_md(md_number: str):
     """Mark an MD as posted."""
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute(
                 "INSERT OR IGNORE INTO posted_mds (md_number) VALUES (?)",
                 (md_number,),
@@ -224,8 +224,8 @@ async def add_posted_md(md_number: str):
 async def prune_posted_mds(max_size: int = 200):
     """Keep only the most recent MD numbers."""
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute("""
                 DELETE FROM posted_mds
                 WHERE md_number NOT IN (
@@ -258,8 +258,8 @@ async def get_posted_watches() -> set:
 async def add_posted_watch(watch_number: str):
     """Mark a watch as posted."""
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute(
                 "INSERT OR IGNORE INTO posted_watches (watch_number) VALUES (?)",
                 (watch_number,),
@@ -272,8 +272,8 @@ async def add_posted_watch(watch_number: str):
 async def prune_posted_watches(max_size: int = 200):
     """Keep only the most recent watch numbers."""
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute("""
                 DELETE FROM posted_watches
                 WHERE watch_number NOT IN (
@@ -306,8 +306,8 @@ async def get_state(key: str) -> Optional[str]:
 async def set_state(key: str, value: str):
     """Set a value in the key/value store."""
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute(
                 """INSERT INTO bot_state (key, value)
                    VALUES (?, ?)
@@ -322,8 +322,8 @@ async def set_state(key: str, value: str):
 async def delete_state(key: str):
     """Delete a key from the key/value store."""
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute(
                 "DELETE FROM bot_state WHERE key = ?", (key,)
             )
@@ -354,8 +354,8 @@ async def set_posted_urls(day_key: str, urls: list):
     """Store last posted URLs for a day key."""
     import json
     try:
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute(
                 """INSERT INTO posted_urls (day_key, urls)
                    VALUES (?, ?)
@@ -395,8 +395,8 @@ async def set_product_cache(product_id: str, text: str, ttl: int = 600):
     import time
     try:
         expires_at = time.time() + ttl
+        db = await get_db()
         async with _LOCK:
-            db = await get_db()
             await db.execute(
                 """INSERT INTO product_text_cache (product_id, text, expires_at)
                    VALUES (?, ?, ?)


### PR DESCRIPTION
## Summary

- **`utils/db.py` — deadlock fix (root cause of hanging tests):** Every write function held `_LOCK` then called `get_db()`, which also acquires `_LOCK` when `_db is None`. `asyncio.Lock` is not reentrant, so this deadlocked whenever the DB hadn't been initialized yet. Caused the entire pytest suite to hang indefinitely at 25%. Fix: move `db = await get_db()` before `async with _LOCK:` in all 10 write functions.
- **`main.py` — fast shutdown:** `_shutdown()` was cancelling all asyncio tasks before `bot.close()`. Discord.py needs its own internal tasks alive to send the WebSocket close frame; killing them first left `bot.close()` waiting on a dead connection. Fix: cancel managed loops → `bot.close()` → cancel remaining background tasks → close DB/session.
- **`cogs/watches.py` — eliminate duplicate IEM request:** `fetch_watch_details_iem()` fetched the same IEM JSON endpoint twice (once for text, once for probs) and discarded the first response's numeric data. Fix: single fetch populates both.
- **`cogs/failover.py`:** Remove unused `loop = asyncio.get_event_loop()`.

## Test plan

- [x] `venv/bin/pytest tests/ -v` — 97/97 passed (previously hung at 25%)
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)