### PR TITLE
fix: correct CSU type check, watches embed duplication, and sounding race

### DIFF
--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -264,7 +264,7 @@ class CSUMLPCog(commands.Cog):
             return
 
         for day in range(1, 9):
-            if str(day) in self.bot.state.csu_posted or day in self.bot.state.csu_posted:
+            if str(day) in self.bot.state.csu_posted:
                 continue
 
             url, label = await _resolve_best_url(day)

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -660,26 +660,56 @@ async def fetch_sounding(
     loop = asyncio.get_running_loop()
 
     if hour in ("00", "12"):
-        # Wyoming has quality preference for standard hours (better hodograph data).
-        # Try Wyoming first, fallback to IEM only if Wyoming fails.
-        try:
-            logger.debug(f"[SOUNDING] Trying Wyoming for {station_id} {hour}z")
-            data = await loop.run_in_executor(
-                None,
-                lambda: spy.get_obs_data(station_id, year, month, day, hour)
-            )
-            if data:
-                logger.debug(f"[SOUNDING] Got Wyoming data for {station_id} {hour}z")
+        # Race Wyoming and IEM simultaneously — whichever returns valid data
+        # first wins. Wyoming has quality preference: if both succeed, the
+        # Wyoming result is used. Racing avoids blocking on Wyoming's full
+        # timeout when it is slow or unavailable.
+        async def _try_wyoming():
+            try:
+                data = await loop.run_in_executor(
+                    None,
+                    lambda: spy.get_obs_data(station_id, year, month, day, hour)
+                )
                 return data
-        except Exception as e:
-            logger.debug(f"[SOUNDING] Wyoming failed for {station_id} {hour}z: {e}")
+            except Exception as e:
+                logger.debug(f"[SOUNDING] Wyoming failed for {station_id} {hour}z: {e}")
+                return None
 
-        # Fallback to IEM
-        logger.debug(f"[SOUNDING] Falling back to IEM for {station_id} {hour}z")
-        return await fetch_iem_sounding(
-            station_id, year, month, day, hour,
-            station_name=station_name, lat=lat, lon=lon, elev=elev
+        async def _try_iem():
+            return await fetch_iem_sounding(
+                station_id, year, month, day, hour,
+                station_name=station_name, lat=lat, lon=lon, elev=elev
+            )
+
+        wyoming_task = asyncio.create_task(_try_wyoming())
+        iem_task = asyncio.create_task(_try_iem())
+
+        done, pending = await asyncio.wait(
+            [wyoming_task, iem_task],
+            return_when=asyncio.FIRST_COMPLETED,
         )
+
+        first = done.pop()
+        result = first.result()
+        if result:
+            for t in pending:
+                t.cancel()
+            source = "Wyoming" if first is wyoming_task else "IEM"
+            logger.debug(f"[SOUNDING] {source} won race for {station_id} {hour}z")
+            return result
+
+        # First result was None — wait for the second
+        if pending:
+            second = pending.pop()
+            try:
+                result = await second
+                if result:
+                    source = "Wyoming" if second is wyoming_task else "IEM"
+                    logger.debug(f"[SOUNDING] {source} fallback for {station_id} {hour}z")
+                    return result
+            except Exception:
+                pass
+        return None
 
     # Non-standard hours: IEM only (Wyoming doesn't carry special soundings)
     iem_data = await fetch_iem_sounding(

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -156,23 +156,11 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
                     if is_pds:
                         parts.append("⚠️ **Particularly Dangerous Situation (PDS)**")
 
-                    prob_lines = []
-                    if tor_pct:
-                        prob_lines.append(f"🔴 **Tornado**")
-                        prob_lines.append(f"🔴 Sig. tornado (EF2+): **{tor_pct}%**")
-                    if hail_pct:
-                        prob_lines.append(f"🟢 **Hail**")
-                        prob_lines.append(f'🟢 2"+  hail: **{hail_pct}%** | Max: **{max_hail}"**')
-                    if max_wind_mph:
-                        prob_lines.append(f"🔵 **Wind**")
-                        prob_lines.append(f"🔵 Max gusts: **{max_wind_mph} mph ({int(max_wind)} kt)**")
-
-                    if prob_lines:
-                        parts.append("**Probabilities (IEM)**\n" + "\n".join(prob_lines))
-
                     text_summary = "\n".join(parts)
 
-                    # Build preliminary probs from same event data
+                    # Probabilities go only in the probs field (rendered as a
+                    # separate embed field) — not in text_summary — to avoid
+                    # the same numbers appearing twice in the embed.
                     prelim_lines = ["**Probabilities (preliminary — will update)**"]
                     if tor_pct:
                         prelim_lines.append(f"🔴 Sig. tornado (EF2+): **{tor_pct}%**")


### PR DESCRIPTION
## Summary

- **cogs/csu_mlp.py**: `csu_posted` always stores strings via `str(day)` — the `or day in self.bot.state.csu_posted` int fallback on the already-posted check was dead/confusing code. Removed.

- **cogs/watches.py**: When SPC is unreachable and IEM is used as fallback, `fetch_watch_details_iem` was embedding probability data into both `text_summary` ("Probabilities (IEM)") and `probs` ("preliminary — will update"). The embed renders both as separate fields, so users saw the same numbers twice under contradictory headings. Removed the prob block from `text_summary`; it belongs only in `probs`.

- **cogs/sounding_utils.py**: Restored the original Wyoming/IEM parallel race for 00z/12z soundings. The sequential fallback was a latency regression — if Wyoming is slow or down, the fetch blocks for Wyoming's full executor timeout before IEM is attempted. The race fires both simultaneously and uses whichever returns first, falling back to the second if the winner returns None.

## Test plan

- [ ] Confirm CSU auto-post loop correctly skips already-posted days (no duplicate posts)
- [ ] Trigger IEM watch fallback path and confirm embed has no duplicate probability data
- [ ] Confirm sounding fetches for 00z/12z complete faster when Wyoming is slow