### PR TITLE
fix: /md slash crash + ncar state-reset bugs

### DIFF
--- a/cogs/ncar.py
+++ b/cogs/ncar.py
@@ -10,8 +10,10 @@ from config import MANUAL_CACHE_FILE, MODELS_CHANNEL_ID, WXNEXT_BASE
 from utils.cache import (
     calculate_hash_bytes,
     download_single_image,
+    get_cache_path_for_url,
+    is_placeholder_image,
 )
-from utils.state_store import get_state, set_state
+from utils.state_store import delete_state, get_state, set_hash, set_state
 from utils.http import ensure_session
 
 import aiohttp
@@ -130,13 +132,15 @@ class NCARCog(commands.Cog):
         now_utc = datetime.now(timezone.utc)
         today_str = now_utc.strftime("%Y-%m-%d")
 
-        # Reset state at 04 UTC daily (before products start appearing)
+        # Reset state at 03 UTC daily (before products start appearing).
+        # Fires when stored state is from a prior UTC day.
         if now_utc.hour == 3 and now_utc.minute < 10:
-            if _posted_state.get("date") == today_str:
+            stored_date = _posted_state.get("date")
+            if stored_date and stored_date != today_str:
                 logger.info("[NCAR] Resetting daily posted state")
                 _posted_state = {}
                 _timing_logged = False
-                _save_state("", "")
+                await delete_state("ncar_posted")
 
         # Only poll 06-18 UTC
         if not (5 <= now_utc.hour < 12):
@@ -170,11 +174,19 @@ class NCARCog(commands.Cog):
             logger.warning("[NCAR] SCP channel not found")
             return
 
-        cache_path, _, _ = await download_single_image(
-            url, MANUAL_CACHE_FILE, self.bot.state.manual_cache
-        )
-        if not cache_path:
-            logger.warning("[NCAR] Download failed for WxNext2")
+        # We already fetched `content` in _resolve_wxnext for hashing;
+        # save it directly instead of refetching via download_single_image.
+        if is_placeholder_image(content):
+            logger.warning("[NCAR] WxNext2 image looks like a placeholder, skipping")
+            return
+        cache_path = get_cache_path_for_url(url)
+        try:
+            with open(cache_path, "wb") as f:
+                f.write(content)
+            self.bot.state.manual_cache[url] = h
+            await set_hash(url, h, "manual")
+        except Exception as e:
+            logger.error(f"[NCAR] Failed to save WxNext2 image: {e}")
             return
 
         try:

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -308,7 +308,7 @@ class StatusCog(commands.Cog):
             )
             return
         for md_num in md_numbers:
-            image_url, summary, from_cache = await fetch_md_details(md_num)
+            image_url, summary, from_cache, _ = await fetch_md_details(md_num)
             cache_path = None
             if image_url:
                 cache_path, _, _ = await download_single_image(


### PR DESCRIPTION
## Summary
- **`/md` slash command**: `cogs/status.py:311` unpacks a 3-tuple from `fetch_md_details`, which actually returns 4 values (raw_text was added later). Every `/md` invocation raises `ValueError: too many values to unpack`. The auto-post call sites unpack 4 correctly — only the slash command was broken.
- **NCAR daily reset is a no-op**: `_save_state(\"\", \"\")` was called without `await`, discarding the coroutine. Even if awaited, empty strings don't clear state — they stored `{date: \"\", hash: \"\"}`. And the guard used `== today_str` when it meant `!= today_str`; at 03 UTC the stored state is yesterday's, so the reset would never fire. Fixed by using `delete_state()` and inverting the guard.
- **NCAR double-downloads the WxNext image**: `_resolve_wxnext` fetches the full PNG to hash it, then `download_single_image` re-fetches the same URL. Thread the bytes through to disk directly.

## Test plan
- [x] `pytest` — 172 passed, warning count 6 → 5 (one was the un-awaited coroutine)
- [ ] Invoke `/md` in Discord after deploy — should no longer crash
- [ ] Observe NCAR state reset at 03 UTC — log line should appear when a new UTC day rolls over with prior state