### PR TITLE
fix(failover): close promotion races that nearly caused split-brain

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -18,6 +18,7 @@ Standby (3CAPE):
 import asyncio
 import logging
 import os
+import time
 from datetime import datetime, timezone
 
 import aiohttp
@@ -44,6 +45,18 @@ def _require_failover_token() -> str:
 HEARTBEAT_TTL = 420  # 7 minutes
 SYNC_INTERVAL = 30   # seconds
 
+# Grace period on standby boot during which sync-loop failures are NOT counted
+# toward promotion. Covers the common case of deploying the standby before
+# the primary has finished its own restart.
+STARTUP_GRACE_SECONDS = 120
+
+# Tolerate up to half the heartbeat TTL of consecutive failures before
+# promoting. Derived so the threshold scales with HEARTBEAT_TTL instead of
+# being a bare magic number — the old value (3) meant 90 s of unreachability
+# triggered promotion, which is shorter than a normal primary redeploy with
+# tunnel bring-up.
+MAX_FAILURES = max(5, HEARTBEAT_TTL // (2 * SYNC_INTERVAL))
+
 UPSTASH_HEADERS = {"Authorization": f"Bearer {UPSTASH_TOKEN}"}
 
 from cogs import ALL_EXTENSIONS
@@ -56,18 +69,63 @@ class FailoverCog(commands.Cog):
         self._tunnel_proc = None
         self._tunnel_url = None
         self._primary_failures = 0
-        self._max_failures = 3
+        self._max_failures = MAX_FAILURES
         self._ready = False
+        # The URL the standby was trying to reach last cycle. Used to detect
+        # that the primary published a *new* tunnel URL, which is a recovery
+        # signal and must reset the failure counter — otherwise failures
+        # against an old, dead URL accumulate against the new primary.
+        self._last_seen_primary_url: str | None = None
+        # Boot time for the startup grace period. During the first
+        # STARTUP_GRACE_SECONDS after cog_load, sync-loop failures are
+        # logged but do not count toward promotion.
+        self._cog_load_monotonic: float | None = None
 
     async def cog_load(self):
         # Both primary (serves /state, /sync) and standby (calls them) must
         # share a real token. Fail fast at cog load so misconfiguration is
         # obvious at startup rather than surfacing as silent 401s later.
         _require_failover_token()
+        self._cog_load_monotonic = time.monotonic()
         if self.bot.state.is_primary:
             await self._start_http_server()
             await self._start_tunnel()
         self.sync_loop.start()
+
+    def _in_startup_grace(self) -> bool:
+        """True for the first STARTUP_GRACE_SECONDS after cog_load.
+
+        While the grace window is open, the sync loop still runs and will
+        happily hydrate from the primary if it's reachable — but failures
+        do not advance `_primary_failures`. This exists because when you
+        deploy both machines, the standby usually boots before the
+        primary has finished its tunnel bring-up, and the failing cycles
+        during that window are artifacts of the deploy, not evidence of
+        a real outage.
+        """
+        if self._cog_load_monotonic is None:
+            return False
+        return (time.monotonic() - self._cog_load_monotonic) < STARTUP_GRACE_SECONDS
+
+    def _register_failure(self, reason: str) -> int:
+        """Increment the failure counter unless we're in the startup
+        grace window. Returns the post-increment count (0 during grace).
+
+        `reason` is logged so operators can see what was wrong, independent
+        of whether the counter advanced.
+        """
+        if self._in_startup_grace():
+            logger.info(
+                f"[FAILOVER] {reason} — in startup grace "
+                f"({STARTUP_GRACE_SECONDS}s), not counting toward promotion"
+            )
+            return 0
+        self._primary_failures += 1
+        logger.warning(
+            f"[FAILOVER] {reason} "
+            f"(failure {self._primary_failures}/{self._max_failures})"
+        )
+        return self._primary_failures
 
     async def cog_unload(self):
         self.sync_loop.cancel()
@@ -206,10 +264,24 @@ class FailoverCog(commands.Cog):
 
     async def _standby_cycle(self):
         primary_url = await self._get_primary_url()
+
+        # Recovery signal: if Upstash now hands us a URL that differs from
+        # the one we were trying last cycle, the primary has republished —
+        # any accumulated failures were against a stale URL and should not
+        # count against the new primary. Reset before doing anything else.
+        if primary_url and primary_url != self._last_seen_primary_url:
+            if self._primary_failures > 0:
+                logger.info(
+                    f"[FAILOVER] Primary URL changed "
+                    f"({self._last_seen_primary_url!r} → {primary_url!r}); "
+                    f"resetting {self._primary_failures} accumulated failures"
+                )
+            self._primary_failures = 0
+            self._last_seen_primary_url = primary_url
+
         if not primary_url:
-            self._primary_failures += 1
-            logger.warning(f"[FAILOVER] Primary URL missing from Upstash (failure {self._primary_failures}/{self._max_failures})")
-            if self._primary_failures >= self._max_failures:
+            count = self._register_failure("Primary URL missing from Upstash")
+            if count >= self._max_failures:
                 await self._promote()
             return
 
@@ -228,14 +300,14 @@ class FailoverCog(commands.Cog):
                         logger.debug("[FAILOVER] Hydrated state from primary")
                         await self._persist_hydrated_state()
                     else:
-                        self._primary_failures += 1
-                        logger.warning(f"[FAILOVER] Primary /state returned {resp.status} (failure {self._primary_failures}/{self._max_failures})")
-                        if self._primary_failures >= self._max_failures:
+                        count = self._register_failure(
+                            f"Primary /state returned {resp.status}"
+                        )
+                        if count >= self._max_failures:
                             await self._promote()
         except Exception as e:
-            self._primary_failures += 1
-            logger.warning(f"[FAILOVER] Cannot reach primary: {e} (failure {self._primary_failures}/{self._max_failures})")
-            if self._primary_failures >= self._max_failures:
+            count = self._register_failure(f"Cannot reach primary: {e}")
+            if count >= self._max_failures:
                 await self._promote()
 
     async def _get_primary_url(self) -> str | None:

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -309,8 +309,12 @@ async def test_upstash_seqnum_missing_returns_none(monkeypatch):
 
 # ── _standby_cycle / _promote ───────────────────────────────────────────────
 
-async def test_standby_promotes_after_three_missing_primary(monkeypatch):
-    """Three cycles with no URL in Upstash → promote."""
+async def test_standby_promotes_after_max_failures_missing_primary(monkeypatch):
+    """MAX_FAILURES consecutive cycles with no URL in Upstash → promote.
+
+    The threshold is derived from HEARTBEAT_TTL so the test reads it back
+    from the module rather than hardcoding a count.
+    """
     monkeypatch.setattr(
         FailoverCog, "_get_primary_url", AsyncMock(return_value=None)
     )
@@ -318,12 +322,109 @@ async def test_standby_promotes_after_three_missing_primary(monkeypatch):
     monkeypatch.setattr(FailoverCog, "_start_tunnel", AsyncMock())
 
     cog = FailoverCog(_make_bot(is_primary=False))
-    for _ in range(3):
+    for _ in range(failover_module.MAX_FAILURES):
         await cog._standby_cycle()
 
     assert cog.bot.state.is_primary is True
-    # Promotion path loads every extension.
     assert cog.bot.load_extension.call_count == len(failover_module.ALL_EXTENSIONS)
+
+
+async def test_standby_does_not_promote_before_max_failures(monkeypatch):
+    """One short of the threshold: must stay in standby."""
+    monkeypatch.setattr(
+        FailoverCog, "_get_primary_url", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(FailoverCog, "_start_http_server", AsyncMock())
+    monkeypatch.setattr(FailoverCog, "_start_tunnel", AsyncMock())
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    for _ in range(failover_module.MAX_FAILURES - 1):
+        await cog._standby_cycle()
+
+    assert cog.bot.state.is_primary is False
+    cog.bot.load_extension.assert_not_called()
+
+
+async def test_standby_startup_grace_does_not_count_failures(monkeypatch):
+    """Failures during the startup grace window are logged but must NOT
+    advance the counter. Covers the "standby deployed before primary"
+    race that caused the near-miss in prod."""
+    import time as _time
+
+    monkeypatch.setattr(
+        FailoverCog, "_get_primary_url", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(FailoverCog, "_start_http_server", AsyncMock())
+    monkeypatch.setattr(FailoverCog, "_start_tunnel", AsyncMock())
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    # Simulate cog_load having just been called.
+    cog._cog_load_monotonic = _time.monotonic()
+
+    for _ in range(failover_module.MAX_FAILURES + 3):
+        await cog._standby_cycle()
+
+    assert cog._primary_failures == 0
+    assert cog.bot.state.is_primary is False
+
+
+async def test_standby_promotes_after_grace_expires(monkeypatch):
+    """After the grace window closes, failures count normally again."""
+    monkeypatch.setattr(
+        FailoverCog, "_get_primary_url", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(FailoverCog, "_start_http_server", AsyncMock())
+    monkeypatch.setattr(FailoverCog, "_start_tunnel", AsyncMock())
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    # Pretend cog_load ran well before the grace window — already expired.
+    cog._cog_load_monotonic = 0.0
+
+    for _ in range(failover_module.MAX_FAILURES):
+        await cog._standby_cycle()
+
+    assert cog.bot.state.is_primary is True
+
+
+async def test_standby_resets_failures_on_new_primary_url(monkeypatch):
+    """When Upstash returns a URL that differs from the last one we were
+    trying, the failure counter must reset — a new tunnel means the
+    primary has republished itself, so prior failures were against a
+    stale URL.
+    """
+    # Script: first 2 calls to Upstash return the OLD URL, then the NEW URL.
+    urls = iter([
+        "https://old.example",
+        "https://old.example",
+        "https://new.example",   # primary republished
+        "https://new.example",
+    ])
+
+    async def _next_url(self_):
+        return next(urls)
+
+    monkeypatch.setattr(FailoverCog, "_get_primary_url", _next_url)
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+
+    # /state always errors — doesn't matter; we're watching the counter.
+    def _responder(method, url, kwargs):
+        raise RuntimeError("tunnel unreachable")
+
+    fake_session = _fake_session_factory(_responder)
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+    )
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    cog._cog_load_monotonic = 0.0  # past grace
+
+    await cog._standby_cycle()  # old URL, failure #1
+    await cog._standby_cycle()  # old URL, failure #2
+    assert cog._primary_failures == 2
+
+    await cog._standby_cycle()  # NEW URL → reset, then try+fail → failure #1
+    assert cog._primary_failures == 1
+    assert cog._last_seen_primary_url == "https://new.example"
 
 
 async def test_standby_hydrates_when_primary_reachable(monkeypatch):


### PR DESCRIPTION
## Context
Deploying both machines back-to-back almost triggered a standby promotion while the primary was restarting. Timeline from the logs: standby accumulated `_primary_failures=2` against the old (dead) tunnel URL, primary redeployed and published a new URL, standby's next cycle was ~6 seconds from failure #3 → `_promote()`. Pure luck.

## Three compounding bugs

1. **Counter persisted across tunnel-URL changes.** Failures against a dead URL still counted when the primary published a new one. Fix: when Upstash hands us a URL different from `_last_seen_primary_url`, reset `_primary_failures` — a new URL is a recovery signal.

2. **No startup grace period.** Standby began counting failures on its first sync cycle, 5s after boot. If standby booted before primary had finished its own restart, those failures burned toward promotion despite being deploy artifacts. Fix: `STARTUP_GRACE_SECONDS = 120`; during that window failures are logged but the counter is frozen at 0. Centralized via a new `_register_failure(reason)` helper.

3. **Threshold too aggressive.** `3 × 30s = 90s` of unreachability is shorter than a normal redeploy with tunnel bring-up. Fix: derive from `HEARTBEAT_TTL` — `MAX_FAILURES = max(5, HEARTBEAT_TTL // (2 * SYNC_INTERVAL))`. At current TTL that yields 7 failures (~210s = half the heartbeat TTL).

## Test plan
- [x] `pytest -q` — 173 passed (was 169 + 4 new)
- New/updated failover tests:
  - `test_standby_promotes_after_max_failures_missing_primary` — reads threshold from module, replaces hard-coded-3 test
  - `test_standby_does_not_promote_before_max_failures` — off-by-one boundary
  - `test_standby_startup_grace_does_not_count_failures` — grace window invariant
  - `test_standby_promotes_after_grace_expires` — grace does expire
  - `test_standby_resets_failures_on_new_primary_url` — new-URL recovery signal

## Tunables (for reference)
```
HEARTBEAT_TTL=420s  SYNC_INTERVAL=30s  MAX_FAILURES=7 (~210s)  STARTUP_GRACE=120s
```