### PR TITLE
docs: update README, CONTRIBUTING, .env.example for v5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,15 @@ GUILD_ID=your_guild_id
 # MANUAL_CACHE_FILE=posted_records.json
 # AUTO_CACHE_FILE=auto_posted_records.json
 
-# Upstash Redis (for failover coordination)
+# Upstash Redis — shared state + leader election (required, see CONTRIBUTING.md)
 UPSTASH_REDIS_REST_URL=https://your-upstash-url.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your-upstash-token
 
 # Failover
+# Set IS_PRIMARY=true on one box, false on the other. The bot picks up
+# leader-election duty from the Upstash lease regardless; this flag only
+# controls initial cog loading so the standby starts with no cogs running.
 IS_PRIMARY=true
+# Shared secret between primary and standby. Must be a non-empty, non-default
+# value — the cog refuses to start if it's empty or "changeme".
 FAILOVER_TOKEN=your-shared-secret-here
-STATE_PORT=8765

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ scraping the SPC watch index HTML directly.
 
 ### IEMBot Real-Time Feed
 
-`IEMBotCog` polls `weather.im/iembot-json/room/spcchat` every 15 seconds. When a new SEL (watch) or SWOMCD (MD) product appears, the full text is fetched from `mesonet.agron.iastate.edu/api/1/nwstext/{product_id}` and cached in the SQLite database (`product_text_cache`) with a 10-minute TTL. `fetch_watch_details` and `fetch_md_details` check this persistent cache first, ensuring embeds are populated within seconds of issuance even across bot restarts or failovers. The last-seen seqnum is also persisted to SQLite.
+`IEMBotCog` polls `weather.im/iembot-json/room/spcchat` every 15 seconds. When a new SEL (watch) or SWOMCD (MD) product appears, the full text is fetched from `mesonet.agron.iastate.edu/api/1/nwstext/{product_id}` and cached via `state_store.set_product_cache` with a 10-minute TTL (written to both Upstash and SQLite). `fetch_watch_details` and `fetch_md_details` check the cache first, so embeds are populated within seconds of issuance — and the Upstash copy means a fresh primary after a failover already has the text. The last-seen seqnum is persisted via `state_store.set_state("iembot_last_seqnum", …)` through the same double-write path.
 
 ### SCP Graphics
 
@@ -131,7 +131,7 @@ The `/sounding` command geocodes the location, finds nearby RAOB stations that h
 
 ### CSU-MLP and NCAR WxNext2
 
-Both poll once daily around model update time. State is persisted to the SQLite database so restarts don't cause duplicate posts.
+Both poll once daily around model update time. State is persisted via `state_store` (Upstash + SQLite) so restarts and failovers don't cause duplicate posts.
 
 ---
 
@@ -154,40 +154,112 @@ Tasks are registered with the watchdog in `main.py` after cogs load.
 
 ---
 
-## Persistence
+## Persistence (v5+)
 
-All persistent state lives in a single SQLite database at `CACHE_DIR/bot_state.db`, managed by `utils/db.py` using `aiosqlite`. The database uses WAL mode and a 5-second busy timeout for safe concurrent access.
+Bot state lives in **Upstash Redis** as the source of truth, with a local SQLite database as a durable mirror for outage survival. Everything in the codebase goes through `utils/state_store.py`, which is a drop-in replacement for the historical `utils/db.py` interface.
 
-| Table | Contents |
-|---|---|
-| `image_hashes` | URL → hash mapping for change detection (replaces JSON hash caches) |
-| `posted_mds` | Set of posted MD numbers (pruned to last 200) |
-| `posted_watches` | Set of posted watch numbers (pruned to last 200) |
-| `bot_state` | Key/value store for CSU-MLP, NCAR, and sounding preferences |
-| `product_text_cache` | Fast-path text products (watch/MD) with TTL for cross-instance sync |
+### Data flow
 
-On first startup, existing JSON files are automatically migrated into the database. The in-memory dicts (`auto_cache`, `manual_cache`, `posted_mds`, `posted_watches`) are kept as a fast lookup layer — the database is the persistence layer only.
+```
+    cogs → state_store → in-process cache (60 s TTL)
+                          │
+                          ├─→ Upstash Redis (authoritative)
+                          └─→ SQLite mirror (utils/db.py)
+```
 
-If the database fails an integrity check on startup, it is renamed to `bot_state.db.corrupted` and recreated from scratch.
+- **Read**: cache hit → return. Miss → Upstash → populate cache. Upstash unavailable → fall back to SQLite.
+- **Write**: update cache immediately, then double-write to SQLite (durability guarantee) and Upstash (best-effort). An Upstash failure enqueues the write on a dirty list; a background reconciler retries every 30 s until it lands.
+- **Startup resync**: on promotion (and optionally on boot) the node pushes anything SQLite has that Upstash is missing. Handles the "Upstash was down when we wrote, then we restarted" edge case.
+
+### Upstash key schema
+
+All keys are prefixed with `spcbot:` and are centralized in `utils/state_store.py` `_k_*` helpers.
+
+| Key | Type | Contents |
+|---|---|---|
+| `spcbot:hashes_index:auto` | HASH | URL → image hash (auto-posted graphics) |
+| `spcbot:hashes_index:manual` | HASH | URL → image hash (manual slash-command results) |
+| `spcbot:posted_mds` | SET | Posted MD numbers |
+| `spcbot:posted_watches` | SET | Posted watch numbers |
+| `spcbot:state:<key>` | STRING | KV store (e.g. `iembot_last_seqnum`, `csu_mlp_posted`, sounding prefs) |
+| `spcbot:posted_urls:<day>` | STRING | JSON-encoded list of posted URLs for that outlook day |
+| `spcbot:product_cache:<id>` | STRING (EX) | Watch/MD text bodies with TTL |
+| `spcbot:primary_url` | STRING (EX) | Leader-election lease (see Failover) |
+
+### SQLite mirror
+
+Same tables as historical `utils/db.py`: `image_hashes`, `posted_mds`, `posted_watches`, `bot_state`, `posted_urls`, `product_text_cache`. WAL mode, 5-second busy timeout. If the database fails an integrity check on startup it is renamed to `bot_state.db.corrupted` and recreated.
+
+### Free-tier Upstash budget
+
+Projected ~8.2 k commands/day across both nodes (primary heartbeat writes, standby heartbeat reads, periodic bulk refreshes, state mutations) against the 10 k/day free-tier ceiling. Hot reads are served from the in-process cache, not billed.
 
 ---
 
 ## Running Tests
 
+Install the dev dependency set (runtime + pytest/pytest-asyncio/pytest-cov/ruff):
+
 ```bash
-pip install pytest pytest-asyncio
+pip install -r requirements-dev.txt
 python -m pytest tests/ -v
+```
+
+With coverage:
+
+```bash
+python -m pytest tests/ \
+    --cov=cogs --cov=utils --cov=config --cov=main \
+    --cov-report=term-missing
+```
+
+Lint (same selection CI uses):
+
+```bash
+ruff check --select=E9,F63,F7,F82,F401 --exclude=venv,lib,cache .
+```
 
 ---
 
-## Failover Configuration
+## Migrating from an older bot_state.db (pre-v5)
 
-WxAlert supports a primary/standby failover architecture using Cloudflare tunnels and Upstash Redis for coordination.
+If you have an existing SQLite-only install, one-shot migrate it into Upstash before booting the v5 code:
+
+```bash
+# First, a dry-run to print counts without touching Upstash:
+python -m scripts.migrate_sqlite_to_upstash --dry-run
+
+# Then the real run:
+python -m scripts.migrate_sqlite_to_upstash
+
+# Use --force to DEL existing Upstash keys before re-seeding (e.g. after a
+# schema change):
+python -m scripts.migrate_sqlite_to_upstash --force
+```
+
+The script is idempotent (Redis `SADD`/`HSET` won't duplicate on re-run). It requires `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in `.env`.
+
+---
+
+## Failover (v5+)
+
+Two-node primary/standby architecture using Upstash Redis for **both** leader election *and* shared state. As of v5 there is no HTTP state-sync between nodes — they both read/write the same Upstash keys directly.
 
 ### How it works
-- **Primary** runs an aiohttp HTTP server on `STATE_PORT` (default 8765), starts a cloudflared tunnel, and writes the tunnel URL to Upstash Redis with a 7-minute TTL every 30 seconds.
-- **Standby** polls Upstash every 30 seconds. If the primary URL is missing or unreachable for 3 consecutive checks (~90 seconds), it promotes itself, loads all cogs, starts its own tunnel, and writes its URL to Upstash.
-- When the primary comes back online, it reads the standby's URL from Upstash, hydrates its state from the standby via `GET /state`, then writes its own URL. The standby detects the URL change and demotes itself, pushing accumulated state back to the primary via `POST /sync`.
+
+- **Primary** holds an Upstash lease at `spcbot:primary_url` with `EX HEARTBEAT_TTL` (420 s) and refreshes it every `SYNC_INTERVAL` (30 s). The lease value is a per-process identity (`<hostname>:<random>`) so a node can recognize whether the lease is still its own.
+- **Standby** reads the lease every sync interval. If the key is **present**, the primary is alive — the standby does nothing. If the key is **missing** for `MAX_FAILURES` consecutive cycles (derived from the TTL — currently 7 failures ≈ 210 s, half the TTL), the standby promotes:
+  1. Invalidates its in-process cache so the first read on every key goes to Upstash.
+  2. Writes its own lease value.
+  3. Rehydrates `bot.state` mirrors from Upstash.
+  4. Calls `state_store.resync_to_upstash()` to push any SQLite-only writes that may have happened during an Upstash outage.
+  5. Loads every cog and syncs the slash-command tree.
+- **Startup grace**: for the first 120 s after cog load the standby's failure counter does not advance — covers the common case of deploying the standby before the primary has finished its own restart.
+- **Self-demotion**: if the current holder sees a *different* node's identity in the lease, it demotes and unloads its cogs rather than fighting.
+
+### What this replaces (historical)
+
+Older versions (≤ v4) shipped state between the two nodes via an HTTP endpoint exposed through a Cloudflare tunnel (`cloudflared`) and used `/state` and `/sync` handlers plus hydration logic. All of that is gone in v5 — state is in Upstash; nodes talk to the shared store directly, not to each other.
 
 ### Required `.env` variables
 
@@ -195,10 +267,11 @@ WxAlert supports a primary/standby failover architecture using Cloudflare tunnel
 |---|---|---|
 | `IS_PRIMARY` | `true` | `false` |
 | `FAILOVER_TOKEN` | shared secret | same shared secret |
-| `STATE_PORT` | `8765` (default) | `8765` (default) |
 | `UPSTASH_REDIS_REST_URL` | your Upstash URL | same |
 | `UPSTASH_REDIS_REST_TOKEN` | your Upstash token | same |
 
-### Dependencies
-- `cloudflared` must be installed on both servers (handled by `deploy.sh`)
-- A free Upstash Redis instance is sufficient (well within free tier limits)
+`FAILOVER_TOKEN` is validated at cog load; the cog refuses to start if it's empty or the literal `"changeme"`. This was added after a production incident where the default value meant anyone who discovered the (now-removed) tunnel URL could read full bot state.
+
+### No `cloudflared` dependency
+
+`deploy.sh` and the Dockerfile used to install cloudflared for the tunnel. Neither does as of v5 — if you're upgrading from an older install, the binary can be removed (`sudo rm /usr/local/bin/cloudflared`) but leaving it installed is harmless.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ A Discord bot for severe weather enthusiasts. Auto-posts SPC convective outlooks
 
 ## Prerequisites
 
-* Python 3.10+
+* Python 3.12+ (matches the Dockerfile; 3.10/3.11 may still work but CI runs on 3.12)
 * A Discord bot token and application ([Discord Developer Portal](https://discord.com/developers/applications))
 * Channel IDs and Guild ID for where the bot should post
+* An [Upstash Redis](https://upstash.com/) instance (free tier is sufficient) — shared state for the primary/standby pair
 
 ## Setup
 
@@ -72,21 +73,26 @@ spc-bot/
 ├── docker-compose.yml       # Docker orchestration
 ├── install-hooks.sh         # Installs pre-push git hooks (syntax + test checks)
 ├── config.py                # Configuration and centralized URL constants
-├── requirements.txt         # Python dependencies
+├── requirements.txt         # Runtime dependencies (what the bot needs to run)
+├── requirements-dev.txt     # Runtime + pytest/pytest-asyncio/pytest-cov/ruff for development & CI
 ├── .env.example             # Template for required environment variables
 ├── CREDITS.md               # Third-party attributions
+├── scripts/
+│   └── migrate_sqlite_to_upstash.py  # One-shot migration of local SQLite into Upstash
 ├── utils/
-│   ├── http.py              # Async HTTP session management (centralized pooling)
-│   ├── change_detection.py  # HEAD-based change detection, hashing
-│   ├── cache.py             # Download orchestration, legacy globals (deprecated)
-│   ├── state.py             # BotState class — single source of truth for in-memory state
+│   ├── http.py              # Async HTTP session management (centralized pooling, retry, conditional GET)
+│   ├── change_detection.py  # Content hashing and placeholder-image detection
+│   ├── cache.py             # Download orchestration; conditional-GET poll path
+│   ├── state.py             # BotState — HashStore + PostingLog + TimingTracker sub-stores
+│   ├── state_store.py       # Upstash Redis facade: read-through cache → Upstash → SQLite fallback;
+│   │                        # double-writes both backends, retries failed Upstash writes via a reconciler
 │   ├── spc_urls.py          # SPC outlook URL resolution
 │   ├── backoff.py           # Exponential backoff tracker for task loops
-│   └── db.py                # Async SQLite state manager (aiosqlite) with persistent product text caching
+│   └── db.py                # Async SQLite backend used internally by state_store as the durable mirror
 ├── cogs/
 │   ├── outlooks.py          # SPC Day 1-3 and Day 4-8 auto-posting
 │   ├── mesoscale.py         # SPC MD monitoring with watch probability detection and IEM fallbacks
-│   ├── iembot.py            # IEM iembot feed poller with persistent DB-backed text cache
+│   ├── iembot.py            # IEM iembot feed poller with persistent text-product caching
 │   ├── watches.py           # SPC watch monitoring via NWS API (stores affected_zones)
 │   ├── scp.py               # NIU/Gensini SCP graphics, twice daily
 │   ├── csu_mlp.py           # CSU-MLP consolidated /csu command with Choice dropdown
@@ -95,7 +101,7 @@ spc-bot/
 │   ├── sounding_utils.py    # Location resolution, IEM fetch (all hours), ACARS fetch, plot generation
 │   ├── sounding_views.py    # Discord UI: CombinedSoundingView, IEMTimeSelectionView, ACARS views
 │   ├── hodograph.py         # VWP hodograph generation via /hodograph
-│   ├── failover.py          # HTTP failover: cloudflared tunnel, Upstash coordination, primary/standby logic
+│   ├── failover.py          # Leader election via an Upstash lease (no HTTP tunnel — v5+)
 │   ├── status.py            # Bot status and manual slash commands
 │   └── radar/
 │       ├── __init__.py      # Radar cog: /download with quick-start site+time+count params
@@ -111,13 +117,22 @@ spc-bot/
 │       ├── wsr88d.py        # Radar site info and filename utilities
 │       ├── asos.py          # ASOS surface wind fetching
 │       └── utils.py         # Shared exception types
-└── tests/
-    ├── conftest.py          # Test environment setup
-    ├── test_utils.py        # Unit tests for utilities and sounding parsing
-    ├── test_watches.py      # Unit tests for watch VTEC parsing
-    ├── test_integration.py  # Integration tests: BotState, cog instantiation, function signatures
-    ├── test_hodograph.py    # Unit tests for hodograph cog
-    └── test_iem_races.py    # Tests for IEM/SPC race logic and watch-triggered soundings
+└── tests/                   # pytest suite (169+ tests, see CONTRIBUTING.md)
+    ├── conftest.py          # Fixtures: fake_bot (real BotState), isolated_db, opt-in patches
+    ├── test_fixtures.py     # Fixture invariants
+    ├── test_utils.py        # Utility and sounding parsing
+    ├── test_watches.py      # Watch VTEC parsing
+    ├── test_integration.py  # BotState, cog instantiation, function signatures
+    ├── test_state_split.py  # HashStore / PostingLog / TimingTracker delegation
+    ├── test_state_store.py  # Upstash-backed state store (cache, reconciler, SQLite fallback)
+    ├── test_db.py           # SQLite backend roundtrips
+    ├── test_http.py         # HTTP retry + conditional GET
+    ├── test_cache_conditional.py  # Partial-update poll with ETag/If-Modified-Since
+    ├── test_backoff.py      # TaskBackoff delay and alert logic
+    ├── test_main_lifecycle.py  # Shutdown guard, watchdog restart, startup smoke
+    ├── test_failover_coverage.py  # Lease election, promotion, demotion
+    ├── test_hodograph.py    # Hodograph cog
+    └── test_iem_races.py    # IEM/SPC race logic and watch-triggered soundings
 ```
 
 ## Status

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -144,7 +144,7 @@ async def test_standby_increments_failures_when_lease_missing(monkeypatch):
     monkeypatch.setattr(FailoverCog, "_upstash", mock)
 
     cog = FailoverCog(_make_bot(is_primary=False))
-    cog._cog_load_monotonic = 0.0  # past grace
+    cog._cog_load_monotonic = __import__("time").monotonic() - failover_module.STARTUP_GRACE_SECONDS - 10  # past grace
 
     await cog._standby_cycle()
     assert cog._primary_failures == 1
@@ -172,7 +172,7 @@ async def test_standby_promotes_after_max_failures(monkeypatch):
     monkeypatch.setattr(FailoverCog, "_promote", AsyncMock())
 
     cog = FailoverCog(_make_bot(is_primary=False))
-    cog._cog_load_monotonic = 0.0
+    cog._cog_load_monotonic = __import__("time").monotonic() - failover_module.STARTUP_GRACE_SECONDS - 10  # past grace
 
     for _ in range(failover_module.MAX_FAILURES):
         await cog._standby_cycle()
@@ -186,7 +186,7 @@ async def test_standby_does_not_promote_one_short_of_threshold(monkeypatch):
     monkeypatch.setattr(FailoverCog, "_promote", AsyncMock())
 
     cog = FailoverCog(_make_bot(is_primary=False))
-    cog._cog_load_monotonic = 0.0
+    cog._cog_load_monotonic = __import__("time").monotonic() - failover_module.STARTUP_GRACE_SECONDS - 10  # past grace
 
     for _ in range(failover_module.MAX_FAILURES - 1):
         await cog._standby_cycle()


### PR DESCRIPTION
## Summary
Brings the docs in line with the v5 Upstash-backed architecture.

### README.md
- Prerequisites: Python 3.12, Upstash now stated as required.
- Project Structure: `utils/state_store.py` added and explained; `utils/db.py` demoted to internal SQLite mirror; `cogs/failover.py` description rewritten (lease, not tunnel); `scripts/migrate_sqlite_to_upstash.py` and `requirements-dev.txt` listed; tests section expanded to cover all the files that landed during v4.x coverage work.

### CONTRIBUTING.md
- **Persistence** section rewritten: Upstash as source of truth, SQLite as durable mirror, in-process 60 s read-through cache, dirty-queue reconciler, startup resync. Full Upstash key schema documented. Free-tier command budget called out.
- **Running Tests**: switched from ad-hoc `pip install pytest pytest-asyncio` to `requirements-dev.txt`; added coverage and ruff invocations.
- **New "Migrating from an older bot_state.db"** section covering `scripts/migrate_sqlite_to_upstash.py` including `--dry-run` and `--force`.
- **Failover** section rewritten: lease-based leader election, startup grace, derived `MAX_FAILURES`, self-demotion, what v5 replaced, why `FAILOVER_TOKEN` fails fast.
- IEMBot and CSU-MLP/NCAR sub-sections reference `state_store` instead of "the SQLite database".
- Stray closing ``` that broke section formatting fixed.

### .env.example
- Dropped `STATE_PORT` (no longer read).
- Clarified `IS_PRIMARY` and `FAILOVER_TOKEN` semantics.

## Test plan
- [x] `pytest -q` — 172 passed
- [x] ruff clean