### PR TITLE
ci: add dependabot (pip, actions, docker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  # Python runtime + dev dependencies
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # Group all non-major bumps into one PR per week to keep noise low.
+      # Major bumps stay individual so they get their own review.
+      python-minor-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - python
+
+  # GitHub Actions used in .github/workflows/
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - ci
+
+  # Base images in the Dockerfile
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+      - docker


### PR DESCRIPTION
## Summary
Weekly dependency checks across all three ecosystems the repo uses.

- **pip** (`requirements.txt`, `requirements-dev.txt`): grouped minor/patch PRs, individual PRs for majors.
- **github-actions**: same grouping pattern — keeps workflow actions current without per-bump PR noise.
- **docker**: checks the `python:3.12-slim-bookworm` base image weekly.

All PRs labeled so you can filter them out of the active dev queue.

## Test plan
No functional changes; `.github/dependabot.yml` is read by GitHub.