### PR TITLE
fix(failover): separate primary liveness from hydration reachability

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -263,12 +263,31 @@ class FailoverCog(commands.Cog):
             logger.error(f"[FAILOVER] Sync loop error: {e}")
 
     async def _standby_cycle(self):
+        """Standby's sync-loop body.
+
+        Promotion uses two *independent* signals and only the first one
+        can advance `_primary_failures`:
+
+          1. **Primary liveness** — does Upstash still have the
+             primary's URL?  The primary refreshes this key every
+             SYNC_INTERVAL with EX HEARTBEAT_TTL, so the key's
+             presence *is* a heartbeat. If the key is missing, the
+             primary has stopped refreshing for at least HEARTBEAT_TTL
+             seconds; only *that* is evidence the primary is dead.
+
+          2. **Hydration reachability** — can this host reach the
+             primary's tunnel right now?  A failure here could be
+             standby-side (DNS, local network, Cloudflare edge in my
+             region) and says nothing about whether the primary is
+             alive. It must NOT advance the failure counter — doing so
+             was the bug that caused a false promotion attempt when
+             the standby couldn't resolve trycloudflare.com while the
+             primary was fine.
+        """
         primary_url = await self._get_primary_url()
 
-        # Recovery signal: if Upstash now hands us a URL that differs from
-        # the one we were trying last cycle, the primary has republished —
-        # any accumulated failures were against a stale URL and should not
-        # count against the new primary. Reset before doing anything else.
+        # Recovery signal: new tunnel URL ⇒ any accumulated failures
+        # were against a stale URL, wipe the slate.
         if primary_url and primary_url != self._last_seen_primary_url:
             if self._primary_failures > 0:
                 logger.info(
@@ -279,13 +298,26 @@ class FailoverCog(commands.Cog):
             self._primary_failures = 0
             self._last_seen_primary_url = primary_url
 
+        # Signal 1: primary liveness.
         if not primary_url:
-            count = self._register_failure("Primary URL missing from Upstash")
+            count = self._register_failure(
+                "Primary heartbeat expired in Upstash"
+            )
             if count >= self._max_failures:
                 await self._promote()
             return
 
-        # Try to reach primary
+        # Primary is alive (heartbeat is fresh by definition of the
+        # Upstash TTL). Any failures below are hydration problems, not
+        # evidence of primary death. Clear the failure counter.
+        if self._primary_failures > 0:
+            logger.info(
+                f"[FAILOVER] Primary heartbeat fresh; clearing "
+                f"{self._primary_failures} hydration failures"
+            )
+            self._primary_failures = 0
+
+        # Signal 2: hydration. Best-effort — does not advance promotion.
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(
@@ -296,19 +328,20 @@ class FailoverCog(commands.Cog):
                     if resp.status == 200:
                         data = await resp.json()
                         self._hydrate(data)
-                        self._primary_failures = 0
                         logger.debug("[FAILOVER] Hydrated state from primary")
                         await self._persist_hydrated_state()
                     else:
-                        count = self._register_failure(
-                            f"Primary /state returned {resp.status}"
+                        logger.warning(
+                            f"[FAILOVER] Cannot hydrate: /state returned "
+                            f"{resp.status} — primary heartbeat still fresh, "
+                            f"not counting toward promotion"
                         )
-                        if count >= self._max_failures:
-                            await self._promote()
         except Exception as e:
-            count = self._register_failure(f"Cannot reach primary: {e}")
-            if count >= self._max_failures:
-                await self._promote()
+            logger.warning(
+                f"[FAILOVER] Cannot hydrate from primary: {e} — "
+                f"primary heartbeat still fresh, not counting toward "
+                f"promotion"
+            )
 
     async def _get_primary_url(self) -> str | None:
         try:

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -386,17 +386,14 @@ async def test_standby_promotes_after_grace_expires(monkeypatch):
     assert cog.bot.state.is_primary is True
 
 
-async def test_standby_resets_failures_on_new_primary_url(monkeypatch):
-    """When Upstash returns a URL that differs from the last one we were
-    trying, the failure counter must reset — a new tunnel means the
-    primary has republished itself, so prior failures were against a
-    stale URL.
+async def test_standby_tracks_last_seen_primary_url(monkeypatch):
+    """Verifies `_last_seen_primary_url` is kept in sync with Upstash —
+    the actual counter-reset behaviour on URL change is exercised by
+    `test_standby_clears_prior_failures_when_heartbeat_returns` via
+    the None → present transition.
     """
-    # Script: first 2 calls to Upstash return the OLD URL, then the NEW URL.
     urls = iter([
         "https://old.example",
-        "https://old.example",
-        "https://new.example",   # primary republished
         "https://new.example",
     ])
 
@@ -406,24 +403,21 @@ async def test_standby_resets_failures_on_new_primary_url(monkeypatch):
     monkeypatch.setattr(FailoverCog, "_get_primary_url", _next_url)
     monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
 
-    # /state always errors — doesn't matter; we're watching the counter.
-    def _responder(method, url, kwargs):
-        raise RuntimeError("tunnel unreachable")
+    # Hydration is irrelevant to this test — make it a no-op 200.
+    def _ok(method, url, kwargs):
+        return _FakeResponse(200, payload={})
 
-    fake_session = _fake_session_factory(_responder)
     monkeypatch.setattr(
-        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+        "cogs.failover.aiohttp.ClientSession",
+        lambda: _fake_session_factory(_ok),
     )
 
     cog = FailoverCog(_make_bot(is_primary=False))
-    cog._cog_load_monotonic = 0.0  # past grace
+    cog._cog_load_monotonic = 0.0
 
-    await cog._standby_cycle()  # old URL, failure #1
-    await cog._standby_cycle()  # old URL, failure #2
-    assert cog._primary_failures == 2
-
-    await cog._standby_cycle()  # NEW URL → reset, then try+fail → failure #1
-    assert cog._primary_failures == 1
+    await cog._standby_cycle()
+    assert cog._last_seen_primary_url == "https://old.example"
+    await cog._standby_cycle()
     assert cog._last_seen_primary_url == "https://new.example"
 
 
@@ -469,8 +463,15 @@ async def test_standby_hydrates_when_primary_reachable(monkeypatch):
     assert cog._primary_failures == 0
 
 
-async def test_standby_counts_failure_on_primary_5xx(monkeypatch):
-    """/state returns 500 → failure counter increments."""
+async def test_standby_hydration_failure_does_not_count_when_heartbeat_fresh(monkeypatch):
+    """If Upstash still has the primary URL (primary heartbeat fresh)
+    but /state is unreachable, this is a hydration problem, not a
+    primary-death signal. Must NOT advance `_primary_failures`.
+
+    This is the fix for the false-promotion race that fired in prod
+    when the standby could not resolve the trycloudflare.com tunnel
+    hostname while the primary was fully healthy.
+    """
     monkeypatch.setattr(
         FailoverCog,
         "_get_primary_url",
@@ -478,18 +479,68 @@ async def test_standby_counts_failure_on_primary_5xx(monkeypatch):
     )
     monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
 
-    def _responder(method, url, kwargs):
+    def _500(method, url, kwargs):
         return _FakeResponse(500, text="boom")
 
-    fake_session = _fake_session_factory(_responder)
+    def _raise(method, url, kwargs):
+        raise RuntimeError("Name or service not known")
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    cog._cog_load_monotonic = 0.0  # past startup grace
+
+    # 5xx response: heartbeat is fresh → no counter advance.
     monkeypatch.setattr(
-        "cogs.failover.aiohttp.ClientSession", lambda: fake_session
+        "cogs.failover.aiohttp.ClientSession",
+        lambda: _fake_session_factory(_500),
+    )
+    for _ in range(failover_module.MAX_FAILURES + 3):
+        await cog._standby_cycle()
+    assert cog._primary_failures == 0
+    assert cog.bot.state.is_primary is False
+
+    # Connection exception: still fresh → still no counter advance.
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession",
+        lambda: _fake_session_factory(_raise),
+    )
+    for _ in range(failover_module.MAX_FAILURES + 3):
+        await cog._standby_cycle()
+    assert cog._primary_failures == 0
+    assert cog.bot.state.is_primary is False
+
+
+async def test_standby_clears_prior_failures_when_heartbeat_returns(monkeypatch):
+    """After the key goes missing (counter climbs) and then returns
+    (primary recovered, republished), the counter must reset even if
+    hydration keeps failing afterwards."""
+    states = iter([None, None, "https://tunnel.example", "https://tunnel.example"])
+
+    async def _next_url(self_):
+        return next(states)
+
+    monkeypatch.setattr(FailoverCog, "_get_primary_url", _next_url)
+    monkeypatch.setattr(failover_module, "FAILOVER_TOKEN", "secret")
+
+    # Hydration always errors — exercises the "heartbeat fresh but
+    # hydration dead" path that used to mistakenly increment.
+    monkeypatch.setattr(
+        "cogs.failover.aiohttp.ClientSession",
+        lambda: _fake_session_factory(
+            lambda m, u, k: (_ for _ in ()).throw(RuntimeError("x"))
+        ),
     )
 
     cog = FailoverCog(_make_bot(is_primary=False))
-    await cog._standby_cycle()
-    assert cog._primary_failures == 1
-    assert cog.bot.state.is_primary is False
+    cog._cog_load_monotonic = 0.0
+
+    await cog._standby_cycle()  # None: liveness fail #1
+    await cog._standby_cycle()  # None: liveness fail #2
+    assert cog._primary_failures == 2
+
+    await cog._standby_cycle()  # URL returns → counter cleared
+    assert cog._primary_failures == 0
+    await cog._standby_cycle()  # URL present, hydration still failing → still 0
+    assert cog._primary_failures == 0
 
 
 # ── _check_for_demotion / _demote ───────────────────────────────────────────


### PR DESCRIPTION
## Urgent fix
Standby was ~90 s from falsely promoting while the primary was fully healthy, because it could not resolve the `*.trycloudflare.com` tunnel hostname (DNS issue on the standby network). The code was counting hydration failures toward promotion even though Upstash showed the primary's heartbeat was fresh.

## The change
Two independent signals, only one advances the promotion counter:
- **Primary liveness** = Upstash key present with fresh TTL. Missing = ≥ `HEARTBEAT_TTL` since last refresh = real outage.
- **Hydration reachability** = can I fetch `/state`? Failure could be standby-side. Logged as WARNING but does not count.

A fresh heartbeat also clears any prior liveness failures — previously accumulated counter state is wiped the moment the primary republishes.

## Test plan
- [x] `pytest -q` — 174 passed
- New tests:
  - `test_standby_hydration_failure_does_not_count_when_heartbeat_fresh` — loops past `MAX_FAILURES` with 5xx and connection-exception hydration failures, counter stays at 0.
  - `test_standby_clears_prior_failures_when_heartbeat_returns` — models the exact prod scenario.