### PR TITLE
refactor: centralize extension list and require products.json

### DIFF
--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -1,0 +1,5 @@
+ALL_EXTENSIONS = [
+    "cogs.iembot", "cogs.scp", "cogs.outlooks", "cogs.mesoscale", "cogs.watches",
+    "cogs.status", "cogs.radar", "cogs.csu_mlp", "cogs.ncar",
+    "cogs.sounding", "cogs.hodograph",
+]

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -38,11 +38,7 @@ SYNC_INTERVAL = 30   # seconds
 
 UPSTASH_HEADERS = {"Authorization": f"Bearer {UPSTASH_TOKEN}"}
 
-ALL_EXTENSIONS = [
-    "cogs.scp", "cogs.outlooks", "cogs.mesoscale", "cogs.watches",
-    "cogs.status", "cogs.radar", "cogs.csu_mlp", "cogs.ncar",
-    "cogs.sounding", "cogs.hodograph",
-]
+from cogs import ALL_EXTENSIONS
 
 
 class FailoverCog(commands.Cog):

--- a/config.py
+++ b/config.py
@@ -50,59 +50,15 @@ os.makedirs(CACHE_DIR, exist_ok=True)
 _base_dir = os.path.dirname(os.path.abspath(__file__))
 _products_file = os.path.join(_base_dir, "config", "products.json")
 
-# Default values if JSON load fails
-_P = {
-    "spc_schedule": {"1": [1, 6, 13, 20], "2": [2, 13], "3": [3, 15]},
-    "spc_outlook_base": "https://www.spc.noaa.gov/products/outlook",
-    "spc_urls_fallback": {
-        "1": [
-            "https://www.spc.noaa.gov/products/outlook/day1otlk.gif",
-            "https://www.spc.noaa.gov/products/outlook/day1probotlk_torn.gif",
-            "https://www.spc.noaa.gov/products/outlook/day1probotlk_wind.gif",
-            "https://www.spc.noaa.gov/products/outlook/day1probotlk_hail.gif"
-        ],
-        "2": [
-            "https://www.spc.noaa.gov/products/outlook/day2otlk.gif",
-            "https://www.spc.noaa.gov/products/outlook/day2probotlk_torn.gif",
-            "https://www.spc.noaa.gov/products/outlook/day2probotlk_wind.gif",
-            "https://www.spc.noaa.gov/products/outlook/day2probotlk_hail.gif"
-        ],
-        "3": [
-            "https://www.spc.noaa.gov/products/outlook/day3otlk.gif",
-            "https://www.spc.noaa.gov/products/outlook/day3prob.gif"
-        ],
-        "48": ["https://www.spc.noaa.gov/products/exper/day4-8/day48prob.gif"]
-    },
-    "scp_image_urls": [
-        "https://atlas.niu.edu/forecast/scp/cfs_week1.png",
-        "https://atlas.niu.edu/forecast/scp/cfs_week2.png",
-        "https://atlas.niu.edu/forecast/scp/cfs_week3.png",
-        "https://atlas.niu.edu/forecast/scp/gefs_week1__CTRL.png",
-        "https://atlas.niu.edu/forecast/scp/gefs_week2__CTRL.png"
-    ],
-    "wpc_image_urls": [
-        "https://www.wpc.ncep.noaa.gov/qpf/94ewbg.gif",
-        "https://www.wpc.ncep.noaa.gov/qpf/98ewbg.gif",
-        "https://www.wpc.ncep.noaa.gov/qpf/99ewbg.gif"
-    ],
-    "spc_md_index_url": "https://www.spc.noaa.gov/products/md/",
-    "spc_watch_index_url": "https://www.spc.noaa.gov/products/watch/",
-    "spc_valid_watches_url": "https://www.spc.noaa.gov/products/watch/validww.png",
-    "nws_alerts_url": "https://api.weather.gov/alerts/active?event=Severe%20Thunderstorm%20Watch,Tornado%20Watch&status=actual",
-    "iembot_feed_url": "https://weather.im/iembot-json/room/spcchat",
-    "iem_nwstext_url": "https://mesonet.agron.iastate.edu/api/1/nwstext/{product_id}",
-    "wxnext_base_url": "https://www2.mmm.ucar.edu/projects/ncar_ensemble/ainwp/img",
-    "wxnext_page_url": "https://www2.mmm.ucar.edu/projects/ncar_ensemble/ainwp/"
-}
+if not os.path.exists(_products_file):
+    raise FileNotFoundError(
+        f"Product config file not found at {_products_file}. "
+        f"This file is required — the hardcoded fallback has been removed "
+        f"to prevent silent drift between the JSON and code."
+    )
 
-if os.path.exists(_products_file):
-    try:
-        with open(_products_file, "r") as f:
-            _P.update(json.load(f))
-    except Exception as e:
-        logger.error(f"Failed to load product config from {_products_file}: {e}")
-else:
-    logger.warning(f"Product config file NOT FOUND at {_products_file} — using hardcoded defaults")
+with open(_products_file, "r") as f:
+    _P = json.load(f)
 
 # Exported constants used by cogs
 SPC_SCHEDULE = {int(k): v for k, v in _P["spc_schedule"].items()}

--- a/config/products.json
+++ b/config/products.json
@@ -41,5 +41,9 @@
   "spc_md_index_url": "https://www.spc.noaa.gov/products/md/",
   "spc_watch_index_url": "https://www.spc.noaa.gov/products/watch/",
   "spc_valid_watches_url": "https://www.spc.noaa.gov/products/watch/validww.png",
-  "nws_alerts_url": "https://api.weather.gov/alerts/active?event=Severe%20Thunderstorm%20Watch,Tornado%20Watch&status=actual"
+  "nws_alerts_url": "https://api.weather.gov/alerts/active?event=Severe%20Thunderstorm%20Watch,Tornado%20Watch&status=actual",
+  "iembot_feed_url": "https://weather.im/iembot-json/room/spcchat",
+  "iem_nwstext_url": "https://mesonet.agron.iastate.edu/api/1/nwstext/{product_id}",
+  "wxnext_base_url": "https://www2.mmm.ucar.edu/projects/ncar_ensemble/ainwp/img",
+  "wxnext_page_url": "https://www2.mmm.ucar.edu/projects/ncar_ensemble/ainwp/"
 }

--- a/main.py
+++ b/main.py
@@ -12,8 +12,13 @@ from discord.ext import commands, tasks
 
 from config import CACHE_DIR, GUILD_ID, TOKEN, CONFIG
 from utils.http import close_session, ensure_session
-from utils.db import check_integrity, close_db, get_db
+from utils.db import (
+    check_integrity, close_db, get_db,
+    get_all_hashes, get_posted_urls, get_posted_mds, get_posted_watches,
+    get_state,
+)
 from utils.state import BotState
+from cogs import ALL_EXTENSIONS
 
 # ── Logging setup ────────────────────────────────────────────────────────────
 logger = logging.getLogger("spc_bot")
@@ -43,11 +48,6 @@ bot.state = BotState()
 
 async def setup_hook():
     """Hydrate state from DB before any cogs are loaded."""
-    from utils.db import (
-        check_integrity, get_db,
-        get_all_hashes, get_posted_urls, get_posted_mds, get_posted_watches,
-        get_state
-    )
     import json as _json
 
     # Initialize database
@@ -126,12 +126,6 @@ bot.setup_hook = setup_hook
 
 IS_PRIMARY = os.getenv("IS_PRIMARY", "true").lower() == "true"
 bot.state.is_primary = IS_PRIMARY
-
-ALL_EXTENSIONS = [
-    "cogs.iembot", "cogs.scp", "cogs.outlooks", "cogs.mesoscale", "cogs.watches",
-    "cogs.status", "cogs.radar", "cogs.csu_mlp", "cogs.ncar",
-    "cogs.sounding", "cogs.hodograph",
-]
 
 # Watchdog state
 _task_fail_counts = {}


### PR DESCRIPTION
## Summary
- Centralize `ALL_EXTENSIONS` in `cogs/__init__.py`, consumed by both `main.py` and `cogs/failover.py`. Fixes a real drift bug where failover's list was missing `cogs.iembot` (iembot would fail to load on standby promotion).
- Remove the hardcoded product-config fallback from `config.py`. `products.json` is now required; missing keys (`iembot_feed_url`, `iem_nwstext_url`, `wxnext_base_url`, `wxnext_page_url`) are added so the JSON is complete.
- Consolidate duplicate `utils.db` imports inside `main.setup_hook`.

## Test plan
- [x] `pytest -q` — 97 passed