### PR TITLE
chore: lint/hygiene sweep (v5.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.1.2] — 2026-04-22
+
+### Changed
+- `logger.error(..., exc_info=True)` and in-`except` `logger.error(...)`
+  calls converted to `logger.exception(...)` across cogs and utils so
+  tracebacks are captured consistently (ruff G201/TRY400).
+- Re-raised `RuntimeError` / `ValueError` in `cogs/radar/downloads.py`,
+  `cogs/radar/s3.py`, `cogs/sounding_utils.py` now use `raise ... from e`
+  to preserve the original exception cause (ruff B904).
+- `zip(...)` calls in `main.py` and `utils/cache.py` pass `strict=True`
+  to catch length mismatches instead of silently truncating (ruff B905).
+- `config.py` opens `products.json` with `encoding="utf-8"` for
+  portability.
+- `main.py` hoists the `aiohttp` import to the top of the file
+  (ruff E402).
+
+### Removed
+- Stray empty `│/` directory at repo root.
+
 ## [5.1.1] — 2026-04-22
 
 ### Changed

--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -180,7 +180,7 @@ class CSUMLPCog(commands.Cog):
             else:
                 await source.send(title, files=[discord.File(cache_path)])
         except discord.HTTPException as e:
-            logger.error(f"[CSU-MLP] Send failed for Day {day}: {e}")
+            logger.exception(f"[CSU-MLP] Send failed for Day {day}: {e}")
 
     # ── Slash command ─────────────────────────────────────────────────────
 
@@ -299,8 +299,8 @@ class CSUMLPCog(commands.Cog):
                 self.bot.state.last_post_times[f"csu_day{day}"] = now_utc
                 logger.info(f"[CSU-MLP] Auto-posted Day {day} ({label})")
             except Exception as e:
-                logger.error(
-                    f"[CSU-MLP] Failed to post Day {day}: {e}", exc_info=True
+                logger.exception(
+                    f"[CSU-MLP] Failed to post Day {day}: {e}"
                 )
 
         # Auto-post 6-panel products
@@ -331,7 +331,7 @@ class CSUMLPCog(commands.Cog):
                 self.bot.state.last_post_times[f"csu_{state_key}"] = now_utc
                 logger.info(f"[CSU-MLP] Auto-posted {label_name} ({label})")
             except Exception as e:
-                logger.error(f"[CSU-MLP] Failed to post {label_name}: {e}", exc_info=True)
+                logger.exception(f"[CSU-MLP] Failed to post {label_name}: {e}")
 
     @csu_mlp_daily_poll.after_loop
     async def after_csu_mlp_poll(self):

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -159,7 +159,7 @@ class FailoverCog(commands.Cog):
             else:
                 await self._standby_cycle()
         except Exception as e:
-            logger.error(f"[FAILOVER] Sync loop error: {e}")
+            logger.exception(f"[FAILOVER] Sync loop error: {e}")
 
     async def _primary_cycle(self) -> None:
         """Hold the lease; step down if someone else grabbed it."""
@@ -229,7 +229,7 @@ class FailoverCog(commands.Cog):
         try:
             await self._rehydrate_bot_state()
         except Exception as e:
-            logger.error(f"[FAILOVER] Rehydrate on promotion failed: {e}")
+            logger.exception(f"[FAILOVER] Rehydrate on promotion failed: {e}")
 
         # Push anything SQLite has that Upstash is missing. Handles the
         # edge case where this node's prior writes during an Upstash
@@ -237,20 +237,20 @@ class FailoverCog(commands.Cog):
         try:
             await state_store.resync_to_upstash()
         except Exception as e:
-            logger.error(f"[FAILOVER] Resync on promotion failed: {e}")
+            logger.exception(f"[FAILOVER] Resync on promotion failed: {e}")
 
         for ext in ALL_EXTENSIONS:
             try:
                 await self.bot.load_extension(ext)
                 logger.info(f"[FAILOVER] Loaded {ext}")
             except Exception as e:
-                logger.error(f"[FAILOVER] Failed to load {ext}: {e}")
+                logger.exception(f"[FAILOVER] Failed to load {ext}: {e}")
 
         try:
             synced = await self.bot.tree.sync()
             logger.info(f"[FAILOVER] Synced {len(synced)} slash commands")
         except Exception as e:
-            logger.error(f"[FAILOVER] Failed to sync commands: {e}")
+            logger.exception(f"[FAILOVER] Failed to sync commands: {e}")
 
     async def _rehydrate_bot_state(self) -> None:
         """Pull authoritative state from Upstash into BotState mirrors.

--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -35,7 +35,7 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
     except asyncio.TimeoutError:
         process.kill()
         await process.communicate()
-        logger.error(f"[HODO] vad.py timed out for {site}")
+        logger.exception(f"[HODO] vad.py timed out for {site}")
         await interaction.followup.send(
             f"⏱️ Timed out fetching data for `{site}`. The radar may be offline or have no recent VWP data.",
             ephemeral=True,

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -65,7 +65,7 @@ async def fetch_latest_md_numbers() -> List[str]:
                 # but for simplicity we'll just return the unique ones in the feed.
                 return sorted(list(md_nums), reverse=True)
         except Exception as e:
-            logger.error(f"[MD] IEM fallback for index failed: {e}")
+            logger.exception(f"[MD] IEM fallback for index failed: {e}")
         return []
 
     numbers = re.findall(
@@ -302,7 +302,7 @@ class MesoscaleCog(commands.Cog):
             self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
             logger.info(f"[MD] iembot-triggered: posted MD #{md_num}")
         except discord.HTTPException as e:
-            logger.error(f"[MD] iembot-triggered send failed for #{md_num}: {e}")
+            logger.exception(f"[MD] iembot-triggered send failed for #{md_num}: {e}")
 
     @tasks.loop(seconds=30)
     async def auto_post_md(self):
@@ -343,7 +343,7 @@ class MesoscaleCog(commands.Cog):
                                 f"[MD] Posted cancellation for #{md_num}"
                             )
                         except discord.HTTPException as e:
-                            logger.error(
+                            logger.exception(
                                 f"[MD] Failed to send cancellation "
                                 f"for #{md_num}: {e}"
                             )
@@ -392,15 +392,15 @@ class MesoscaleCog(commands.Cog):
                     self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
                     logger.info(f"[MD] Posted MD #{md_num}")
                 except discord.HTTPException as e:
-                    logger.error(
+                    logger.exception(
                         f"[MD] Discord send failed for MD #{md_num}: {e}"
                     )
             
             self._md_backoff.success()
 
         except Exception as e:
-            logger.error(
-                f"[MD] Unexpected error in auto_post_md: {e}", exc_info=True
+            logger.exception(
+                f"[MD] Unexpected error in auto_post_md: {e}"
             )
             await self._md_backoff.failure(self.bot)
 

--- a/cogs/ncar.py
+++ b/cogs/ncar.py
@@ -188,7 +188,7 @@ class NCARCog(commands.Cog):
             self.bot.state.manual_cache[url] = h
             await set_hash(url, h, "manual")
         except Exception as e:
-            logger.error(f"[NCAR] Failed to save WxNext2 image: {e}")
+            logger.exception(f"[NCAR] Failed to save WxNext2 image: {e}")
             return
 
         try:
@@ -201,7 +201,7 @@ class NCARCog(commands.Cog):
             self.bot.state.last_post_times["wxnext"] = now_utc
             logger.info("[NCAR] Auto-posted WxNext2")
         except Exception as e:
-            logger.error(f"[NCAR] Failed to post WxNext2: {e}", exc_info=True)
+            logger.exception(f"[NCAR] Failed to post WxNext2: {e}")
 
     @wxnext_daily_poll.after_loop
     async def after_wxnext_poll(self):

--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -93,7 +93,7 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
                         )
                         state.last_post_times[day_key] = datetime.now(timezone.utc)
                     except Exception as e:
-                        logger.error(
+                        logger.exception(
                             f"Failed to send partial post for Day {day}: {e}"
                         )
                 state.partial_update_state.pop(day_key, None)
@@ -133,7 +133,7 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
             await set_posted_urls(day_key, urls)
             logger.info(f"[Day {day}] Posted {len(files)} images. URLs: {urls}")
         except Exception as e:
-            logger.error(f"Failed to send post for Day {day}: {e}")
+            logger.exception(f"Failed to send post for Day {day}: {e}")
 
 
 class OutlooksCog(commands.Cog):
@@ -227,7 +227,7 @@ class OutlooksCog(commands.Cog):
                     )
                     self.bot.state.last_post_times["day48"] = datetime.now(timezone.utc)
                 except Exception as e:
-                    logger.error(f"Failed to send SPC48 post: {e}")
+                    logger.exception(f"Failed to send SPC48 post: {e}")
 
     @auto_post_spc.after_loop
     async def after_spc_loop(self):

--- a/cogs/radar/downloads.py
+++ b/cogs/radar/downloads.py
@@ -119,7 +119,7 @@ async def cleanup_old_files(directory, age_threshold):
                     item.unlink()
                     logger.debug(f"[RADAR] Deleted old file: {item}")
                 except Exception as e:
-                    logger.error(
+                    logger.exception(
                         f"[RADAR] Failed to delete old file {item}: {e}"
                     )
 
@@ -195,8 +195,8 @@ async def split_and_zip_files(
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, _zip)
     except Exception as e:
-        logger.error(f"[RADAR] ZIP creation failed: {e}")
-        raise RuntimeError(f"Failed to create ZIP file: {e}")
+        logger.exception(f"[RADAR] ZIP creation failed: {e}")
+        raise RuntimeError(f"Failed to create ZIP file: {e}") from e
 
 
 async def send_error(interaction, title, description):
@@ -212,7 +212,7 @@ async def send_error(interaction, title, description):
         try:
             await interaction.channel.send(embed=embed)
         except Exception as e:
-            logger.error(f"[RADAR] Could not send error message: {e}")
+            logger.exception(f"[RADAR] Could not send error message: {e}")
 
 
 async def run_download(
@@ -408,7 +408,7 @@ async def download_and_zip(
                 discord.errors.NotFound,
                 discord.errors.HTTPException,
             ) as e:
-                logger.error(
+                logger.exception(
                     f"[RADAR] Failed to edit progress message: {e}"
                 )
             last_update_time = current_time
@@ -607,7 +607,7 @@ async def download_and_zip(
                             )
                             embed.color = discord.Color.red()
                             await message.edit(embed=embed)
-                            logger.error(
+                            logger.exception(
                                 f"[RADAR] Upload failed for "
                                 f"{zip_path.name}: {e}"
                             )
@@ -620,7 +620,7 @@ async def download_and_zip(
             embed.description = str(e)
             embed.color = discord.Color.red()
             await message.edit(embed=embed)
-            logger.error(f"[RADAR] ZIP creation error: {e}")
+            logger.exception(f"[RADAR] ZIP creation error: {e}")
             return
 
         if not all_uploaded:
@@ -636,9 +636,8 @@ async def download_and_zip(
             logger.error("[RADAR] Upload failed at all size levels")
 
     except Exception as e:
-        logger.error(
+        logger.exception(
             f"[RADAR] Unexpected error in download_and_zip: {e}",
-            exc_info=True,
         )
         embed.title = "Unexpected Error"
         embed.description = (
@@ -658,7 +657,7 @@ async def download_and_zip(
                 try:
                     os.remove(file_path)
                 except Exception as e:
-                    logger.error(
+                    logger.exception(
                         f"[RADAR] Failed to delete temp file "
                         f"{file_path}: {e}"
                     )
@@ -666,14 +665,14 @@ async def download_and_zip(
             try:
                 zip_path.unlink()
             except Exception as e:
-                logger.error(
+                logger.exception(
                     f"[RADAR] Failed to delete zip {zip_path}: {e}"
                 )
         if os.path.exists(output_dir):
             try:
                 shutil.rmtree(output_dir)
             except Exception as e:
-                logger.error(
+                logger.exception(
                     f"[RADAR] Failed to delete output dir: {e}"
                 )
         with progress_lock:

--- a/cogs/radar/s3.py
+++ b/cogs/radar/s3.py
@@ -47,7 +47,7 @@ async def get_radar_sites(date: datetime) -> list[str]:
         )
         return sites
     except Exception as e:
-        logger.error(f"[RADAR] Error listing radar sites: {e}")
+        logger.exception(f"[RADAR] Error listing radar sites: {e}")
         return []
 
 
@@ -93,14 +93,14 @@ async def list_files(radar_site: str, dates: list) -> list[dict]:
                         f["FileTimestamp"] = f["LastModified"]
                 all_files.extend(files)
             except Exception as e:
-                logger.error(
+                logger.exception(
                     f"[RADAR] Error listing files for {radar_site} "
                     f"on {date.strftime('%Y-%m-%d')}: {e}"
                 )
                 raise RuntimeError(
                     f"Could not reach S3 to list files for {radar_site} "
                     f"on {date.strftime('%Y-%m-%d')}. Check your connection."
-                )
+                ) from e
     return sorted(all_files, key=lambda x: x["FileTimestamp"], reverse=True)
 
 

--- a/cogs/scp.py
+++ b/cogs/scp.py
@@ -82,7 +82,7 @@ class SCPCog(commands.Cog):
             else:
                 logger.info("[SCP_DAILY] No SCP images could be downloaded")
         except Exception as e:
-            logger.error(f"[SCP_DAILY] Unexpected error: {e}", exc_info=True)
+            logger.exception(f"[SCP_DAILY] Unexpected error: {e}")
 
         self._next_post_time = self._compute_next_post_time()
         logger.info(

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -60,7 +60,7 @@ class SoundingCog(commands.Cog):
         try:
             stations_df = await get_raob_stations()
         except Exception as e:
-            logger.error(f"[SOUNDING-PREWARM] Failed to load station list: {e}")
+            logger.exception(f"[SOUNDING-PREWARM] Failed to load station list: {e}")
             return
 
         candidates = find_nearest_stations(lat, lon, stations_df, n=4)
@@ -106,7 +106,7 @@ class SoundingCog(commands.Cog):
         try:
             stations_df = await get_raob_stations()
         except Exception as e:
-            logger.error(f"[SOUNDING-AUTO] Failed to load station list: {e}")
+            logger.exception(f"[SOUNDING-AUTO] Failed to load station list: {e}")
             return
 
         candidates = find_nearest_stations(lat, lon, stations_df, n=6)
@@ -152,7 +152,7 @@ class SoundingCog(commands.Cog):
                 await target_channel.send(caption, files=[discord.File(png_path)])
                 logger.info(f"[SOUNDING-AUTO] Posted {station_id} for watch #{watch_num}")
             except Exception as e:
-                logger.error(f"[SOUNDING-AUTO] Failed to post {station_id}: {e}")
+                logger.exception(f"[SOUNDING-AUTO] Failed to post {station_id}: {e}")
 
         acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
         for profile in acars_profiles[:2]:
@@ -187,7 +187,7 @@ class SoundingCog(commands.Cog):
                 await channel.send(caption, files=[discord.File(png_path)])
                 logger.info(f"[SOUNDING-AUTO] Posted ACARS {profile['airport']} for watch #{watch_num}")
             except Exception as e:
-                logger.error(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
+                logger.exception(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
 
     @tasks.loop(minutes=30)
     async def auto_sounding_watches(self):
@@ -218,7 +218,7 @@ class SoundingCog(commands.Cog):
         try:
             stations_df = await get_raob_stations()
         except Exception as e:
-            logger.error(f"[SOUNDING-AUTO] Failed to load station list: {e}")
+            logger.exception(f"[SOUNDING-AUTO] Failed to load station list: {e}")
             return
 
         year = now.strftime("%Y")
@@ -279,7 +279,7 @@ class SoundingCog(commands.Cog):
                     await channel.send(caption, files=[discord.File(png_path)])
                     logger.info(f"[SOUNDING-AUTO] Posted {station_id} for watch #{watch_num}")
                 except Exception as e:
-                    logger.error(f"[SOUNDING-AUTO] Failed to post: {e}")
+                    logger.exception(f"[SOUNDING-AUTO] Failed to post: {e}")
 
         # ── ACARS auto-posting ────────────────────────────────────────────
             acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
@@ -315,7 +315,7 @@ class SoundingCog(commands.Cog):
                     await channel.send(caption, files=[discord.File(png_path)])
                     logger.info(f"[SOUNDING-AUTO] Posted ACARS {profile['airport']} for watch #{watch_num}")
                 except Exception as e:
-                    logger.error(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
+                    logger.exception(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
 
     @discord.app_commands.command(
         name="sounding",
@@ -358,7 +358,7 @@ class SoundingCog(commands.Cog):
             await interaction.followup.send(str(e), ephemeral=True)
             return
         except Exception as e:
-            logger.error(f"[SOUNDING] Location resolution error: {e}", exc_info=True)
+            logger.exception(f"[SOUNDING] Location resolution error: {e}")
             await interaction.followup.send(
                 "Could not resolve that location. Try a city name or station code.",
                 ephemeral=True,
@@ -370,7 +370,7 @@ class SoundingCog(commands.Cog):
             stations_df = await get_raob_stations()
             nearest = find_nearest_stations(lat, lon, stations_df, n=3)
         except Exception as e:
-            logger.error(f"[SOUNDING] Station lookup error: {e}", exc_info=True)
+            logger.exception(f"[SOUNDING] Station lookup error: {e}")
             await interaction.followup.send(
                 "Could not load station list. Try again later.",
                 ephemeral=True,

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -221,12 +221,12 @@ def parse_sounding_time(time_str: Optional[str]) -> Optional[tuple[str, str, str
             str(dt.day).zfill(2),
             str(hour).zfill(2),
         )
-    except Exception:
+    except Exception as e:
         raise ValueError(
             f"Invalid time format: **{time_str}**\n"
             f"Use: `MM-DD-YYYY 00z` or `MM-DD-YYYY 12z`\n"
             f"Example: `04-10-2026 12z`"
-        )
+        ) from e
 
 def get_recent_sounding_times(n: int = 4) -> list[tuple[str, str, str, str]]:
     """
@@ -759,7 +759,7 @@ async def generate_plot(
         )
         return True
     except Exception as e:
-        logger.error(f"[SOUNDING] Plot generation failed: {e}", exc_info=True)
+        logger.exception(f"[SOUNDING] Plot generation failed: {e}")
         return False
 
 def _plot_sync(clean_data: dict, output_path: str, dark_mode: bool):

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -136,7 +136,7 @@ async def post_sounding(
                 pass
 
     except Exception as e:
-        logger.error(f"[SOUNDING] Failed to post: {e}", exc_info=True)
+        logger.exception(f"[SOUNDING] Failed to post: {e}")
 
 
 # ── Time selection view ───────────────────────────────────────────────────────
@@ -526,4 +526,4 @@ async def _post_from_clean_data(
         await interaction.channel.send(caption, files=[discord.File(png_path)])
         logger.info(f"[SOUNDING] Posted {station_id} {year}/{month}/{day} {hour}z")
     except Exception as e:
-        logger.error(f"[SOUNDING] Failed to post: {e}", exc_info=True)
+        logger.exception(f"[SOUNDING] Failed to post: {e}")

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -41,11 +41,11 @@ async def send_with_handling(source, content: str, file_paths=None):
             await source.send(content, files=files)
     except discord.HTTPException as e:
         if e.status == 413:
-            logger.error(f"Discord file size limit exceeded: {e}")
+            logger.exception(f"Discord file size limit exceeded: {e}")
         else:
-            logger.error(f"Discord send failed: {e}")
+            logger.exception(f"Discord send failed: {e}")
     except Exception as e:
-        logger.error(f"Unexpected error sending message: {e}")
+        logger.exception(f"Unexpected error sending message: {e}")
 
 
 async def fetch_and_send_weather_images(
@@ -346,7 +346,7 @@ class StatusCog(commands.Cog):
                     embed=embed, files=files_to_send
                 )
             except discord.HTTPException as e:
-                logger.error(f"[/md] Failed to send MD #{md_num}: {e}")
+                logger.exception(f"[/md] Failed to send MD #{md_num}: {e}")
 
     @discord.app_commands.command(
         name="status",

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -733,7 +733,7 @@ class WatchesCog(commands.Cog):
                     self._upgrade_watch_embed(watch_num, message, is_tornado, watch_label, color, expires)
                 )
         except discord.HTTPException as e:
-            logger.error(f"[WATCH] iembot-triggered send failed for #{watch_num}: {e}")
+            logger.exception(f"[WATCH] iembot-triggered send failed for #{watch_num}: {e}")
 
     @tasks.loop(minutes=2)
     async def auto_post_watches(self):
@@ -797,7 +797,7 @@ class WatchesCog(commands.Cog):
                         f"[WATCH] Posted cancellation for #{watch_num}"
                     )
                 except discord.HTTPException as e:
-                    logger.error(
+                    logger.exception(
                         f"[WATCH] Failed to send cancellation "
                         f"for #{watch_num}: {e}"
                     )
@@ -867,16 +867,15 @@ class WatchesCog(commands.Cog):
                             sounding_cog.post_soundings_for_watch(watch_num, nws_info, channel)
                         )
                 except discord.HTTPException as e:
-                    logger.error(
+                    logger.exception(
                         f"[WATCH] Discord send failed for #{watch_num}: {e}"
                     )
 
             self._watches_backoff.success()
 
         except Exception as e:
-            logger.error(
+            logger.exception(
                 f"[WATCH] Unexpected error in auto_post_watches: {e}",
-                exc_info=True,
             )
             await self._watches_backoff.failure(self.bot)
 

--- a/config.py
+++ b/config.py
@@ -61,7 +61,7 @@ if not os.path.exists(_products_file):
         f"to prevent silent drift between the JSON and code."
     )
 
-with open(_products_file, "r") as f:
+with open(_products_file, "r", encoding="utf-8") as f:
     _P = json.load(f)
 
 # Exported constants used by cogs

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Single source of truth for the release displayed in /help.
 # Bump this in the same commit as the git tag.
-__version__ = "5.1.1"
+__version__ = "5.1.2"
 
 load_dotenv()
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import os
 import signal
 from datetime import datetime, timezone
 
+import aiohttp
 import discord
 from discord.ext import commands, tasks
 
@@ -108,7 +109,7 @@ async def setup_hook():
         except Exception:
             pass
 
-    for day_key, urls in zip(["day1", "day2", "day3"], [d1_urls, d2_urls, d3_urls]):
+    for day_key, urls in zip(["day1", "day2", "day3"], [d1_urls, d2_urls, d3_urls], strict=True):
         if isinstance(urls, list) and urls:
             bot.state.last_posted_urls[day_key] = urls
             logger.info(f"[DB] Restored posted URLs for {day_key}")
@@ -162,7 +163,7 @@ async def send_bot_alert(
         await channel.send(embed=embed)
         logger.warning(f"[ALERT] Sent Discord alert: {title}")
     except Exception as e:
-        logger.error(f"[ALERT] Failed to send Discord alert '{title}': {e}")
+        logger.exception(f"[ALERT] Failed to send Discord alert '{title}': {e}")
 
 
 # ── Events ───────────────────────────────────────────────────────────────────
@@ -186,13 +187,13 @@ async def on_ready():
                     f"Successfully synced {len(synced)} global slash command(s)"
                 )
             except Exception as e:
-                logger.error(f"Failed to sync command tree: {e}")
+                logger.exception(f"Failed to sync command tree: {e}")
         else:
             logger.info("[FAILOVER] Standby — skipping command sync to preserve primary commands")
         logger.info("All tasks started. Bot is ready.")
         periodic_sync.start()
     except Exception as e:
-        logger.error(f"[on_ready] Unhandled error: {e}")
+        logger.exception(f"[on_ready] Unhandled error: {e}")
 
 @tasks.loop(hours=24)
 async def periodic_sync():
@@ -203,7 +204,7 @@ async def periodic_sync():
         synced = await bot.tree.sync()
         logger.info(f"[SYNC] Periodic command sync: {len(synced)} commands")
     except Exception as e:
-        logger.error(f"[SYNC] Periodic command sync failed: {e}")
+        logger.exception(f"[SYNC] Periodic command sync failed: {e}")
 
 
 @bot.event
@@ -215,9 +216,6 @@ async def on_command_error(ctx, error):
 
 
 # ── Watchdog ─────────────────────────────────────────────────────────────────
-import aiohttp
-
-
 @tasks.loop(minutes=2)
 async def watchdog_task():
     await bot.wait_until_ready()
@@ -306,7 +304,7 @@ async def watchdog_task():
             task.start()
             logger.info(f"[WATCHDOG] Successfully restarted '{name}'")
         except Exception as e:
-            logger.error(
+            logger.exception(
                 f"[WATCHDOG] Failed to restart '{name}': {e}"
             )
 

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -362,6 +362,6 @@ async def check_all_urls_exist_parallel(urls: List[str]) -> bool:
     if not ok:
         logger.warning(
             f"Some URLs not reachable: "
-            f"{[(u, r) for u, r in zip(urls, results) if not r]}"
+            f"{[(u, r) for u, r in zip(urls, results, strict=True) if not r]}"
         )
     return ok

--- a/utils/db.py
+++ b/utils/db.py
@@ -173,7 +173,7 @@ async def check_integrity() -> bool:
                 logger.error(f"[DB] Integrity check failed: {row}")
             return ok
     except Exception as e:
-        logger.error(f"[DB] Integrity check error: {e}")
+        logger.exception(f"[DB] Integrity check error: {e}")
         return False
 
 

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -288,7 +288,7 @@ async def _reconciler_loop() -> None:
                 except _UpstashUnavailable:
                     still_dirty.append((op, args))
                 except Exception as e:
-                    logger.error(
+                    logger.exception(
                         f"[STATE] Reconciler dropped write {op}{args}: {e}"
                     )
 
@@ -305,7 +305,7 @@ async def _reconciler_loop() -> None:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.error(f"[STATE] Reconciler loop error: {e}")
+            logger.exception(f"[STATE] Reconciler loop error: {e}")
 
 
 async def _replay(op: str, args: tuple) -> None:


### PR DESCRIPTION
## Summary
- Convert `logger.error(..., exc_info=True)` and in-`except` `logger.error(...)` → `logger.exception(...)` across cogs/utils (ruff G201/TRY400)
- `raise X from e` in `cogs/radar/downloads.py`, `cogs/radar/s3.py`, `cogs/sounding_utils.py` (B904)
- `zip(..., strict=True)` in `main.py` and `utils/cache.py` (B905)
- `config.py` opens `products.json` with `encoding="utf-8"`
- Hoist `aiohttp` import to top of `main.py` (E402)
- Remove stray empty `│/` directory at repo root
- Bump `__version__` to 5.1.2, backfill CHANGELOG

## Test plan
- [x] `pytest -q` — 171 passed
- [x] `ruff check . --exclude=lib --exclude=tests --select=G201,TRY400,B904,B905` — clean
- [ ] Verify live deploy logs show tracebacks for exception paths