### PR TITLE
chore: remove dead code

### DIFF
--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -129,9 +129,8 @@ async def _save_posted_today(posted: set):
     except Exception as e:
         logger.warning(f"[CSU-MLP] Failed to save posted state: {e}")
 
-# Auto-post state — which days posted today, persisted to disk
-_posted_today: set = set()  # loaded async on first poll
-_availability_log: dict[int, str] = {}  # day -> first-seen time string
+# Per-day first-seen timestamps; purely diagnostic.
+_availability_log: dict[int, str] = {}
 
 
 class CSUMLPCog(commands.Cog):

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -315,9 +315,6 @@ class MesoscaleCog(commands.Cog):
             if not self.bot.state.is_primary:
                 return
 
-            if self._md_backoff.should_skip():
-                return
-
             channel = self.bot.get_channel(SPC_CHANNEL_ID)
             if not channel:
                 logger.warning("SPC channel not found for auto_post_md")

--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -158,8 +158,6 @@ class OutlooksCog(commands.Cog):
     @tasks.loop(seconds=30)
     async def auto_post_spc(self):
         await self.bot.wait_until_ready()
-        if self._spc_backoff.should_skip():
-            return
         channel = self.bot.get_channel(SPC_CHANNEL_ID)
         if not channel:
             logger.warning("SPC channel not found for auto_post_spc")

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -398,7 +398,6 @@ class StatusCog(commands.Cog):
             "auto_post_scp":        "NIU/Gensini SCP graphics",
             "csu_mlp_daily_poll":   "CSU-MLP forecasts",
             "wxnext_daily_poll":    "NCAR WxNext2",
-            "watchdog_task":        "watchdog",
             "periodic_cleanup":     "periodic cache cleanup",
             "poll_iembot_feed":     "IEMBot real-time feed",
             "sync_loop":            "Failover standby sync",

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -717,8 +717,6 @@ class WatchesCog(commands.Cog):
             if not self.bot.state.is_primary:
                 return
 
-            if self._watches_backoff.should_skip():
-                return
             channel = self.bot.get_channel(SPC_CHANNEL_ID)
             if not channel:
                 logger.warning("SPC channel not found for auto_post_watches")

--- a/main.py
+++ b/main.py
@@ -380,12 +380,8 @@ def _setup_signal_handlers(loop: asyncio.AbstractEventLoop):
 # ── Entrypoint ───────────────────────────────────────────────────────────────
 async def main():
     async with bot:
-        # Register signal handlers with the running loop
-        try:
-            _setup_signal_handlers(asyncio.get_running_loop())
-        except Exception as e:
-            logger.warning(f"Could not set up signal handlers: {e}")
-
+        # _setup_signal_handlers handles per-signal errors itself.
+        _setup_signal_handlers(asyncio.get_running_loop())
         await bot.start(TOKEN)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,24 +73,6 @@ def suppress_create_task():
 
 
 @pytest.fixture
-def stub_task_backoff(monkeypatch):
-    """Stub `utils.backoff.TaskBackoff` for one test.
-
-    Replaces the real class with a mock whose `should_skip` is always
-    False and whose `failure`/`success` are no-ops. Use when a test
-    exercises a loop task body and the backoff dance is irrelevant.
-    """
-    mock_backoff = MagicMock()
-    mock_backoff.failure = AsyncMock()
-    mock_backoff.success = MagicMock()
-    mock_backoff.should_skip = MagicMock(return_value=False)
-    monkeypatch.setattr(
-        "utils.backoff.TaskBackoff", MagicMock(return_value=mock_backoff)
-    )
-    return mock_backoff
-
-
-@pytest.fixture
 def bot_state():
     """Fresh, real `BotState` (not a MagicMock)."""
     from utils.state import BotState

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,8 +1,4 @@
-"""Tests for `utils.backoff.TaskBackoff`.
-
-Previously this class was stubbed by an autouse conftest fixture across
-the whole suite, so no test ever exercised the real delay/skip logic.
-"""
+"""Tests for `utils.backoff.TaskBackoff`."""
 
 from unittest.mock import AsyncMock, patch
 
@@ -10,17 +6,11 @@ from unittest.mock import AsyncMock, patch
 from utils.backoff import TaskBackoff, _BACKOFF_DELAYS
 
 
-def test_fresh_backoff_does_not_skip():
-    b = TaskBackoff("t1")
-    assert b.should_skip() is False
-
-
 def test_success_resets_failure_count():
     b = TaskBackoff("t1")
     b._failures = 4
     b.success()
     assert b._failures == 0
-    assert b.should_skip() is False
 
 
 async def test_failure_increments_and_sleeps(monkeypatch):

--- a/utils/backoff.py
+++ b/utils/backoff.py
@@ -6,8 +6,6 @@ Usage:
     backoff = TaskBackoff("auto_post_spc")
 
     # In your task loop:
-    if backoff.should_skip():
-        return
     try:
         await do_work()
         backoff.success()
@@ -27,26 +25,13 @@ _BACKOFF_DELAYS = [0, 0, 30, 60, 120, 300, 300]
 
 class TaskBackoff:
     """
-    Tracks consecutive failures for a named task and provides
-    skip/sleep logic to back off during network issues.
+    Tracks consecutive failures for a named task and sleeps inline
+    on `failure()` to back off during network issues.
     """
 
     def __init__(self, name: str):
         self.name = name
         self._failures = 0
-        self._skip_cycles = 0
-
-    def should_skip(self) -> bool:
-        """Call at the top of your loop. Returns True if this cycle should be skipped."""
-        if self._skip_cycles > 0:
-            self._skip_cycles -= 1
-            logger.debug(
-                f"[BACKOFF] {self.name}: skipping cycle "
-                f"({self._skip_cycles} skips remaining, "
-                f"{self._failures} consecutive failures)"
-            )
-            return True
-        return False
 
     def success(self):
         """Call after a successful cycle to reset backoff."""
@@ -56,7 +41,6 @@ class TaskBackoff:
                 f"{self._failures} consecutive failure(s)"
             )
         self._failures = 0
-        self._skip_cycles = 0
 
     async def failure(self, bot=None):
         """


### PR DESCRIPTION
## Summary
- **`TaskBackoff._skip_cycles` / `should_skip()`**: the field was declared but never incremented, so the skip-cycles code path was unreachable. The actual backoff works via inline `await asyncio.sleep(delay)` in `failure()`. Dropped the dead field + method, updated the three cog callers (mesoscale, watches, outlooks) and the unused \`stub_task_backoff\` conftest fixture.
- **`csu_mlp._posted_today`**: module-global \`set()\` never referenced — state lives on \`bot.state.csu_posted\`.
- **`status.py` \`watchdog_task\` label**: status iterates \`self.bot.cogs.values()\`, but \`watchdog_task\` is module-level in \`main.py\`, so the label never resolved.
- **\`main.py\` signal-handler try/except**: redundant outer wrapper; \`_setup_signal_handlers\` already catches per-signal errors.

## Test plan
- [x] \`pytest\` — 171 passed (172 → 171, \`test_fresh_backoff_does_not_skip\` removed)