### PR TITLE
refactor: split BotState into HashStore, PostingLog, TimingTracker

### DIFF
--- a/tests/test_state_split.py
+++ b/tests/test_state_split.py
@@ -1,0 +1,81 @@
+"""Tests for the BotState sub-store split.
+
+The split's load-bearing property is that the legacy attribute surface
+(`state.posted_mds`, `state.auto_cache`, …) keeps working AND returns
+the same underlying container the sub-store owns, so existing
+in-place mutations (`state.posted_mds.add(x)`, dict updates) still
+reach the intended storage.
+"""
+
+from utils.state import BotState, HashStore, PostingLog, TimingTracker
+
+
+def test_substores_are_present():
+    s = BotState()
+    assert isinstance(s.hashes, HashStore)
+    assert isinstance(s.posting, PostingLog)
+    assert isinstance(s.timing, TimingTracker)
+
+
+def test_legacy_attribute_is_same_object_as_substore_field():
+    """Mutating via the legacy attribute must reach the sub-store."""
+    s = BotState()
+    s.posted_mds.add("0100")
+    assert "0100" in s.posting.posted_mds
+
+    s.auto_cache["url"] = "hash"
+    assert s.hashes.auto_cache["url"] == "hash"
+
+    s.last_posted_urls["day1"] = ["u"]
+    assert s.timing.last_posted_urls["day1"] == ["u"]
+
+
+def test_legacy_assignment_replaces_substore_field():
+    """`state.posted_mds = new_set` must update the sub-store too."""
+    s = BotState()
+    new_set = {"A", "B"}
+    s.posted_mds = new_set
+    # The delegated setter replaced the field on the sub-store.
+    assert s.posting.posted_mds is new_set
+
+
+def test_substore_mutation_visible_via_legacy_attr():
+    """The reverse direction — mutate sub-store, read via legacy attr."""
+    s = BotState()
+    s.posting.posted_watches.add("0042")
+    assert "0042" in s.posted_watches
+
+
+def test_to_dict_output_shape_unchanged():
+    """Failover protocol depends on the exact keys to_dict emits."""
+    s = BotState()
+    s.iembot_last_seqnum = 7
+    s.posted_mds.add("0100")
+    s.auto_cache["u"] = "h"
+
+    d = s.to_dict()
+    expected_keys = {
+        "iembot_last_seqnum",
+        "auto_cache",
+        "manual_cache",
+        "posted_mds",
+        "posted_watches",
+        "csu_posted",
+        "active_watches",
+        "last_posted_urls",
+        "last_post_times",
+    }
+    assert set(d.keys()) == expected_keys
+    assert d["iembot_last_seqnum"] == 7
+    assert "0100" in d["posted_mds"]
+    assert d["auto_cache"] == {"u": "h"}
+
+
+def test_substores_are_independent():
+    """Separate BotState instances must not share sub-store state."""
+    a = BotState()
+    b = BotState()
+    a.posted_mds.add("X")
+    assert "X" not in b.posted_mds
+    a.auto_cache["k"] = "v"
+    assert "k" not in b.auto_cache

--- a/utils/state.py
+++ b/utils/state.py
@@ -1,33 +1,67 @@
 # utils/state.py
 """
-BotState — single source of truth for all in-memory bot state.
-Attached to the bot instance as bot.state at startup.
+BotState — in-memory state for the bot, attached to the bot instance
+as `bot.state` at startup.
+
+Composition
+-----------
+BotState is a thin coordinator over three focused sub-stores:
+
+  HashStore     — image-hash caches used for content-change detection.
+  PostingLog    — which MDs / watches / CSU days we've already posted,
+                  plus the currently-active set (as returned by the NWS
+                  feed).
+  TimingTracker — when each category was last posted, and the URLs we
+                  published for each outlook day.
+
+BotState still exposes the legacy attribute names (`posted_mds`,
+`auto_cache`, `last_post_times`, …) as properties so every existing
+call site keeps working unchanged. The sub-store references are also
+exposed directly (`state.hashes`, `state.posting`, `state.timing`) so
+new code can take an explicit dependency on the component it needs
+rather than on the whole coordinator.
 """
 
 from datetime import datetime
 from typing import Dict, List, Optional, Set
 
 
+class HashStore:
+    """Image-hash caches and partial-update state."""
 
-class BotState:
-    """Encapsulates all mutable in-memory state for the bot."""
+    __slots__ = ("auto_cache", "manual_cache", "partial_update_state")
 
     def __init__(self):
-        self.is_primary: bool = True  # overridden by IS_PRIMARY env var in main.py
-        self.iembot_last_seqnum: int = 0
-        # ── Image hash caches ─────────────────────────────────────────────
         self.auto_cache: Dict[str, str] = {}
         self.manual_cache: Dict[str, str] = {}
         self.partial_update_state: Dict[str, Dict] = {}
 
-        # ── SPC watch/MD tracking ─────────────────────────────────────────
+
+class PostingLog:
+    """Deduplication log for SPC posts and the currently-active alerts."""
+
+    __slots__ = (
+        "posted_mds",
+        "posted_watches",
+        "csu_posted",
+        "active_mds",
+        "active_watches",
+    )
+
+    def __init__(self):
         self.posted_mds: Set[str] = set()
         self.posted_watches: Set[str] = set()
-        self.csu_posted: Set[str] = set()  # Tracked daily
+        self.csu_posted: Set[str] = set()
         self.active_mds: Set[str] = set()
         self.active_watches: Dict[str, dict] = {}
 
-        # ── Post timing ───────────────────────────────────────────────────
+
+class TimingTracker:
+    """Per-category last-posted timestamps and URL payloads."""
+
+    __slots__ = ("last_post_times", "last_posted_urls")
+
+    def __init__(self):
         self.last_post_times: Dict[str, Optional[datetime]] = {
             "day1": None, "day2": None, "day3": None,
             "day48": None, "scp": None, "md": None, "watch": None,
@@ -39,8 +73,58 @@ class BotState:
         }
         self.last_posted_urls: Dict[str, List[str]] = {}
 
+
+def _delegate(store_attr: str, field: str) -> property:
+    """Build a read/write property that forwards to a sub-store field.
+
+    Reading returns the underlying container by reference, so existing
+    callers doing `state.posted_mds.add(x)` keep mutating the same set
+    the sub-store owns. Writing replaces the field on the sub-store.
+    """
+
+    def _get(self):
+        return getattr(getattr(self, store_attr), field)
+
+    def _set(self, value):
+        setattr(getattr(self, store_attr), field, value)
+
+    return property(_get, _set)
+
+
+class BotState:
+    """Top-level mutable state for the bot.
+
+    Scalar flags (`is_primary`, `iembot_last_seqnum`) live here directly
+    because they don't belong to any sub-store. Everything else is
+    delegated to `hashes`, `posting`, or `timing`.
+    """
+
+    def __init__(self):
+        self.is_primary: bool = True  # overridden by IS_PRIMARY env var in main.py
+        self.iembot_last_seqnum: int = 0
+
+        self.hashes = HashStore()
+        self.posting = PostingLog()
+        self.timing = TimingTracker()
+
+    # ── Legacy attribute surface (delegated) ────────────────────────────────
+    auto_cache = _delegate("hashes", "auto_cache")
+    manual_cache = _delegate("hashes", "manual_cache")
+    partial_update_state = _delegate("hashes", "partial_update_state")
+
+    posted_mds = _delegate("posting", "posted_mds")
+    posted_watches = _delegate("posting", "posted_watches")
+    csu_posted = _delegate("posting", "csu_posted")
+    active_mds = _delegate("posting", "active_mds")
+    active_watches = _delegate("posting", "active_watches")
+
+    last_post_times = _delegate("timing", "last_post_times")
+    last_posted_urls = _delegate("timing", "last_posted_urls")
+
+    # ── Serialization ───────────────────────────────────────────────────────
     def to_dict(self) -> dict:
-        """Serialize state to a JSON-safe dict (for failover endpoint)."""
+        """Serialize state to a JSON-safe dict (for the failover /state
+        endpoint). Shape is stable — the failover protocol depends on it."""
         return {
             "iembot_last_seqnum": self.iembot_last_seqnum,
             "auto_cache": self.auto_cache,


### PR DESCRIPTION
## Summary
`BotState` had accumulated three unrelated concerns in one class:
- Image-hash caches (change detection).
- Deduplication logs for posted MDs / watches / CSU days.
- Per-category timing data.

Split into three `__slots__` containers, each holding the fields that actually go together:

| sub-store | owns |
|---|---|
| `HashStore` | `auto_cache`, `manual_cache`, `partial_update_state` |
| `PostingLog` | `posted_mds`, `posted_watches`, `csu_posted`, `active_mds`, `active_watches` |
| `TimingTracker` | `last_post_times`, `last_posted_urls` |

`BotState` now composes them as `state.hashes`, `state.posting`, `state.timing`. Scalars (`is_primary`, `iembot_last_seqnum`) stay on `BotState` directly.

### Backwards compatibility
Every legacy attribute name (`state.posted_mds`, `state.auto_cache`, …) is preserved via a delegating `property`:
- **Getter** returns the container *by reference*, so `state.posted_mds.add(x)` and `state.auto_cache[url] = h` keep reaching the sub-store's storage.
- **Setter** writes the new value back to the sub-store's field, covering the handful of call sites that do full-attribute assignment.

No cog or test required a call-site change — all 163 pre-existing tests pass untouched.

### Protocol stability
`to_dict()` key set and shape are identical — the failover `/state` protocol is byte-compatible.

### New tests (6)
`tests/test_state_split.py` pins the critical invariants:
- Sub-stores present and correctly typed.
- Legacy attribute is the same object as the sub-store field.
- Assignment via legacy attr replaces the sub-store's field.
- Sub-store mutation is visible via the legacy attribute.
- `to_dict()` emits the stable key set.
- Independent `BotState` instances don't share sub-store state.

## Test plan
- [x] `pytest -q` — 169 passed (163 existing + 6 new)
- [x] `python -c "import main"` with stub env — import ok
- [x] Ruff clean (F401 included)