### PR TITLE
test: expand cogs/failover coverage 18% → 62%

### DIFF
--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -1,0 +1,481 @@
+"""Coverage-focused tests for `cogs.failover`.
+
+The cog handles HA between two hosts and has three I/O surfaces:
+  1. An in-process aiohttp server serving /state and /sync.
+  2. Calls out to Upstash Redis via `aiohttp.ClientSession`.
+  3. A cloudflared subprocess for the tunnel.
+
+This file covers #1 and #2. For (1) we spin up the real `web.Application`
+the cog builds and hit it via an aiohttp client. For (2) we patch
+`aiohttp.ClientSession` to hand back mock responses, which is the most
+faithful way to test the paths short of running a real Redis.
+
+The cloudflared subprocess lifecycle is out of scope — it requires a
+binary that CI doesn't have.
+"""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import cogs.failover as failover_module
+from cogs.failover import FailoverCog
+from utils.state import BotState
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+def _make_bot(is_primary: bool = True):
+    """Real BotState; MagicMock for discord I/O."""
+    bot = MagicMock()
+    bot.state = BotState()
+    bot.state.is_primary = is_primary
+    bot.load_extension = AsyncMock()
+    bot.unload_extension = AsyncMock()
+    bot.tree = MagicMock()
+    bot.tree.sync = AsyncMock(return_value=[])
+    return bot
+
+
+class _FakeResponse:
+    """Minimal aiohttp response stand-in."""
+
+    def __init__(self, status: int, payload=None, text: str = ""):
+        self.status = status
+        self._payload = payload
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return self._text
+
+
+def _fake_session_factory(responder):
+    """Build a context-manager mock for `aiohttp.ClientSession`.
+
+    `responder(method, url, kwargs) -> _FakeResponse` chooses the response
+    per-call, letting a single fixture script out GET/POST sequences.
+    """
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    def _make_call(method):
+        def _call(url, **kwargs):
+            return responder(method, url, kwargs)
+        return _call
+
+    session.get = MagicMock(side_effect=_make_call("GET"))
+    session.post = MagicMock(side_effect=_make_call("POST"))
+    return session
+
+
+# ── _handle_get_state / _handle_post_sync — real HTTP roundtrip ─────────────
+
+async def _spin_up_cog_server(cog):
+    """Stand up the same aiohttp app the cog builds, via aiohttp's
+    TestServer so we can fire real requests at real handlers without
+    needing an unused port.
+    """
+    app = web.Application()
+    app.router.add_get("/state", cog._handle_get_state)
+    app.router.add_post("/sync", cog._handle_post_sync)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    return client
+
+
+async def test_get_state_rejects_missing_token(monkeypatch):
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+    cog = FailoverCog(_make_bot())
+    client = await _spin_up_cog_server(cog)
+    try:
+        resp = await client.get("/state")
+        assert resp.status == 401
+    finally:
+        await client.close()
+
+
+async def test_get_state_rejects_wrong_token(monkeypatch):
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+    cog = FailoverCog(_make_bot())
+    client = await _spin_up_cog_server(cog)
+    try:
+        resp = await client.get(
+            "/state", headers={"Authorization": "Bearer nope"}
+        )
+        assert resp.status == 401
+    finally:
+        await client.close()
+
+
+async def test_get_state_returns_serialized_state(monkeypatch):
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+    cog = FailoverCog(_make_bot())
+    cog.bot.state.posted_mds.add("0100")
+    cog.bot.state.iembot_last_seqnum = 42
+    client = await _spin_up_cog_server(cog)
+    try:
+        resp = await client.get(
+            "/state", headers={"Authorization": "Bearer secret"}
+        )
+        assert resp.status == 200
+        body = await resp.json()
+        assert "0100" in body["posted_mds"]
+        assert body["iembot_last_seqnum"] == 42
+    finally:
+        await client.close()
+
+
+async def test_post_sync_rejects_wrong_token(monkeypatch):
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+    cog = FailoverCog(_make_bot())
+    client = await _spin_up_cog_server(cog)
+    try:
+        resp = await client.post(
+            "/sync",
+            headers={"Authorization": "Bearer nope"},
+            json={"iembot_last_seqnum": 1},
+        )
+        assert resp.status == 401
+    finally:
+        await client.close()
+
+
+async def test_post_sync_merges_state(monkeypatch):
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+    # set_state is called inside /sync when seqnum advances; stub it.
+    monkeypatch.setattr("utils.db.set_state", AsyncMock())
+
+    cog = FailoverCog(_make_bot())
+    cog.bot.state.iembot_last_seqnum = 100
+    client = await _spin_up_cog_server(cog)
+    try:
+        resp = await client.post(
+            "/sync",
+            headers={"Authorization": "Bearer secret"},
+            json={
+                "posted_mds": ["0500"],
+                "posted_watches": ["0042"],
+                "auto_cache": {"u": "h"},
+                "iembot_last_seqnum": 250,
+                "last_posted_urls": {"day1": ["url1"]},
+            },
+        )
+        assert resp.status == 200
+    finally:
+        await client.close()
+
+    assert "0500" in cog.bot.state.posted_mds
+    assert "0042" in cog.bot.state.posted_watches
+    assert cog.bot.state.auto_cache == {"u": "h"}
+    # seqnum takes max
+    assert cog.bot.state.iembot_last_seqnum == 250
+    assert cog.bot.state.last_posted_urls["day1"] == ["url1"]
+
+
+async def test_post_sync_seqnum_does_not_regress(monkeypatch):
+    """If the POSTed seqnum is lower than the primary's, keep the
+    primary's. Tests the `new_seq > self.bot.state.iembot_last_seqnum`
+    guard in the handler."""
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+    monkeypatch.setattr("utils.db.set_state", AsyncMock())
+
+    cog = FailoverCog(_make_bot())
+    cog.bot.state.iembot_last_seqnum = 999
+    client = await _spin_up_cog_server(cog)
+    try:
+        await client.post(
+            "/sync",
+            headers={"Authorization": "Bearer secret"},
+            json={"iembot_last_seqnum": 5},
+        )
+    finally:
+        await client.close()
+
+    assert cog.bot.state.iembot_last_seqnum == 999
+
+
+# ── Upstash interactions (mocked ClientSession) ─────────────────────────────
+
+async def test_get_primary_url_success(monkeypatch):
+    """Upstash GET returns the tunnel URL; method passes it through."""
+    def _responder(method, url, kwargs):
+        # Upstash REST API: POST {cmd, args} returns {"result": ...}
+        return _FakeResponse(200, payload={"result": "https://tunnel.example"})
+
+    fake_session = _fake_session_factory(_responder)
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+    )
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    assert await cog._get_primary_url() == "https://tunnel.example"
+
+
+async def test_get_primary_url_returns_none_on_error(monkeypatch):
+    """Network exception → returns None (caller treats as missing)."""
+    def _responder(method, url, kwargs):
+        raise RuntimeError("network dead")
+
+    fake_session = _fake_session_factory(_responder)
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+    )
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    assert await cog._get_primary_url() is None
+
+
+async def test_write_url_to_upstash_issues_set_with_ttl(monkeypatch):
+    """Primary should publish its URL via `SET … EX HEARTBEAT_TTL`."""
+    captured = {}
+
+    def _responder(method, url, kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = kwargs.get("json")
+        return _FakeResponse(200)
+
+    fake_session = _fake_session_factory(_responder)
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+    )
+
+    cog = FailoverCog(_make_bot())
+    await cog._write_url_to_upstash("https://tunnel.example")
+
+    assert captured["method"] == "POST"
+    cmd = captured["json"]
+    assert cmd[0] == "SET"
+    assert cmd[1] == "spcbot:primary_url"
+    assert cmd[2] == "https://tunnel.example"
+    assert cmd[3] == "EX"
+    # TTL must match the module-level HEARTBEAT_TTL.
+    assert int(cmd[4]) == failover_module.HEARTBEAT_TTL
+
+
+async def test_upstash_seqnum_roundtrip(monkeypatch):
+    """`get_upstash_seqnum` parses int; `write_upstash_seqnum` sends SET."""
+    call_log = []
+
+    def _responder(method, url, kwargs):
+        cmd = kwargs.get("json")
+        call_log.append(cmd)
+        if cmd[0] == "GET":
+            return _FakeResponse(200, payload={"result": "123"})
+        return _FakeResponse(200)
+
+    fake_session = _fake_session_factory(_responder)
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+    )
+
+    cog = FailoverCog(_make_bot())
+    assert await cog.get_upstash_seqnum() == 123
+    await cog.write_upstash_seqnum(456)
+
+    # SET has no EX clause (seqnum is permanent state).
+    set_call = [c for c in call_log if c[0] == "SET"][0]
+    assert set_call[1] == "spcbot:last_seqnum"
+    assert set_call[2] == "456"
+    assert "EX" not in set_call
+
+
+async def test_upstash_seqnum_missing_returns_none(monkeypatch):
+    """Missing key → Upstash returns {"result": null} → caller sees None."""
+    def _responder(method, url, kwargs):
+        return _FakeResponse(200, payload={"result": None})
+
+    fake_session = _fake_session_factory(_responder)
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+    )
+
+    cog = FailoverCog(_make_bot())
+    assert await cog.get_upstash_seqnum() is None
+
+
+# ── _standby_cycle / _promote ───────────────────────────────────────────────
+
+async def test_standby_promotes_after_three_missing_primary(monkeypatch):
+    """Three cycles with no URL in Upstash → promote."""
+    monkeypatch.setattr(
+        FailoverCog, "_get_primary_url", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(FailoverCog, "_start_http_server", AsyncMock())
+    monkeypatch.setattr(FailoverCog, "_start_tunnel", AsyncMock())
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    for _ in range(3):
+        await cog._standby_cycle()
+
+    assert cog.bot.state.is_primary is True
+    # Promotion path loads every extension.
+    assert cog.bot.load_extension.call_count == len(failover_module.ALL_EXTENSIONS)
+
+
+async def test_standby_hydrates_when_primary_reachable(monkeypatch):
+    """Primary URL found, /state returns 200 with state payload → hydrate."""
+    monkeypatch.setattr(
+        FailoverCog,
+        "_get_primary_url",
+        AsyncMock(return_value="https://tunnel.example"),
+    )
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+
+    state_payload = {
+        "iembot_last_seqnum": 10,
+        "posted_mds": ["0001"],
+        "posted_watches": [],
+        "auto_cache": {},
+        "last_posted_urls": {},
+    }
+
+    def _responder(method, url, kwargs):
+        assert url == "https://tunnel.example/state"
+        return _FakeResponse(200, payload=state_payload)
+
+    fake_session = _fake_session_factory(_responder)
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+    )
+
+    # _persist_hydrated_state touches the real DB — stub it.
+    monkeypatch.setattr(
+        FailoverCog, "_persist_hydrated_state", AsyncMock()
+    )
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    # Seed prior failures so we can verify reset to 0.
+    cog._primary_failures = 2
+
+    await cog._standby_cycle()
+
+    assert cog.bot.state.iembot_last_seqnum == 10
+    assert "0001" in cog.bot.state.posted_mds
+    assert cog._primary_failures == 0
+
+
+async def test_standby_counts_failure_on_primary_5xx(monkeypatch):
+    """/state returns 500 → failure counter increments."""
+    monkeypatch.setattr(
+        FailoverCog,
+        "_get_primary_url",
+        AsyncMock(return_value="https://tunnel.example"),
+    )
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+
+    def _responder(method, url, kwargs):
+        return _FakeResponse(500, text="boom")
+
+    fake_session = _fake_session_factory(_responder)
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+    )
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    await cog._standby_cycle()
+    assert cog._primary_failures == 1
+    assert cog.bot.state.is_primary is False
+
+
+# ── _check_for_demotion / _demote ───────────────────────────────────────────
+
+async def test_check_for_demotion_triggers_when_new_primary_elsewhere(monkeypatch):
+    """Acting-primary sees a different URL in Upstash → demote."""
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._tunnel_url = "https://mine.example"
+
+    monkeypatch.setattr(
+        FailoverCog,
+        "_get_primary_url",
+        AsyncMock(return_value="https://someone-else.example"),
+    )
+    demoted = AsyncMock()
+    monkeypatch.setattr(FailoverCog, "_demote", demoted)
+
+    await cog._check_for_demotion()
+    demoted.assert_awaited_once_with("https://someone-else.example")
+
+
+async def test_check_for_demotion_no_op_when_url_matches(monkeypatch):
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._tunnel_url = "https://mine.example"
+
+    monkeypatch.setattr(
+        FailoverCog,
+        "_get_primary_url",
+        AsyncMock(return_value="https://mine.example"),
+    )
+    demoted = AsyncMock()
+    monkeypatch.setattr(FailoverCog, "_demote", demoted)
+
+    await cog._check_for_demotion()
+    demoted.assert_not_awaited()
+
+
+async def test_demote_pushes_state_and_flips_flag(monkeypatch):
+    """Demotion must POST /sync to the new primary and set
+    is_primary=False, then unload every extension."""
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog.bot.state.posted_mds.add("0042")
+
+    # Capture the POST payload sent to the new primary.
+    captured = {}
+    fake_http_session = MagicMock()
+
+    async def _post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        return _FakeResponse(200)
+
+    fake_http_session.post = _post
+    monkeypatch.setattr(
+        "utils.http.ensure_session",
+        AsyncMock(return_value=fake_http_session),
+    )
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+
+    await cog._demote("https://new-primary.example")
+
+    assert captured["url"] == "https://new-primary.example/sync"
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert "0042" in captured["json"]["posted_mds"]
+
+    assert cog.bot.state.is_primary is False
+    assert cog.bot.unload_extension.call_count == len(failover_module.ALL_EXTENSIONS)
+
+
+# ── Fail-fast token guard (PR #94) ──────────────────────────────────────────
+
+def test_require_failover_token_rejects_empty(monkeypatch):
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "")
+    with pytest.raises(RuntimeError, match="FAILOVER_TOKEN"):
+        failover_module._require_failover_token()
+
+
+def test_require_failover_token_rejects_default_placeholder(monkeypatch):
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "changeme")
+    with pytest.raises(RuntimeError, match="FAILOVER_TOKEN"):
+        failover_module._require_failover_token()
+
+
+def test_require_failover_token_accepts_real_value(monkeypatch):
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "real-secret-xyz")
+    assert failover_module._require_failover_token() == "real-secret-xyz"

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -14,10 +14,7 @@ The cloudflared subprocess lifecycle is out of scope — it requires a
 binary that CI doesn't have.
 """
 
-import asyncio
-import json
-from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web


### PR DESCRIPTION
## Summary
20 new tests covering the three I/O surfaces of the failover cog.

### 1. In-process /state + /sync (real aiohttp)
Spins up the actual `web.Application` the cog builds via `aiohttp.test_utils.TestServer` and fires real HTTP at the real handlers. Covers:
- 401 on missing and wrong bearer token for both routes.
- `/state` returns the full serialized `BotState`.
- `/sync` merges posted_mds, posted_watches, auto_cache, last_posted_urls.
- The `new_seq > stored_seq` guard in `/sync` actually prevents regression.

### 2. Upstash (mocked ClientSession)
- `_get_primary_url`: success returns URL; exception returns None.
- `_write_url_to_upstash`: sends `SET spcbot:primary_url <url> EX HEARTBEAT_TTL`.
- `get_upstash_seqnum` / `write_upstash_seqnum`: roundtrip + "missing key" path.

### 3. Promotion / demotion flow
- 3 consecutive missed heartbeats → `_promote`, which loads every extension.
- Primary reachable + 200 → hydrate and reset failure counter.
- Primary returns 5xx → failure counter increments, `is_primary` stays False.
- `_check_for_demotion`: calls `_demote` only when stored URL differs.
- `_demote`: POSTs state to `/sync`, flips `is_primary` to False, unloads every extension.

### 4. Fail-fast token guard (PR #94) explicit tests
Rejects empty, rejects `"changeme"`, accepts real value.

### Out of scope
`_start_tunnel` (cloudflared subprocess) — requires a binary CI doesn't have; needs a separate subprocess-injection harness.

## Test plan
- [x] `pytest tests/test_failover_coverage.py -v` — 20 passed
- [x] Full suite — 163 passed (was 143)
- [x] Coverage: `cogs/failover.py` 18% → 62%