### PR TITLE
ci: overhaul pipeline (match runtime, cache, gate publish)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,9 +5,35 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - name: System build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgeos-dev libproj-dev proj-bin libgdal-dev libhdf5-dev libnetcdf-dev
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: python -m pytest tests/ -q
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: verify
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI
 
 on:
   push:
@@ -6,23 +6,83 @@ on:
   pull_request:
     branches: [ main ]
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
+  lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - run: pip install ruff
+      - name: Ruff (syntax + undefined-name only)
+        # Narrowed to true errors. Style/unused-import cleanup is out of scope
+        # for CI blocking; add F401 once the codebase is clean.
+        run: ruff check --select=E9,F63,F7,F82 --exclude=venv,lib,cache .
 
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - name: System build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgeos-dev libproj-dev proj-bin libgdal-dev libhdf5-dev libnetcdf-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-asyncio
+          pip install -r requirements-dev.txt
+      - name: Run tests with coverage
+        run: |
+          python -m pytest tests/ \
+            --cov=cogs --cov=utils --cov=config --cov=main \
+            --cov-report=term-missing --cov-report=xml -v
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: warn
 
-      - name: Run tests
-        run: python -m pytest tests/ -v
+  docker-build:
+    # Verify the image builds on every PR / main push. Do not push.
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: spc-bot:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke test — image imports main.py
+        env:
+          DISCORD_TOKEN: ci-smoke-token
+          SPC_CHANNEL_ID: '1'
+          MODELS_CHANNEL_ID: '2'
+          GUILD_ID: '3'
+          FAILOVER_TOKEN: ci-smoke-failover-token
+        run: |
+          docker run --rm \
+            -e DISCORD_TOKEN -e SPC_CHANNEL_ID -e MODELS_CHANNEL_ID \
+            -e GUILD_ID -e FAILOVER_TOKEN \
+            spc-bot:ci python -c "import main; print('import ok')"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest>=8.0
+pytest-asyncio>=0.23
+pytest-cov>=5.0
+ruff>=0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ sounderpy>=3.1.0
 metpy>=1.5.0
 aiosqlite>=0.19
 aioboto3>=13.0
-pytest-asyncio


### PR DESCRIPTION
## Summary
**Test workflow**
- Align Python to 3.12 so CI matches the Dockerfile runtime (was 3.11).
- Add pip cache keyed on `requirements-dev.txt`.
- Add `lint` job running ruff on real errors only (E9/F63/F7/F82). F401 cleanup deferred — 58 existing unused imports would scope-creep this PR.
- Add coverage (`pytest-cov`, term-missing + XML, uploaded as artifact). Baseline: ~28%.
- Add `docker-build` job that builds the image on every PR and smoke-runs `python -c "import main"` inside the built image. Catches Dockerfile / import-time regressions before they reach a release tag.
- Concurrency group cancels stale runs on the same ref.

**Publish workflow**
- Add a `verify` job that runs `pytest` before `build-and-push`, so a bad tag cannot ship a broken image.
- Non-cancelling concurrency group prevents tag-push races.

**Requirements**
- New `requirements-dev.txt` = runtime + `pytest`, `pytest-asyncio`, `pytest-cov`, `ruff`.
- Remove stray `pytest-asyncio` from runtime `requirements.txt`.

## Test plan
- [x] `pytest -q` — 97 passed
- [x] `ruff check --select=E9,F63,F7,F82 --exclude=venv,lib,cache .` — clean
- [x] `python -c "import main"` with stub env — import ok