### PR TITLE
Feat: add RSS memory to /status; suppress no-change cache log spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Discord bot for severe weather enthusiasts. Auto-posts SPC convective outlooks
 * NEXRAD Level 2 radar downloader from NOAA AWS S3
   * Single or multi-site downloads with per-site ZIP packaging
   * Z-to-Z range, start+duration, explicit datetime, or N most recent files
-* **Enhanced Observability**: Detailed `/status` dashboard showing node roles (Primary/Standby), real-time task health, and feed synchronization state
+* **Enhanced Observability**: Detailed `/status` dashboard showing node roles (Primary/Standby), real-time task health, RSS memory usage, and feed synchronization state
 
 ## Prerequisites
 

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -1,5 +1,6 @@
 # cogs/status.py
 import logging
+import resource
 import socket
 from datetime import datetime, timezone
 from typing import Optional
@@ -300,6 +301,9 @@ class StatusCog(commands.Cog):
             lines.append(f"Uptime         : {format_timedelta(uptime)}")
         else:
             lines.append("Uptime         : unknown")
+
+        rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        lines.append(f"RSS Memory     : {rss_kb / 1024:.1f} MB")
 
         session_ok = (
             _http.http_session is not None

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -212,7 +212,8 @@ async def check_partial_updates_parallel(
 
     await asyncio.gather(*[_check_one(u) for u in urls])
 
-    logger.info(
+    log = logger.info if updated_count > 0 else logger.debug
+    log(
         f"[CACHE] Partial check complete: {updated_count}/{total_count} updated "
         f"({head_fetched}/{total_count} warranted full fetch)"
     )


### PR DESCRIPTION
## Summary
- `/status` now shows process RSS memory usage (MB) using stdlib `resource` module — no new dependency
- Cache partial-check log downgraded from `INFO` to `DEBUG` when zero URLs were updated, eliminating routine journal noise like `Partial check complete: 0/4 updated`

## Test plan
- [ ] Run `/status` and confirm RSS Memory line appears
- [ ] Confirm no `[CACHE] Partial check complete: 0/...` lines in `spclog` during quiet periods