### PR TITLE
perf: reduce redundant HTTP + hardening

### DIFF
--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -235,7 +235,9 @@ class CSUMLPCog(commands.Cog):
     @tasks.loop(minutes=10)
     async def csu_mlp_daily_poll(self):
         await self.bot.wait_until_ready()
-        
+        if not self.bot.state.is_primary:
+            return
+
         # Hydrate from DB if memory is empty
         if not self.bot.state.csu_posted:
             db_posted = await _load_posted_today()

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -86,38 +86,48 @@ class FailoverCog(commands.Cog):
         self._primary_failures = 0
         self._identity = _node_identity()
         self._cog_load_monotonic: float | None = None
+        # Dedicated session for leader-election traffic, kept separate from
+        # utils.http.http_session so lease operations don't interfere (and
+        # aren't interfered with) by the shared pool if it misbehaves.
+        self._session: aiohttp.ClientSession | None = None
 
     async def cog_load(self):
         _require_failover_token()
         self._cog_load_monotonic = time.monotonic()
+        self._session = aiohttp.ClientSession()
         self.sync_loop.start()
 
     async def cog_unload(self):
         self.sync_loop.cancel()
         if self.bot.state.is_primary:
             await self._release_lease()
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+            self._session = None
 
     # ── Upstash ──────────────────────────────────────────────────────────
 
     async def _upstash(self, *args) -> object | None:
-        """Single REST command. Kept separate from utils.state_store so
-        leader election keeps working even if the main store is
+        """Single REST command. Uses a dedicated session (see cog_load)
+        so leader election keeps working even if utils.http is
         misbehaving (the two paths are independent)."""
         if not UPSTASH_URL or not UPSTASH_TOKEN:
             return None
+        if self._session is None or self._session.closed:
+            # Can happen during cog reload or an unexpected unload; recreate.
+            self._session = aiohttp.ClientSession()
         try:
             headers = {**UPSTASH_HEADERS, "Content-Type": "application/json"}
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    UPSTASH_URL,
-                    headers=headers,
-                    json=[str(a) for a in args],
-                    timeout=aiohttp.ClientTimeout(total=5),
-                ) as resp:
-                    if resp.status != 200:
-                        return None
-                    data = await resp.json()
-                    return data.get("result")
+            async with self._session.post(
+                UPSTASH_URL,
+                headers=headers,
+                json=[str(a) for a in args],
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json()
+                return data.get("result")
         except Exception as e:
             logger.warning(f"[FAILOVER] Upstash error: {e!r}")
             return None

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -31,18 +31,14 @@ async def fetch_latest_md_numbers() -> List[str]:
     """
     meta = await http_head_meta(SPC_MD_INDEX_URL)
     if meta is not None and _md_index_head:
-        unchanged = (
-            (meta["etag"] and meta["etag"] == _md_index_head.get("etag"))
-            or (
-                meta["last_modified"]
-                and meta["last_modified"] == _md_index_head.get("last_modified")
-            )
-            or (
-                meta["content_length"]
-                and meta["content_length"] == _md_index_head.get("content_length")
-            )
-        )
-        if unchanged and any(meta.values()):
+        # Require ALL non-empty validators to match. OR was too loose —
+        # if content_length happened to line up while the page actually
+        # changed, we'd silently drop the new MD.
+        checks = []
+        for key in ("etag", "last_modified", "content_length"):
+            if meta.get(key):
+                checks.append(meta[key] == _md_index_head.get(key))
+        if checks and all(checks):
             return []
     if meta:
         _md_index_head.update(meta)

--- a/cogs/ncar.py
+++ b/cogs/ncar.py
@@ -125,6 +125,8 @@ class NCARCog(commands.Cog):
     @tasks.loop(minutes=10)
     async def wxnext_daily_poll(self):
         await self.bot.wait_until_ready()
+        if not self.bot.state.is_primary:
+            return
         global _posted_state, _timing_logged
         if not _posted_state:
             _posted_state = await _load_state()

--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -158,6 +158,8 @@ class OutlooksCog(commands.Cog):
     @tasks.loop(seconds=30)
     async def auto_post_spc(self):
         await self.bot.wait_until_ready()
+        if not self.bot.state.is_primary:
+            return
         channel = self.bot.get_channel(SPC_CHANNEL_ID)
         if not channel:
             logger.warning("SPC channel not found for auto_post_spc")
@@ -199,6 +201,8 @@ class OutlooksCog(commands.Cog):
     @tasks.loop(minutes=30)
     async def auto_post_spc48(self):
         await self.bot.wait_until_ready()
+        if not self.bot.state.is_primary:
+            return
         channel = self.bot.get_channel(SPC_CHANNEL_ID)
         if not channel:
             logger.warning("SPC channel not found for auto_post_spc48")

--- a/cogs/scp.py
+++ b/cogs/scp.py
@@ -44,6 +44,8 @@ class SCPCog(commands.Cog):
         Posts at 6am and 6pm Pacific if the images have changed.
         """
         await self.bot.wait_until_ready()
+        if not self.bot.state.is_primary:
+            return
 
         if self._next_post_time is None:
             self._next_post_time = self._compute_next_post_time()

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -35,7 +35,9 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
     Returns dict: watch_num -> {"type": "SVR"|"TORNADO", "expires": datetime}
     Deduplicates by watch number from the VTEC string.
     """
-    content, status = await http_get_bytes(NWS_ALERTS_URL, retries=5, timeout=30)
+    # Keep retries×timeout well under the 2-minute auto_post_watches
+    # cycle so a bad NWS API window doesn't stall successive ticks.
+    content, status = await http_get_bytes(NWS_ALERTS_URL, retries=2, timeout=15)
     if not content or status != 200:
         logger.warning(
             f"[WATCH] NWS API returned status {status} — will retry next cycle"

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -370,17 +370,16 @@ async def get_hash(url: str) -> Optional[str]:
         return val
 
     # Upstash path: the per-type Hash is the authoritative index.
+    # We don't know the cache_type at this call, so query both in
+    # parallel (one round-trip wall-clock) and prefer auto on match.
     try:
-        # We don't know the cache_type at this call — check both.
-        for cache_type in ("auto", "manual"):
-            result = await _upstash_cmd(
-                "HGET", _k_hash_url_lookup(cache_type, url), url
-            )
-            if result:
-                _cache_set(cache_key, result)
-                return result
-        _cache_set(cache_key, None)
-        return None
+        auto_result, manual_result = await asyncio.gather(
+            _upstash_cmd("HGET", _k_hash_url_lookup("auto", url), url),
+            _upstash_cmd("HGET", _k_hash_url_lookup("manual", url), url),
+        )
+        result = auto_result or manual_result
+        _cache_set(cache_key, result)
+        return result
     except _UpstashUnavailable as e:
         logger.debug(f"[STATE] get_hash({url}) falling back to SQLite: {e}")
         val = await sqlite_backend.get_hash(url)


### PR DESCRIPTION
## Summary

### Efficiency
- **\`cogs/failover.py\`**: reuse a single \`aiohttp.ClientSession\` for the leader-election path instead of opening a new one (TLS handshake and all) on every 30s tick. Isolation from the shared \`utils.http.http_session\` is preserved by keeping this session dedicated to the cog.
- **\`utils/state_store.py\` \`get_hash\`**: query the auto and manual hash indices via \`asyncio.gather\` instead of sequentially, so a cache miss costs one RTT wall-clock instead of two.

### Defense / consistency
- Add \`is_primary\` guards to \`auto_post_spc\`, \`auto_post_spc48\`, \`csu_mlp_daily_poll\`, \`wxnext_daily_poll\`, and \`auto_post_scp\`. Failover unloads cogs on demotion so these were safe in practice, but \`watches\`/\`mesoscale\`/\`iembot\` all check — the inconsistency was a footgun for future refactors or a slow unload.
- **\`cogs/mesoscale.py\` \`fetch_latest_md_numbers\` unchanged-check**: now requires ALL non-empty validators (etag, last-modified, content-length) to match instead of ANY. The OR could declare the page unchanged if content_length coincidentally matched while etag/last-modified had moved — silently dropping a new MD.
- **\`cogs/watches.py\` \`fetch_active_watches_nws\`**: \`retries=5\` × \`timeout=30\` = up to 150s of blocking inside a 2-minute \`tasks.loop\`. Today's log showed it hitting retry caps repeatedly during an NWS API bad window. Lowered to \`retries=2\`, \`timeout=15\` so a bad window no longer stalls successive cycles.

## Test plan
- [x] Full pytest: 171 passed
- [x] Targeted: \`tests/test_failover_coverage.py tests/test_state_store.py\` (28 passed)
- [ ] Watch the log after deploy for \`[FAILOVER]\` traffic — should not see new-session setup on every tick