### PR TITLE
perf: HEAD+GET → single conditional GET (also fixes broken head_changed)

### DIFF
--- a/utils/cache.py
+++ b/utils/cache.py
@@ -20,10 +20,17 @@ from utils.db import set_hash, set_hashes_batch
 from utils.change_detection import (
     calculate_hash_bytes,
     get_cache_path_for_url,
-    head_changed,
     is_placeholder_image,
 )
-from utils.http import ensure_session, http_get_bytes, http_head_meta, http_head_ok
+from utils.http import (
+    ensure_session,
+    http_get_bytes,
+    http_get_bytes_conditional,
+    http_head_ok,
+)
+
+# Per-URL HTTP validators (ETag, Last-Modified) from the most recent 200 response.
+_validators_cache: Dict[str, Dict[str, str]] = {}
 
 logger = logging.getLogger("spc_bot")
 
@@ -176,36 +183,37 @@ async def check_partial_updates_parallel(
     urls: List[str], cache: Dict[str, str]
 ) -> Tuple[int, int, Dict[str, Tuple[bytes, Optional[str]]]]:
     """
-    For each URL, do a HEAD check then conditionally fetch.
+    For each URL, do a conditional GET (If-None-Match / If-Modified-Since).
     Returns (updated_count, total_count, downloaded_data).
     """
     await ensure_session()
     total_count = len(urls)
     downloaded_data = {}
     updated_count = 0
-    head_fetched = 0
+    not_modified_count = 0
 
     async def _check_one(url: str):
-        nonlocal updated_count, head_fetched
-        meta = await http_head_meta(url)
-        if meta is None:
+        nonlocal updated_count, not_modified_count
+        prev = _validators_cache.get(url, {})
+        content, status, validators = await http_get_bytes_conditional(
+            url,
+            etag=prev.get("etag") or None,
+            last_modified=prev.get("last_modified") or None,
+        )
+        if status == 304:
+            not_modified_count += 1
             return
-
-        # Use efficient HEAD check first
-        if not head_changed(url, meta):
-            return
-
-        # If meta changed or unknown, fetch full bytes
-        head_fetched += 1
-        content, status = await http_get_bytes(url)
         if content is None or status != 200:
             return
+
+        # Remember fresh validators for next cycle
+        if validators:
+            _validators_cache[url] = validators
 
         if is_placeholder_image(content):
             return
 
         h = calculate_hash_bytes(content)
-        # Verify content hash actually differs from DB
         if url not in cache or cache.get(url) != h:
             downloaded_data[url] = (content, h)
             updated_count += 1
@@ -215,7 +223,7 @@ async def check_partial_updates_parallel(
     log = logger.info if updated_count > 0 else logger.debug
     log(
         f"[CACHE] Partial check complete: {updated_count}/{total_count} updated "
-        f"({head_fetched}/{total_count} warranted full fetch)"
+        f"({not_modified_count}/{total_count} returned 304 Not Modified)"
     )
     return updated_count, total_count, downloaded_data
 

--- a/utils/http.py
+++ b/utils/http.py
@@ -45,13 +45,18 @@ def _get_retry_after(response: aiohttp.ClientResponse) -> Optional[float]:
 
 
 async def http_get_bytes(
-    url: str, retries: int = 3, timeout: int = 10
+    url: str,
+    retries: int = 3,
+    timeout: int = 10,
+    headers: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[bytes], Optional[int]]:
     for attempt in range(retries):
         try:
             session = await ensure_session()
             async with session.get(
-                url, timeout=aiohttp.ClientTimeout(total=timeout)
+                url,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+                headers=headers,
             ) as response:
                 # Respect Retry-After on 429 or 503
                 if response.status in (429, 503):
@@ -63,6 +68,9 @@ async def http_get_bytes(
                     )
                     await asyncio.sleep(retry_after)
                     continue
+                # 304 Not Modified: caller passed validators; body is empty by spec.
+                if response.status == 304:
+                    return None, 304
                 content = await response.read()
                 return content, response.status
         except Exception as e:
@@ -72,6 +80,59 @@ async def http_get_bytes(
             )
             await asyncio.sleep(2**attempt)
     return None, None
+
+
+async def http_get_bytes_conditional(
+    url: str,
+    etag: Optional[str] = None,
+    last_modified: Optional[str] = None,
+    retries: int = 3,
+    timeout: int = 10,
+) -> Tuple[Optional[bytes], Optional[int], Optional[Dict[str, str]]]:
+    """Conditional GET. Returns (content, status, validators).
+
+    - If the server returns 304, content is None and validators carries the
+      prior values so callers can keep them.
+    - On 200, validators carries the fresh ETag / Last-Modified for storage.
+    """
+    headers: Dict[str, str] = {}
+    if etag:
+        headers["If-None-Match"] = etag
+    if last_modified:
+        headers["If-Modified-Since"] = last_modified
+
+    for attempt in range(retries):
+        try:
+            session = await ensure_session()
+            async with session.get(
+                url,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+                headers=headers or None,
+            ) as response:
+                if response.status in (429, 503):
+                    retry_after = _get_retry_after(response) or (2**attempt)
+                    retry_after = min(retry_after, 60)
+                    logger.warning(
+                        f"Rate limited on {url} (status={response.status}), "
+                        f"waiting {retry_after:.1f}s (attempt {attempt + 1}/{retries})"
+                    )
+                    await asyncio.sleep(retry_after)
+                    continue
+                if response.status == 304:
+                    return None, 304, {"etag": etag or "", "last_modified": last_modified or ""}
+                content = await response.read()
+                validators = {
+                    "etag": response.headers.get("ETag", ""),
+                    "last_modified": response.headers.get("Last-Modified", ""),
+                }
+                return content, response.status, validators
+        except Exception as e:
+            logger.warning(
+                f"Error fetching {url} (attempt {attempt + 1}/{retries}): "
+                f"{type(e).__name__}: {e}"
+            )
+            await asyncio.sleep(2**attempt)
+    return None, None, None
 
 
 async def http_get_text(


### PR DESCRIPTION
## Summary
- `check_partial_updates_parallel` now sends a single conditional GET per URL (`If-None-Match` / `If-Modified-Since`) instead of a HEAD followed by a conditional GET — halves RTTs on the hot poll path.
- Fixes a latent bug: the old code called `head_changed(url, meta)` without `await` while passing a dict in place of the expected function arg. The returned coroutine was always truthy, so `if not head_changed(...)` never short-circuited, meaning every URL fell through to a full GET anyway. The HEAD phase was doing a network round-trip for no gain.
- Adds `http_get_bytes_conditional()` and an optional `headers=` kwarg on `http_get_bytes()`.

## Test plan
- [x] pytest -q — 97 passed