### PR TITLE
perf: comprehensive efficiency and hardening pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. Format
+loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+version numbers follow [SemVer](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Identifying `User-Agent` on all outbound HTTP so NWS/SPC won't throttle
+  the bot as an unknown client. UA is derived from `config.__version__`.
+- `http_validators` SQLite table and `get_validators` / `set_validators` /
+  `get_all_validators` helpers. Conditional-GET ETag / Last-Modified pairs
+  now survive restart, so the first poll after boot no longer redownloads
+  every URL.
+- DB write-failure counter (`utils.db.get_write_failure_count`). Five
+  consecutive failed writes escalate from warning to error so a persistent
+  outage (full disk, schema drift) is visible.
+
+### Changed
+- `utils.state_store.get_hash` accepts an optional `cache_type`. When
+  provided, the Upstash lookup hits a single HGET instead of racing both
+  the `auto` and `manual` indexes — halves command cost on that path.
+- Watchdog session probe now targets `api.weather.gov` (HEAD) instead of
+  `google.com`. Reflects whether the bot's actual upstream is reachable.
+- `cogs.watches._execute_watches` fetches per-watch details in parallel;
+  `fetch_watch_details` fetches the SPC main page and prob page in
+  parallel; the HTML-fallback classifier also runs in parallel.
+- Duplicated watch-embed construction collapsed into a single
+  `_build_watch_embed` / `_watch_files` helper (paginator, auto-post,
+  iembot fast-path, and upgrade-edit all share the same code).
+- Image cache writes (`download_single_image`, `save_downloaded_images`)
+  go through `run_in_executor` so burst saves don't stall the event loop.
+- `http_get_bytes` surfaces the terminal 429/503 status to callers
+  instead of flattening to `(None, None)`, and no longer sleeps after
+  the final retry attempt.
+
+### Fixed
+- Cache-path extension is now whitelisted and the URL query / fragment
+  is stripped before `os.path.splitext`, so a URL like
+  `x.gif?param=..%2F..` can no longer shape the cached filename.
+- `utils.state_store._upstash_cmd` rejects `None` arguments instead of
+  silently shipping the literal `"None"` on the wire.
+- `http_head_ok` no longer falls back to a full GET on HEAD failure — a
+  liveness probe that downloads the body defeats the purpose.
+- `should_use_cache_for_manual` collapses its `exists()` + `getmtime()`
+  pair into a single `os.stat`.
+
+### Removed
+- Unused `_connecting` flag in `utils.db`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.1.0] — 2026-04-21
+
 ### Added
 - Identifying `User-Agent` on all outbound HTTP so NWS/SPC won't throttle
   the bot as an unknown client. UA is derived from `config.__version__`.

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ spc-bot/
 ├── utils/
 │   ├── http.py              # Async HTTP session management (centralized pooling, retry, conditional GET)
 │   ├── change_detection.py  # Content hashing and placeholder-image detection
-│   ├── cache.py             # Download orchestration; conditional-GET poll path
+│   ├── cache.py             # Download orchestration; conditional-GET poll path (validators persist across restarts)
 │   ├── state.py             # BotState — HashStore + PostingLog + TimingTracker sub-stores
 │   ├── state_store.py       # Upstash Redis facade: read-through cache → Upstash → SQLite fallback;
 │   │                        # double-writes both backends, retries failed Upstash writes via a reconciler
 │   ├── spc_urls.py          # SPC outlook URL resolution
 │   ├── backoff.py           # Exponential backoff tracker for task loops
-│   └── db.py                # Async SQLite backend used internally by state_store as the durable mirror
+│   └── db.py                # Async SQLite backend used internally by state_store as the durable mirror; also home of http_validators
 ├── cogs/
 │   ├── outlooks.py          # SPC Day 1-3 and Day 4-8 auto-posting
 │   ├── mesoscale.py         # SPC MD monitoring with watch probability detection and IEM fallbacks

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -102,23 +102,26 @@ async def fetch_latest_watch_numbers() -> List[Tuple[str, str]]:
     html = await http_get_text(SPC_WATCH_INDEX_URL)
     if not html:
         return []
-    results = []
-    seen = set()
-    for m in re.finditer(
-        r'href="[^"]*ww(\d+)\.html"', html, re.IGNORECASE
-    ):
+
+    seen = []
+    seen_set = set()
+    for m in re.finditer(r'href="[^"]*ww(\d+)\.html"', html, re.IGNORECASE):
         num = m.group(1).zfill(4)
-        if num in seen:
+        if num in seen_set:
             continue
-        seen.add(num)
+        seen_set.add(num)
+        seen.append(num)
+
+    async def _classify(num: str) -> Tuple[str, str]:
         watch_html = await http_get_text(
             f"https://www.spc.noaa.gov/products/watch/ww{num}.html"
         )
         wtype = "SVR"
         if watch_html and re.search(r"Tornado Watch", watch_html, re.IGNORECASE):
             wtype = "TORNADO"
-        results.append((num, wtype))
-    return results
+        return num, wtype
+
+    return list(await asyncio.gather(*[_classify(n) for n in seen]))
 
 
 
@@ -187,8 +190,15 @@ async def fetch_watch_details(
     Races SPC and IEM page fetches simultaneously — whichever returns first wins.
     """
     page_url = f"https://www.spc.noaa.gov/products/watch/ww{watch_number}.html"
+    prob_url = (
+        f"https://www.spc.noaa.gov/products/watch/ww{watch_number}_prob.html"
+    )
 
-    html = await http_get_text(page_url)
+    # SPC main page and prob page are independent — fetch them in parallel.
+    html, prob_html = await asyncio.gather(
+        http_get_text(page_url),
+        http_get_text(prob_url),
+    )
 
     image_url = None
     if html:
@@ -285,10 +295,6 @@ async def fetch_watch_details(
                 break
 
     probs = None
-    prob_url = (
-        f"https://www.spc.noaa.gov/products/watch/ww{watch_number}_prob.html"
-    )
-    prob_html = await http_get_text(prob_url)
     if prob_html:
         cells = re.findall(
             r"<td[^>]*>(.*?)</td>", prob_html, re.DOTALL | re.IGNORECASE
@@ -385,6 +391,56 @@ async def fetch_watch_details(
     return image_url, text_summary, probs
 
 
+def _build_watch_embed(
+    watch_num: str,
+    *,
+    is_tornado: bool,
+    watch_label: str,
+    color: discord.Color,
+    timestamp: datetime,
+    expires=None,
+    text_summary: Optional[str] = None,
+    probs: Optional[str] = None,
+    cache_path: Optional[str] = None,
+    footer: str = "SPC Watch Monitor",
+    paginator_index: Optional[Tuple[int, int]] = None,
+) -> discord.Embed:
+    """Canonical watch embed used by paginator, auto-post, iembot fast-path,
+    and the upgrade-edit. One place to fix styling drift."""
+    embed = discord.Embed(
+        title=(
+            f"{'🌪️' if is_tornado else '⛈️'}  "
+            f"{watch_label} #{int(watch_num)}"
+        ),
+        color=color,
+        timestamp=timestamp,
+    )
+    if expires:
+        embed.add_field(
+            name="Expires",
+            value=f"<t:{int(expires.timestamp())}:R>",
+            inline=True,
+        )
+    if text_summary:
+        embed.add_field(name="Details", value=text_summary[:1024], inline=False)
+    if probs:
+        embed.add_field(name="Probabilities", value=probs[:1024], inline=False)
+    if paginator_index is not None:
+        i, n = paginator_index
+        embed.set_footer(text=f"Watch {i + 1} of {n} · {footer}")
+    else:
+        embed.set_footer(text=footer)
+    if cache_path:
+        embed.set_image(url=f"attachment://watch_{watch_num}.gif")
+    return embed
+
+
+def _watch_files(watch_num: str, cache_path: Optional[str]) -> List[discord.File]:
+    if not cache_path:
+        return []
+    return [discord.File(cache_path, filename=f"watch_{watch_num}.gif")]
+
+
 class WatchPaginatorView(discord.ui.View):
     def __init__(self, watch_data, overview_path):
         super().__init__(timeout=300)
@@ -410,55 +466,23 @@ class WatchPaginatorView(discord.ui.View):
         expires = (
             nws_info.get("expires") if isinstance(nws_info, dict) else None
         )
-
         is_tornado = wtype == "TORNADO"
-        watch_label = (
-            "Tornado Watch" if is_tornado else "Severe Thunderstorm Watch"
-        )
-        color = discord.Color.red() if is_tornado else discord.Color.orange()
-
-        embed = discord.Embed(
-            title=(
-                f"{'🌪️' if is_tornado else '⛈️'}  "
-                f"{watch_label} #{int(watch_num)}"
-            ),
-            color=color,
+        return _build_watch_embed(
+            watch_num,
+            is_tornado=is_tornado,
+            watch_label="Tornado Watch" if is_tornado else "Severe Thunderstorm Watch",
+            color=discord.Color.red() if is_tornado else discord.Color.orange(),
             timestamp=datetime.now(timezone.utc),
+            expires=expires,
+            text_summary=text_summary,
+            probs=probs,
+            cache_path=cache_path,
+            paginator_index=(self.index, len(self.watch_data)),
         )
-        if expires:
-            embed.add_field(
-                name="Expires",
-                value=f"<t:{int(expires.timestamp())}:R>",
-                inline=True,
-            )
-        if text_summary:
-            embed.add_field(
-                name="Details", value=text_summary[:1024], inline=False
-            )
-        if probs:
-            embed.add_field(
-                name="Probabilities", value=probs[:1024], inline=False
-            )
-
-        embed.set_footer(
-            text=(
-                f"Watch {self.index + 1} of {len(self.watch_data)} "
-                f"· SPC Watch Monitor"
-            )
-        )
-        if cache_path:
-            embed.set_image(url=f"attachment://watch_{watch_num}.gif")
-        return embed
 
     def build_files(self):
         watch_num, _, _, _, _, cache_path = self.watch_data[self.index]
-        if cache_path:
-            return [
-                discord.File(
-                    cache_path, filename=f"watch_{watch_num}.gif"
-                )
-            ]
-        return []
+        return _watch_files(watch_num, cache_path)
 
     @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
     async def prev_btn(
@@ -544,17 +568,20 @@ async def _execute_watches(interaction: discord.Interaction, bot: commands.Bot):
             )
             overview_path = None
 
-    watch_data = []
-    for watch_num, nws_info in nws_watches.items():
+    async def _hydrate(watch_num: str, nws_info: dict):
         image_url, text_summary, probs = await fetch_watch_details(watch_num)
         cache_path = None
         if image_url:
             cache_path, _, _ = await download_single_image(
                 image_url, MANUAL_CACHE_FILE, bot.state.manual_cache
             )
-        watch_data.append(
-            (watch_num, nws_info, image_url, text_summary, probs, cache_path)
+        return (watch_num, nws_info, image_url, text_summary, probs, cache_path)
+
+    watch_data = list(
+        await asyncio.gather(
+            *[_hydrate(num, info) for num, info in nws_watches.items()]
         )
+    )
 
     view = WatchPaginatorView(watch_data, overview_path)
     if len(watch_data) == 1:
@@ -600,32 +627,18 @@ class WatchesCog(commands.Cog):
                         image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
                     )
 
-                embed = discord.Embed(
-                    title=(
-                        f"{'🌪️' if is_tornado else '⛈️'}  "
-                        f"{watch_label} #{int(watch_num)}"
-                    ),
+                embed = _build_watch_embed(
+                    watch_num,
+                    is_tornado=is_tornado,
+                    watch_label=watch_label,
                     color=color,
                     timestamp=datetime.now(timezone.utc),
+                    expires=expires,
+                    text_summary=text_summary,
+                    probs=probs,
+                    cache_path=cache_path,
                 )
-                if expires:
-                    embed.add_field(
-                        name="Expires",
-                        value=f"<t:{int(expires.timestamp())}:R>",
-                        inline=True,
-                    )
-                if text_summary:
-                    embed.add_field(name="Details", value=text_summary[:1024], inline=False)
-                if probs:
-                    embed.add_field(name="Probabilities", value=probs[:1024], inline=False)
-                embed.set_footer(text="SPC Watch Monitor")
-                if cache_path:
-                    embed.set_image(url=f"attachment://watch_{watch_num}.gif")
-
-                files = (
-                    [discord.File(cache_path, filename=f"watch_{watch_num}.gif")]
-                    if cache_path else []
-                )
+                files = _watch_files(watch_num, cache_path)
                 await message.edit(embed=embed, attachments=files)
                 logger.info(f"[WATCH] Upgraded embed for #{watch_num} with full SPC data")
                 return
@@ -660,33 +673,20 @@ class WatchesCog(commands.Cog):
                 image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
             )
 
-        embed = discord.Embed(
-            title=(
-                f"{'🌪️' if is_tornado else '⛈️'}  "
-                f"{watch_label} #{int(watch_num)}"
-            ),
+        embed = _build_watch_embed(
+            watch_num,
+            is_tornado=is_tornado,
+            watch_label=watch_label,
             color=color,
             timestamp=now_utc,
+            expires=expires,
+            text_summary=text_summary,
+            probs=probs,
+            cache_path=cache_path,
         )
-        if expires:
-            embed.add_field(
-                name="Expires",
-                value=f"<t:{int(expires.timestamp())}:R>",
-                inline=True,
-            )
-        if text_summary:
-            embed.add_field(name="Details", value=text_summary[:1024], inline=False)
-        if probs:
-            embed.add_field(name="Probabilities", value=probs[:1024], inline=False)
-        embed.set_footer(text="SPC Watch Monitor")
-        if cache_path:
-            embed.set_image(url=f"attachment://watch_{watch_num}.gif")
 
         try:
-            files = (
-                [discord.File(cache_path, filename=f"watch_{watch_num}.gif")]
-                if cache_path else []
-            )
+            files = _watch_files(watch_num, cache_path)
             message = await channel.send(embed=embed, files=files)
             # Do NOT add to active_watches here — let the NWS API poll
             # populate it with real expiry/zone data on the next cycle.
@@ -817,49 +817,20 @@ class WatchesCog(commands.Cog):
                         image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
                     )
 
-                embed = discord.Embed(
-                    title=(
-                        f"{'🌪️' if is_tornado else '⛈️'}  "
-                        f"{watch_label} #{int(watch_num)}"
-                    ),
+                embed = _build_watch_embed(
+                    watch_num,
+                    is_tornado=is_tornado,
+                    watch_label=watch_label,
                     color=color,
                     timestamp=now_utc,
+                    expires=expires,
+                    text_summary=text_summary,
+                    probs=probs,
+                    cache_path=cache_path,
                 )
-                if expires:
-                    embed.add_field(
-                        name="Expires",
-                        value=f"<t:{int(expires.timestamp())}:R>",
-                        inline=True,
-                    )
-                if text_summary:
-                    embed.add_field(
-                        name="Details",
-                        value=text_summary[:1024],
-                        inline=False,
-                    )
-                if probs:
-                    embed.add_field(
-                        name="Probabilities",
-                        value=probs[:1024],
-                        inline=False,
-                    )
-                embed.set_footer(text="SPC Watch Monitor")
-                if cache_path:
-                    embed.set_image(
-                        url=f"attachment://watch_{watch_num}.gif"
-                    )
 
                 try:
-                    files = (
-                        [
-                            discord.File(
-                                cache_path,
-                                filename=f"watch_{watch_num}.gif",
-                            )
-                        ]
-                        if cache_path
-                        else []
-                    )
+                    files = _watch_files(watch_num, cache_path)
                     await channel.send(embed=embed, files=files)
                     self.bot.state.posted_watches.add(watch_num)
                     await add_posted_watch(str(watch_num))

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Single source of truth for the release displayed in /help.
 # Bump this in the same commit as the git tag.
-__version__ = "5.0.2"
+__version__ = "5.1.0"
 
 load_dotenv()
 

--- a/main.py
+++ b/main.py
@@ -229,16 +229,21 @@ async def watchdog_task():
 
     from utils.http import http_session
 
+    # Probe an endpoint we actually depend on. Google works as a liveness
+    # check but tells us nothing about SPC/NWS reachability — the things
+    # that would silently break posts. HEAD keeps the check cheap.
     session_healthy = False
+    probe_url = "https://api.weather.gov/"
     if http_session is not None and not http_session.closed:
         try:
-            async with http_session.get(
-                "https://www.google.com",
+            async with http_session.head(
+                probe_url,
                 timeout=aiohttp.ClientTimeout(total=5),
+                allow_redirects=True,
             ) as r:
                 session_healthy = r.status < 500
         except Exception as e:
-            logger.warning(f"[WATCHDOG] Session probe failed: {e!r}")
+            logger.warning(f"[WATCHDOG] Session probe to {probe_url} failed: {e!r}")
 
     if not session_healthy:
         logger.warning(

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from utils.state_store import (
     get_all_hashes, get_posted_urls, get_posted_mds, get_posted_watches,
     get_state,
 )
+from utils.cache import hydrate_validators_from_store
 from utils.state import BotState
 from cogs import ALL_EXTENSIONS
 
@@ -111,6 +112,13 @@ async def setup_hook():
         if isinstance(urls, list) and urls:
             bot.state.last_posted_urls[day_key] = urls
             logger.info(f"[DB] Restored posted URLs for {day_key}")
+    # Warm the conditional-GET validator cache so the first poll after
+    # restart doesn't redownload every URL.
+    try:
+        await hydrate_validators_from_store()
+    except Exception as e:
+        logger.warning(f"[DB] validator hydration skipped: {e}")
+
     logger.info("[DB] Database ready")
 
     # Register failover cog

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -15,7 +15,12 @@ from config import (
     CENTRAL,
     SPC_SCHEDULE,
 )
-from utils.state_store import set_hash, set_hashes_batch
+from utils.state_store import (
+    set_hash,
+    set_hashes_batch,
+    get_all_validators,
+    set_validators,
+)
 from utils.change_detection import (
     calculate_hash_bytes,
     get_cache_path_for_url,
@@ -28,8 +33,26 @@ from utils.http import (
     http_head_ok,
 )
 
-# Per-URL HTTP validators (ETag, Last-Modified) from the most recent 200 response.
+# Per-URL HTTP validators (ETag, Last-Modified) from the most recent 200
+# response. Hydrated from the durable store at startup (see
+# hydrate_validators_from_store) so the first poll after a restart no
+# longer redownloads every URL.
 _validators_cache: Dict[str, Dict[str, str]] = {}
+_validators_hydrated: bool = False
+
+
+async def hydrate_validators_from_store() -> int:
+    """Load persisted validators into the in-process cache. Safe to call
+    more than once; only the first call hits the DB."""
+    global _validators_hydrated
+    if _validators_hydrated:
+        return len(_validators_cache)
+    stored = await get_all_validators()
+    if stored:
+        _validators_cache.update(stored)
+    _validators_hydrated = True
+    logger.info(f"[CACHE] Hydrated {len(_validators_cache)} HTTP validators from store")
+    return len(_validators_cache)
 
 logger = logging.getLogger("spc_bot")
 
@@ -84,18 +107,18 @@ def should_use_cache_for_manual(urls: List[str]) -> bool:
         logger.debug(f"[CACHE] Near Day {day} update window - forcing fresh download")
         return False
     
-    all_exist = all(
-        os.path.exists(get_cache_path_for_url(u)) for u in urls
-    )
-    if not all_exist:
-        return False
     ages = []
     for u in urls:
         p = get_cache_path_for_url(u)
+        # Single stat replaces exists() + getmtime(); on FileNotFoundError
+        # we can't use the cache at all.
         try:
-            ages.append(datetime.now() - datetime.fromtimestamp(os.path.getmtime(p)))
+            mtime = os.stat(p).st_mtime
+        except FileNotFoundError:
+            return False
         except Exception:
             return False
+        ages.append(datetime.now() - datetime.fromtimestamp(mtime))
     if ages and min(ages) > timedelta(days=3):
         logger.info("[CACHE] Cached files are older than 3 days; refreshing")
         return False
@@ -117,6 +140,18 @@ def format_timedelta(td: timedelta) -> str:
         parts.append(f"{hours}h")
     parts.append(f"{minutes}m")
     return " ".join(parts)
+
+
+async def _write_file(path: str, data: bytes) -> None:
+    """Off-loop file write. Images are small but during bursts (several
+    outlook images saved in one tick) synchronous writes stack up."""
+    loop = asyncio.get_running_loop()
+
+    def _do():
+        with open(path, "wb") as f:
+            f.write(data)
+
+    await loop.run_in_executor(None, _do)
 
 
 # ── Download helpers ─────────────────────────────────────────────────────────
@@ -142,8 +177,7 @@ async def download_single_image(
     cache_path = get_cache_path_for_url(url)
 
     try:
-        with open(cache_path, "wb") as f:
-            f.write(content)
+        await _write_file(cache_path, content)
         if url not in cache or cache.get(url) != h:
             cache[url] = h
             cache_type = "manual" if "manual" in cache_file_path else "auto"
@@ -205,9 +239,18 @@ async def check_partial_updates_parallel(
         if content is None or status != 200:
             return
 
-        # Remember fresh validators for next cycle
-        if validators:
+        # Remember fresh validators for next cycle, both in memory and
+        # in the durable store so a restart doesn't force redownload.
+        if validators and (validators.get("etag") or validators.get("last_modified")):
             _validators_cache[url] = validators
+            try:
+                await set_validators(
+                    url,
+                    validators.get("etag", ""),
+                    validators.get("last_modified", ""),
+                )
+            except Exception as e:
+                logger.debug(f"[CACHE] set_validators failed for {url}: {e}")
 
         if is_placeholder_image(content):
             return
@@ -243,8 +286,7 @@ async def save_downloaded_images(
                 continue
             cache_path = get_cache_path_for_url(url)
             try:
-                with open(cache_path, "wb") as f:
-                    f.write(content)
+                await _write_file(cache_path, content)
                 if h:
                     cache[url] = h
                     batch_updates[url] = h

--- a/utils/change_detection.py
+++ b/utils/change_detection.py
@@ -18,10 +18,21 @@ def calculate_hash_bytes(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+# Whitelist of extensions we actually serve. Anything else collapses
+# to ".img" — protects against query-string junk or path separators
+# sneaking into the filename via os.path.splitext on a raw URL.
+_ALLOWED_EXTS = {".gif", ".png", ".jpg", ".jpeg", ".webp", ".svg", ".bmp"}
+
+
 def get_cache_path_for_url(url: str) -> str:
+    # Strip query / fragment before extracting an extension; splitext on
+    # "x.gif?param=.." would otherwise return ".gif?param=..".
+    clean = url.split("?", 1)[0].split("#", 1)[0]
     md5 = hashlib.md5(url.encode()).hexdigest()
-    _, ext = os.path.splitext(url)
-    ext = ext if ext else ".img"
+    _, ext = os.path.splitext(clean)
+    ext = ext.lower() if ext else ""
+    if ext not in _ALLOWED_EXTS:
+        ext = ".img"
     filename = f"cached_{md5}{ext}"
     return os.path.join(CACHE_DIR, filename)
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -28,36 +28,60 @@ logger = logging.getLogger("spc_bot")
 DB_PATH = os.path.join(CACHE_DIR, "bot_state.db")
 _LOCK = asyncio.Lock()
 _db: Optional[aiosqlite.Connection] = None
-_connecting: bool = False
 _last_product_cache_prune: float = 0.0
 _PRODUCT_CACHE_PRUNE_INTERVAL = 3600.0  # 1 hour
+
+# Failure counter so the watchdog / health surface can notice when the
+# DB is silently dropping writes. Swallowing every exception by itself
+# would turn a full disk or schema drift into an invisible outage.
+_write_failure_count: int = 0
+_WRITE_FAILURE_ALERT_THRESHOLD = 5
+
+
+def get_write_failure_count() -> int:
+    return _write_failure_count
+
+
+def reset_write_failure_count() -> None:
+    global _write_failure_count
+    _write_failure_count = 0
 
 
 async def _write(sql: str, params: tuple, op: str) -> None:
     """Serialized write helper. Logs and swallows errors so callers degrade gracefully."""
+    global _write_failure_count
     try:
         db = await get_db()
         async with _LOCK:
             await db.execute(sql, params)
             await db.commit()
+        if _write_failure_count:
+            _write_failure_count = 0
     except Exception as e:
-        logger.warning(f"[DB] {op} failed: {e}")
+        _write_failure_count += 1
+        level = logger.error if _write_failure_count >= _WRITE_FAILURE_ALERT_THRESHOLD else logger.warning
+        level(f"[DB] {op} failed ({_write_failure_count} consecutive): {e}")
 
 
 async def _write_many(sql: str, rows: Iterable[tuple], op: str) -> None:
     """Serialized batch-write helper."""
+    global _write_failure_count
     try:
         db = await get_db()
         async with _LOCK:
             await db.executemany(sql, rows)
             await db.commit()
+        if _write_failure_count:
+            _write_failure_count = 0
     except Exception as e:
-        logger.warning(f"[DB] {op} failed: {e}")
+        _write_failure_count += 1
+        level = logger.error if _write_failure_count >= _WRITE_FAILURE_ALERT_THRESHOLD else logger.warning
+        level(f"[DB] {op} failed ({_write_failure_count} consecutive): {e}")
 
 
 async def get_db() -> aiosqlite.Connection:
     """Get or create the shared database connection (singleton)."""
-    global _db, _connecting
+    global _db
     if _db is not None:
         return _db
     async with _LOCK:
@@ -117,6 +141,12 @@ async def _create_tables(db: aiosqlite.Connection):
             text        TEXT NOT NULL,
             expires_at  REAL NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS http_validators (
+            url           TEXT PRIMARY KEY,
+            etag          TEXT NOT NULL DEFAULT '',
+            last_modified TEXT NOT NULL DEFAULT ''
+        );
     """)
 
 
@@ -149,10 +179,18 @@ async def check_integrity() -> bool:
 
 # ── Image hash operations ─────────────────────────────────────────────────────
 
-async def get_hash(url: str) -> Optional[str]:
-    """Get stored hash for a URL."""
+async def get_hash(url: str, cache_type: Optional[str] = None) -> Optional[str]:
+    """Get stored hash for a URL. When cache_type is given, scope the
+    lookup — saves a second Upstash round-trip at the state-store layer."""
     try:
         db = await get_db()
+        if cache_type:
+            async with db.execute(
+                "SELECT hash FROM image_hashes WHERE url = ? AND cache_type = ?",
+                (url, cache_type),
+            ) as cursor:
+                row = await cursor.fetchone()
+                return row["hash"] if row else None
         async with db.execute(
             "SELECT hash FROM image_hashes WHERE url = ?", (url,)
         ) as cursor:
@@ -376,6 +414,57 @@ async def get_product_cache(product_id: str) -> Optional[str]:
     except Exception as e:
         logger.warning(f"[DB] get_product_cache failed for {product_id}: {e}")
         return None
+
+
+# ── HTTP validators (ETag / Last-Modified) ─────────────────────────────────
+
+async def get_validators(url: str) -> Optional[dict]:
+    """Return {'etag': ..., 'last_modified': ...} for a URL, or None."""
+    try:
+        db = await get_db()
+        async with db.execute(
+            "SELECT etag, last_modified FROM http_validators WHERE url = ?",
+            (url,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            if not row:
+                return None
+            return {"etag": row["etag"], "last_modified": row["last_modified"]}
+    except Exception as e:
+        logger.warning(f"[DB] get_validators failed for {url}: {e}")
+        return None
+
+
+async def get_all_validators() -> dict:
+    """Bulk-load every stored validator for startup hydration."""
+    try:
+        db = await get_db()
+        async with db.execute(
+            "SELECT url, etag, last_modified FROM http_validators"
+        ) as cursor:
+            rows = await cursor.fetchall()
+            return {
+                row["url"]: {
+                    "etag": row["etag"],
+                    "last_modified": row["last_modified"],
+                }
+                for row in rows
+            }
+    except Exception as e:
+        logger.warning(f"[DB] get_all_validators failed: {e}")
+        return {}
+
+
+async def set_validators(url: str, etag: str, last_modified: str) -> None:
+    await _write(
+        """INSERT INTO http_validators (url, etag, last_modified)
+           VALUES (?, ?, ?)
+           ON CONFLICT(url) DO UPDATE SET
+             etag=excluded.etag,
+             last_modified=excluded.last_modified""",
+        (url, etag or "", last_modified or ""),
+        f"set_validators({url})",
+    )
 
 
 async def set_product_cache(product_id: str, text: str, ttl: int = 600):

--- a/utils/http.py
+++ b/utils/http.py
@@ -11,12 +11,26 @@ http_session: Optional[aiohttp.ClientSession] = None
 _session_lock = asyncio.Lock()
 
 
+def _default_user_agent() -> str:
+    # NWS/SPC require an identifying UA with contact info. Pulling the
+    # version here keeps the string aligned with the release tag.
+    try:
+        from config import __version__
+    except Exception:
+        __version__ = "dev"
+    contact = "https://github.com/full-bars/spc-bot"
+    return f"WxAlertSPCBot/{__version__} (+{contact})"
+
+
 async def ensure_session() -> aiohttp.ClientSession:
     global http_session
     async with _session_lock:
         if http_session is None or http_session.closed:
             connector = aiohttp.TCPConnector(limit=20, limit_per_host=10)
-            http_session = aiohttp.ClientSession(connector=connector)
+            http_session = aiohttp.ClientSession(
+                connector=connector,
+                headers={"User-Agent": _default_user_agent()},
+            )
             logger.info("Created new aiohttp ClientSession")
     return http_session
 
@@ -66,6 +80,8 @@ async def http_get_bytes(
                         f"Rate limited on {url} (status={response.status}), "
                         f"waiting {retry_after:.1f}s (attempt {attempt + 1}/{retries})"
                     )
+                    if attempt == retries - 1:
+                        return None, response.status
                     await asyncio.sleep(retry_after)
                     continue
                 # 304 Not Modified: caller passed validators; body is empty by spec.
@@ -78,6 +94,8 @@ async def http_get_bytes(
                 f"Error fetching {url} (attempt {attempt + 1}/{retries}): "
                 f"{type(e).__name__}: {e}"
             )
+            if attempt == retries - 1:
+                break
             await asyncio.sleep(2**attempt)
     return None, None
 
@@ -116,6 +134,8 @@ async def http_get_bytes_conditional(
                         f"Rate limited on {url} (status={response.status}), "
                         f"waiting {retry_after:.1f}s (attempt {attempt + 1}/{retries})"
                     )
+                    if attempt == retries - 1:
+                        return None, response.status, None
                     await asyncio.sleep(retry_after)
                     continue
                 if response.status == 304:
@@ -131,6 +151,8 @@ async def http_get_bytes_conditional(
                 f"Error fetching {url} (attempt {attempt + 1}/{retries}): "
                 f"{type(e).__name__}: {e}"
             )
+            if attempt == retries - 1:
+                break
             await asyncio.sleep(2**attempt)
     return None, None, None
 
@@ -145,6 +167,7 @@ async def http_get_text(
 
 
 async def http_head_ok(url: str, timeout: int = 5) -> bool:
+    """Cheap liveness check. HEAD only; no full-GET fallback (that defeats the point)."""
     try:
         session = await ensure_session()
         async with session.head(
@@ -153,11 +176,7 @@ async def http_head_ok(url: str, timeout: int = 5) -> bool:
             return r.status == 200
     except Exception as e:
         logger.warning(f"HEAD check failed for {url}: {type(e).__name__}: {e}")
-        try:
-            content, status = await http_get_bytes(url, retries=1, timeout=timeout)
-            return status == 200
-        except Exception:
-            return False
+        return False
 
 
 async def http_head_meta(url: str, timeout: int = 5) -> Optional[Dict[str, str]]:

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -159,6 +159,12 @@ async def _upstash_cmd(*args: Any) -> Any:
     if not UPSTASH_URL or not UPSTASH_TOKEN:
         raise _UpstashUnavailable("Upstash not configured")
 
+    # Reject None/bytes explicitly so we don't silently ship the literal
+    # "None" or a mojibake'd byte string to Upstash.
+    for a in args:
+        if a is None:
+            raise ValueError("_upstash_cmd: None is not a valid argument")
+
     from utils.http import ensure_session
 
     session = await ensure_session()
@@ -358,38 +364,42 @@ async def get_db():
 
 # ── Image hashes ─────────────────────────────────────────────────────────────
 
-async def get_hash(url: str) -> Optional[str]:
-    """Get the last-seen content hash for a URL. Cache → Upstash → SQLite."""
-    # Hashes are read inside get_all_hashes bulk-loads in normal
-    # operation; a per-url get_hash call is rare and the cache coverage
-    # reflects that — we key by the canonical hash key, not by the URL
-    # hash. A read-through cache entry is set under both encodings.
-    cache_key = f"hash::{url}"
+async def get_hash(url: str, cache_type: Optional[str] = None) -> Optional[str]:
+    """Get the last-seen content hash for a URL. Cache → Upstash → SQLite.
+
+    When the caller knows the cache_type (auto vs manual), pass it — that
+    cuts Upstash traffic in half by querying only the matching index
+    instead of both. Unscoped callers still work but cost 2 commands.
+    """
+    cache_key = f"hash::{cache_type or 'ANY'}::{url}"
     hit, val = _cache_get(cache_key)
     if hit:
         return val
 
-    # Upstash path: the per-type Hash is the authoritative index.
-    # We don't know the cache_type at this call, so query both in
-    # parallel (one round-trip wall-clock) and prefer auto on match.
     try:
-        auto_result, manual_result = await asyncio.gather(
-            _upstash_cmd("HGET", _k_hash_url_lookup("auto", url), url),
-            _upstash_cmd("HGET", _k_hash_url_lookup("manual", url), url),
-        )
-        result = auto_result or manual_result
+        if cache_type:
+            result = await _upstash_cmd(
+                "HGET", _k_hash_url_lookup(cache_type, url), url
+            )
+        else:
+            auto_result, manual_result = await asyncio.gather(
+                _upstash_cmd("HGET", _k_hash_url_lookup("auto", url), url),
+                _upstash_cmd("HGET", _k_hash_url_lookup("manual", url), url),
+            )
+            result = auto_result or manual_result
         _cache_set(cache_key, result)
         return result
     except _UpstashUnavailable as e:
         logger.debug(f"[STATE] get_hash({url}) falling back to SQLite: {e}")
-        val = await sqlite_backend.get_hash(url)
+        val = await sqlite_backend.get_hash(url, cache_type)
         _cache_set(cache_key, val, ttl=CACHE_TTL_SECONDS / 2)
         return val
 
 
 async def set_hash(url: str, hash_val: str, cache_type: str = "auto") -> None:
     """Store the content hash for a URL. Cache + Upstash + SQLite."""
-    _cache_set(f"hash::{url}", hash_val)
+    _cache_set(f"hash::{cache_type}::{url}", hash_val)
+    _cache_set(f"hash::ANY::{url}", hash_val)
     # Invalidate any cached bulk-load of this cache_type.
     _cache_invalidate(f"all_hashes::{cache_type}")
 
@@ -448,7 +458,8 @@ async def set_hashes_batch(hashes: Dict[str, str], cache_type: str = "auto") -> 
 
     # Warm local cache for any subsequent reads in this process.
     for url, h in hashes.items():
-        _cache_set(f"hash::{url}", h)
+        _cache_set(f"hash::{cache_type}::{url}", h)
+        _cache_set(f"hash::ANY::{url}", h)
     _cache_invalidate(f"all_hashes::{cache_type}")
 
     await sqlite_backend.set_hashes_batch(hashes, cache_type)
@@ -636,6 +647,24 @@ async def set_product_cache(product_id: str, text: str, ttl: int = 600) -> None:
     except _UpstashUnavailable as e:
         logger.warning(f"[STATE] set_product_cache({product_id}) queued: {e}")
         await _enqueue_dirty("set_product_cache", (product_id, text, ttl))
+
+
+# ── HTTP validators (ETag / Last-Modified) ─────────────────────────────────
+# SQLite-only by design — the conditional-GET flow runs every 60s per URL,
+# and pushing every validator update through Upstash would blow the free-
+# tier budget. SQLite is the authoritative source here.
+
+
+async def get_validators(url: str) -> Optional[Dict[str, str]]:
+    return await sqlite_backend.get_validators(url)
+
+
+async def get_all_validators() -> Dict[str, Dict[str, str]]:
+    return await sqlite_backend.get_all_validators()
+
+
+async def set_validators(url: str, etag: str, last_modified: str) -> None:
+    await sqlite_backend.set_validators(url, etag, last_modified)
 
 
 # ── Startup resync ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the 16-item review from the efficiency/security scrutiny. Five logical commits, all 171 tests green.

### Efficiency
- **Conditional-GET validators persist across restarts** (`utils/cache.py`, `utils/db.py`, `utils/state_store.py`). Previously `_validators_cache` was process-local, so every restart redownloaded every URL on the first poll. Now hydrated from a new `http_validators` SQLite table via `hydrate_validators_from_store()` in `setup_hook`.
- **`get_hash` is cache_type-aware** (`utils/state_store.py`). Optional `cache_type` arg scopes the Upstash lookup to one HGET instead of racing both — cuts that code path's command cost in half.
- **`http_head_ok` no longer GETs on HEAD failure** (`utils/http.py`). A liveness probe that downloads the body defeats the point.
- **`_execute_watches` parallelizes per-watch details** (`cogs/watches.py`) via `asyncio.gather`. N active watches used to mean N sequential round-trips.
- **`fetch_watch_details` parallelizes SPC main + prob page fetches** — they were always independent.
- **`fetch_latest_watch_numbers` HTML fallback** now classifies candidate watches in parallel.
- **`should_use_cache_for_manual`** uses one `os.stat` per URL instead of `exists()` + `getmtime()`.
- **Watchdog probes `api.weather.gov`** (`main.py`) instead of `google.com`. The new target actually reflects whether the bot's upstream is reachable. HEAD keeps it cheap.
- **Duplicated watch embed-building collapsed** to `_build_watch_embed` / `_watch_files` helpers. Four drift-prone copies → one.
- **Disk writes moved off the event loop** (`utils/cache.py`) via `run_in_executor`.
- **`http_get_bytes` no longer sleeps after the final attempt** and now surfaces the terminal 429/503 status to callers.

### Security / correctness
- **NWS-compliant `User-Agent`** set on the default `ClientSession` (`utils/http.py`). NWS throttles unidentified clients.
- **Cache-path extension sanitized** (`utils/change_detection.py`). Whitelist of image exts, query/fragment stripped before `splitext` — a URL like `x.gif?param=..%2F..` can no longer shape the filename.
- **`_upstash_cmd` rejects `None` args** (`utils/state_store.py`). Previously `str(None)` silently shipped the literal `"None"`.
- **DB write-failure counter** (`utils/db.py`). Consecutive failures escalate from warning to error at a threshold of 5 so a persistent issue (full disk, schema drift) is visible instead of scrolling past.
- **Dead `_connecting` flag removed** from `utils/db.py`.

## Test plan
- [x] `pytest -q` — 171/171 pass
- [ ] Manual: deploy to staging, confirm first poll after restart actually returns 304s on cached URLs (validator hydration working)
- [ ] Manual: confirm watchdog warning mentions `api.weather.gov` if the session is sick
- [ ] Manual: confirm NWS API responses include the new UA by checking access logs if available