### PR TITLE
perf: conditional GET, jitter, LRU bounds; drop dead code

### DIFF
--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -22,10 +22,25 @@ from utils.cache import (
     download_single_image,
 )
 from utils.change_detection import get_cache_path_for_url, is_placeholder_image
-from utils.http import http_get_bytes, http_get_text
+from utils.http import http_get_bytes, http_get_bytes_conditional, http_get_text
 from utils.state_store import add_posted_watch, prune_posted_watches
 
 logger = logging.getLogger("spc_bot")
+
+# Hoisted patterns — VTEC is scanned in a loop over every active feature,
+# so caching the compiled form measurably helps on large NWS payloads.
+_VTEC_RE = re.compile(
+    r"/[^.]+\.[^.]+\.[^.]+\.(SV|TO)\.A\.(\d{4})\.",
+    re.IGNORECASE,
+)
+_WW_HREF_RE = re.compile(r'href="[^"]*ww(\d+)\.html"', re.IGNORECASE)
+_TORNADO_WATCH_RE = re.compile(r"Tornado Watch", re.IGNORECASE)
+
+# Conditional-GET state for the NWS active-alerts feed. Validators let us
+# 304 most 2-minute polls; _last_parsed holds the parsed dict to return
+# on 304 so callers see no behavioral difference vs. a fresh fetch.
+_nws_validators: Dict[str, str] = {}
+_nws_last_parsed: Optional[Dict[str, dict]] = None
 
 
 
@@ -35,14 +50,26 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
     Returns dict: watch_num -> {"type": "SVR"|"TORNADO", "expires": datetime}
     Deduplicates by watch number from the VTEC string.
     """
+    global _nws_last_parsed
     # Keep retries×timeout well under the 2-minute auto_post_watches
     # cycle so a bad NWS API window doesn't stall successive ticks.
-    content, status = await http_get_bytes(NWS_ALERTS_URL, retries=2, timeout=15)
+    content, status, validators = await http_get_bytes_conditional(
+        NWS_ALERTS_URL,
+        etag=_nws_validators.get("etag") or None,
+        last_modified=_nws_validators.get("last_modified") or None,
+        retries=2,
+        timeout=15,
+    )
+    if status == 304 and _nws_last_parsed is not None:
+        return _nws_last_parsed
     if not content or status != 200:
         logger.warning(
             f"[WATCH] NWS API returned status {status} — will retry next cycle"
         )
         return None
+    if validators and (validators.get("etag") or validators.get("last_modified")):
+        _nws_validators["etag"] = validators.get("etag", "")
+        _nws_validators["last_modified"] = validators.get("last_modified", "")
     try:
         data = _json.loads(content)
     except Exception as e:
@@ -55,11 +82,7 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
         vtec_list = props.get("parameters", {}).get("VTEC", [])
         expires_str = props.get("expires") or props.get("ends")
         for vtec in vtec_list:
-            m = re.search(
-                r"/[^.]+\.[^.]+\.[^.]+\.(SV|TO)\.A\.(\d{4})\.",
-                vtec,
-                re.IGNORECASE,
-            )
+            m = _VTEC_RE.search(vtec)
             if not m:
                 continue
             watch_num = m.group(2).zfill(4)
@@ -83,6 +106,7 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
                 "expires": expires_dt,
                 "affected_zones": affected_zones,
             }
+    _nws_last_parsed = result
     return result
 
 
@@ -105,7 +129,7 @@ async def fetch_latest_watch_numbers() -> List[Tuple[str, str]]:
 
     seen = []
     seen_set = set()
-    for m in re.finditer(r'href="[^"]*ww(\d+)\.html"', html, re.IGNORECASE):
+    for m in _WW_HREF_RE.finditer(html):
         num = m.group(1).zfill(4)
         if num in seen_set:
             continue
@@ -117,7 +141,7 @@ async def fetch_latest_watch_numbers() -> List[Tuple[str, str]]:
             f"https://www.spc.noaa.gov/products/watch/ww{num}.html"
         )
         wtype = "SVR"
-        if watch_html and re.search(r"Tornado Watch", watch_html, re.IGNORECASE):
+        if watch_html and _TORNADO_WATCH_RE.search(watch_html):
             wtype = "TORNADO"
         return num, wtype
 

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -40,9 +40,9 @@ class TestFetchActiveWatchesNWS:
         payload = self._make_response([feature])
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(payload, 200),
+            return_value=(payload, 200, None),
         ):
             result = await fetch_active_watches_nws()
 
@@ -62,9 +62,9 @@ class TestFetchActiveWatchesNWS:
         payload = self._make_response([feature])
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(payload, 200),
+            return_value=(payload, 200, None),
         ):
             result = await fetch_active_watches_nws()
 
@@ -83,9 +83,9 @@ class TestFetchActiveWatchesNWS:
         payload = self._make_response([feature])
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(payload, 200),
+            return_value=(payload, 200, None),
         ):
             result = await fetch_active_watches_nws()
 
@@ -103,9 +103,9 @@ class TestFetchActiveWatchesNWS:
         ])
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(payload, 200),
+            return_value=(payload, 200, None),
         ):
             result = await fetch_active_watches_nws()
 
@@ -121,9 +121,9 @@ class TestFetchActiveWatchesNWS:
         payload = self._make_response([feature])
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(payload, 200),
+            return_value=(payload, 200, None),
         ):
             result = await fetch_active_watches_nws()
 
@@ -141,9 +141,9 @@ class TestFetchActiveWatchesNWS:
         payload = self._make_response([feature])
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(payload, 200),
+            return_value=(payload, 200, None),
         ):
             result = await fetch_active_watches_nws()
 
@@ -156,9 +156,9 @@ class TestFetchActiveWatchesNWS:
         from cogs.watches import fetch_active_watches_nws
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(None, 500),
+            return_value=(None, 500, None),
         ):
             result = await fetch_active_watches_nws()
 
@@ -170,9 +170,9 @@ class TestFetchActiveWatchesNWS:
         from cogs.watches import fetch_active_watches_nws
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(b"not json {{{", 200),
+            return_value=(b"not json {{{", 200, None),
         ):
             result = await fetch_active_watches_nws()
 
@@ -186,9 +186,9 @@ class TestFetchActiveWatchesNWS:
         payload = self._make_response([])
 
         with patch(
-            "cogs.watches.http_get_bytes",
+            "cogs.watches.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(payload, 200),
+            return_value=(payload, 200, None),
         ):
             result = await fetch_active_watches_nws()
 

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -8,6 +8,7 @@ Content-change detection is handled by utils.change_detection.
 import asyncio
 import logging
 import os
+from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
@@ -28,7 +29,6 @@ from utils.change_detection import (
 )
 from utils.http import (
     ensure_session,
-    http_get_bytes,
     http_get_bytes_conditional,
     http_head_ok,
 )
@@ -36,9 +36,26 @@ from utils.http import (
 # Per-URL HTTP validators (ETag, Last-Modified) from the most recent 200
 # response. Hydrated from the durable store at startup (see
 # hydrate_validators_from_store) so the first poll after a restart no
-# longer redownloads every URL.
-_validators_cache: Dict[str, Dict[str, str]] = {}
+# longer redownloads every URL. LRU-bounded so long-running processes
+# don't grow the dict without bound as URLs rotate (e.g. dated filenames).
+_VALIDATORS_CACHE_MAX = 2048
+_validators_cache: "OrderedDict[str, Dict[str, str]]" = OrderedDict()
 _validators_hydrated: bool = False
+
+
+def _validators_set(url: str, validators: Dict[str, str]) -> None:
+    _validators_cache[url] = validators
+    _validators_cache.move_to_end(url)
+    while len(_validators_cache) > _VALIDATORS_CACHE_MAX:
+        _validators_cache.popitem(last=False)
+
+
+def _validators_get(url: str) -> Dict[str, str]:
+    v = _validators_cache.get(url)
+    if v is not None:
+        _validators_cache.move_to_end(url)
+        return v
+    return {}
 
 
 async def hydrate_validators_from_store() -> int:
@@ -92,7 +109,23 @@ def is_near_spc_update(day: int) -> bool:
     return False
 
 
-def should_use_cache_for_manual(urls: List[str]) -> bool:
+def _stat_mtimes(paths: List[str]) -> Optional[List[float]]:
+    """Stat a batch of files. Returns None if any file is missing or
+    unreadable; otherwise a list of mtimes aligned with paths. Runs in
+    a worker thread via run_in_executor to keep the event loop free
+    on slow storage."""
+    out = []
+    for p in paths:
+        try:
+            out.append(os.stat(p).st_mtime)
+        except FileNotFoundError:
+            return None
+        except Exception:
+            return None
+    return out
+
+
+async def should_use_cache_for_manual(urls: List[str]) -> bool:
     day = None
     s = " ".join(urls)
     if "day1" in s:
@@ -106,19 +139,14 @@ def should_use_cache_for_manual(urls: List[str]) -> bool:
     if is_near_spc_update(day):
         logger.debug(f"[CACHE] Near Day {day} update window - forcing fresh download")
         return False
-    
-    ages = []
-    for u in urls:
-        p = get_cache_path_for_url(u)
-        # Single stat replaces exists() + getmtime(); on FileNotFoundError
-        # we can't use the cache at all.
-        try:
-            mtime = os.stat(p).st_mtime
-        except FileNotFoundError:
-            return False
-        except Exception:
-            return False
-        ages.append(datetime.now() - datetime.fromtimestamp(mtime))
+
+    paths = [get_cache_path_for_url(u) for u in urls]
+    loop = asyncio.get_running_loop()
+    mtimes = await loop.run_in_executor(None, _stat_mtimes, paths)
+    if mtimes is None:
+        return False
+    now = datetime.now()
+    ages = [now - datetime.fromtimestamp(m) for m in mtimes]
     if ages and min(ages) > timedelta(days=3):
         logger.info("[CACHE] Cached files are older than 3 days; refreshing")
         return False
@@ -161,10 +189,38 @@ async def download_single_image(
     cache: Dict[str, str],
     retries: int = 3,
 ) -> Tuple[Optional[str], Optional[bytes], Optional[str]]:
-    content, status = await http_get_bytes(url, retries=retries)
+    prev = _validators_get(url)
+    content, status, validators = await http_get_bytes_conditional(
+        url,
+        etag=prev.get("etag") or None,
+        last_modified=prev.get("last_modified") or None,
+        retries=retries,
+    )
+    cache_path = get_cache_path_for_url(url)
+
+    # 304: body unchanged. If we already have the file on disk we can
+    # return it; if not (rare — validator without disk file), fall back
+    # to an unconditional fetch next tick by dropping the validator.
+    if status == 304:
+        if os.path.exists(cache_path):
+            return cache_path, None, cache.get(url)
+        _validators_cache.pop(url, None)
+        return None, None, None
+
     if content is None or status != 200:
         logger.warning(f"Failed to download {url} (status={status})")
         return None, None, None
+
+    if validators and (validators.get("etag") or validators.get("last_modified")):
+        _validators_set(url, validators)
+        try:
+            await set_validators(
+                url,
+                validators.get("etag", ""),
+                validators.get("last_modified", ""),
+            )
+        except Exception as e:
+            logger.debug(f"[CACHE] set_validators failed for {url}: {e}")
 
     if is_placeholder_image(content):
         logger.info(
@@ -174,14 +230,12 @@ async def download_single_image(
         return None, content, None
 
     h = calculate_hash_bytes(content)
-    cache_path = get_cache_path_for_url(url)
 
     try:
         await _write_file(cache_path, content)
         if url not in cache or cache.get(url) != h:
             cache[url] = h
             cache_type = "manual" if "manual" in cache_file_path else "auto"
-            # Standardized await for DB integrity
             await set_hash(url, h, cache_type)
             logger.debug(f"Updated cache hash for {url}: {h}")
         logger.debug(f"Downloaded and saved: {url} -> {cache_path}")
@@ -197,7 +251,7 @@ async def download_images_parallel(
     cache: Dict[str, str],
     use_cached: bool = False,
 ) -> List[str]:
-    if use_cached and should_use_cache_for_manual(urls):
+    if use_cached and await should_use_cache_for_manual(urls):
         files = [
             get_cache_path_for_url(u)
             for u in urls
@@ -221,28 +275,23 @@ async def check_partial_updates_parallel(
     """
     await ensure_session()
     total_count = len(urls)
-    downloaded_data = {}
-    updated_count = 0
-    not_modified_count = 0
+    downloaded_data: Dict[str, Tuple[bytes, Optional[str]]] = {}
 
-    async def _check_one(url: str):
-        nonlocal updated_count, not_modified_count
-        prev = _validators_cache.get(url, {})
+    async def _check_one(url: str) -> Tuple[str, int]:
+        """Return (url, outcome) where outcome is 1=updated, 2=304, 0=other."""
+        prev = _validators_get(url)
         content, status, validators = await http_get_bytes_conditional(
             url,
             etag=prev.get("etag") or None,
             last_modified=prev.get("last_modified") or None,
         )
         if status == 304:
-            not_modified_count += 1
-            return
+            return url, 2
         if content is None or status != 200:
-            return
+            return url, 0
 
-        # Remember fresh validators for next cycle, both in memory and
-        # in the durable store so a restart doesn't force redownload.
         if validators and (validators.get("etag") or validators.get("last_modified")):
-            _validators_cache[url] = validators
+            _validators_set(url, validators)
             try:
                 await set_validators(
                     url,
@@ -253,14 +302,17 @@ async def check_partial_updates_parallel(
                 logger.debug(f"[CACHE] set_validators failed for {url}: {e}")
 
         if is_placeholder_image(content):
-            return
+            return url, 0
 
         h = calculate_hash_bytes(content)
         if url not in cache or cache.get(url) != h:
             downloaded_data[url] = (content, h)
-            updated_count += 1
+            return url, 1
+        return url, 0
 
-    await asyncio.gather(*[_check_one(u) for u in urls])
+    outcomes = await asyncio.gather(*[_check_one(u) for u in urls])
+    updated_count = sum(1 for _, o in outcomes if o == 1)
+    not_modified_count = sum(1 for _, o in outcomes if o == 2)
 
     log = logger.info if updated_count > 0 else logger.debug
     log(

--- a/utils/change_detection.py
+++ b/utils/change_detection.py
@@ -4,14 +4,10 @@
 import hashlib
 import logging
 import os
-from typing import Dict
 
 from config import CACHE_DIR
 
 logger = logging.getLogger("spc_bot")
-
-# Per-URL HEAD snapshot from last poll cycle
-_head_cache: Dict[str, Dict[str, str]] = {}
 
 
 def calculate_hash_bytes(content: bytes) -> str:
@@ -59,36 +55,3 @@ def is_placeholder_image(content: bytes) -> bool:
     return False
 
 
-async def head_changed(url: str, http_head_meta_fn) -> bool:
-    """
-    Check if a URL has changed since the last poll using HEAD headers.
-
-    Returns True if the content appears to have changed (or if we can't tell).
-    """
-    meta = await http_head_meta_fn(url)
-    if meta is None:
-        return True
-
-    prev = _head_cache.get(url, {})
-    if not prev:
-        _head_cache[url] = meta
-        return True
-
-    changed = (
-        (meta["etag"] and meta["etag"] != prev.get("etag"))
-        or (meta["last_modified"] and meta["last_modified"] != prev.get("last_modified"))
-        or (meta["content_length"] and meta["content_length"] != prev.get("content_length"))
-    )
-    if changed:
-        _head_cache[url] = meta
-
-    # If no useful headers at all, assume changed
-    if not any(meta.values()):
-        return True
-
-    return changed
-
-
-def clear_head_cache_for_url(url: str):
-    """Remove a URL from the HEAD cache (e.g. after migration)."""
-    _head_cache.pop(url, None)

--- a/utils/http.py
+++ b/utils/http.py
@@ -1,6 +1,7 @@
 # utils/http.py
 import asyncio
 import logging
+import random
 from typing import Dict, Optional, Tuple
 
 import aiohttp
@@ -26,7 +27,15 @@ async def ensure_session() -> aiohttp.ClientSession:
     global http_session
     async with _session_lock:
         if http_session is None or http_session.closed:
-            connector = aiohttp.TCPConnector(limit=20, limit_per_host=10)
+            # ttl_dns_cache avoids re-resolving the same handful of NWS/SPC
+            # hosts on every request; keepalive_timeout holds TCP/TLS
+            # connections open across the 30s–2min poll cadence.
+            connector = aiohttp.TCPConnector(
+                limit=20,
+                limit_per_host=10,
+                ttl_dns_cache=300,
+                keepalive_timeout=75,
+            )
             http_session = aiohttp.ClientSession(
                 connector=connector,
                 headers={"User-Agent": _default_user_agent()},
@@ -47,6 +56,15 @@ async def close_session():
             http_session = None
 
 
+def _backoff_delay(attempt: int) -> float:
+    """Exponential backoff with jitter.
+
+    Parallel fetches that all 429 at once would otherwise retry in lockstep
+    and re-trigger the rate limit. Full jitter spreads them out.
+    """
+    return random.uniform(0, 2 ** attempt)
+
+
 def _get_retry_after(response: aiohttp.ClientResponse) -> Optional[float]:
     """Extract Retry-After from response headers, if present."""
     val = response.headers.get("Retry-After")
@@ -64,40 +82,17 @@ async def http_get_bytes(
     timeout: int = 10,
     headers: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[bytes], Optional[int]]:
-    for attempt in range(retries):
-        try:
-            session = await ensure_session()
-            async with session.get(
-                url,
-                timeout=aiohttp.ClientTimeout(total=timeout),
-                headers=headers,
-            ) as response:
-                # Respect Retry-After on 429 or 503
-                if response.status in (429, 503):
-                    retry_after = _get_retry_after(response) or (2**attempt)
-                    retry_after = min(retry_after, 60)  # cap at 60s
-                    logger.warning(
-                        f"Rate limited on {url} (status={response.status}), "
-                        f"waiting {retry_after:.1f}s (attempt {attempt + 1}/{retries})"
-                    )
-                    if attempt == retries - 1:
-                        return None, response.status
-                    await asyncio.sleep(retry_after)
-                    continue
-                # 304 Not Modified: caller passed validators; body is empty by spec.
-                if response.status == 304:
-                    return None, 304
-                content = await response.read()
-                return content, response.status
-        except Exception as e:
-            logger.warning(
-                f"Error fetching {url} (attempt {attempt + 1}/{retries}): "
-                f"{type(e).__name__}: {e}"
-            )
-            if attempt == retries - 1:
-                break
-            await asyncio.sleep(2**attempt)
-    return None, None
+    """Unconditional GET. Thin wrapper over the conditional variant with
+    no validators passed in, so the server cannot 304."""
+    content, status, _ = await http_get_bytes_conditional(
+        url,
+        etag=None,
+        last_modified=None,
+        retries=retries,
+        timeout=timeout,
+        extra_headers=headers,
+    )
+    return content, status
 
 
 async def http_get_bytes_conditional(
@@ -106,6 +101,7 @@ async def http_get_bytes_conditional(
     last_modified: Optional[str] = None,
     retries: int = 3,
     timeout: int = 10,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[bytes], Optional[int], Optional[Dict[str, str]]]:
     """Conditional GET. Returns (content, status, validators).
 
@@ -113,7 +109,7 @@ async def http_get_bytes_conditional(
       prior values so callers can keep them.
     - On 200, validators carries the fresh ETag / Last-Modified for storage.
     """
-    headers: Dict[str, str] = {}
+    headers: Dict[str, str] = dict(extra_headers) if extra_headers else {}
     if etag:
         headers["If-None-Match"] = etag
     if last_modified:
@@ -128,7 +124,7 @@ async def http_get_bytes_conditional(
                 headers=headers or None,
             ) as response:
                 if response.status in (429, 503):
-                    retry_after = _get_retry_after(response) or (2**attempt)
+                    retry_after = _get_retry_after(response) or _backoff_delay(attempt)
                     retry_after = min(retry_after, 60)
                     logger.warning(
                         f"Rate limited on {url} (status={response.status}), "
@@ -153,7 +149,7 @@ async def http_get_bytes_conditional(
             )
             if attempt == retries - 1:
                 break
-            await asyncio.sleep(2**attempt)
+            await asyncio.sleep(_backoff_delay(attempt))
     return None, None, None
 
 


### PR DESCRIPTION
## Summary
- HTTP: `TCPConnector` gains `ttl_dns_cache=300` + `keepalive_timeout=75`; all retry sleeps use full-jitter backoff to avoid lockstep thundering-herd on 429/503
- HTTP: `http_get_bytes` collapsed to a thin wrapper over `http_get_bytes_conditional` (added `extra_headers` passthrough) — removes a duplicated retry loop
- Cache: `download_single_image` now uses conditional GET so auto-posts benefit from 304s, not just the partial-update pass
- Cache: `_validators_cache` is now LRU-bounded (2048) via `OrderedDict`
- Cache: `check_partial_updates_parallel` returns tuples from `gather` instead of mutating counters via `nonlocal`
- Cache: `should_use_cache_for_manual` runs stat loop in an executor
- Watches: compile VTEC / href / tornado-watch regex at module level; `fetch_active_watches_nws` uses conditional GET with a module-level last-parsed cache so 304 short-circuits re-parsing
- Change detection: drop unused `head_changed` / `clear_head_cache_for_url` / `_head_cache` (zero callers)

## Test plan
- [x] `pytest` — 171 passed
- [ ] Smoke-check that watches/outlooks auto-post loop still fires on the first tick after deploy
- [ ] Confirm no spike in 429s from SPC/NWS after rollout