### PR TITLE
Robustness Audit: Relax Watchdog and Fix MD Race Conditions

### DIFF
--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -1,15 +1,16 @@
 # cogs/csu_mlp.py
 import json
 import logging
-
-from utils.state_store import get_state, set_state
 from datetime import datetime, timedelta, timezone
 
+import aiohttp
 import discord
 from discord.app_commands import Choice
 from discord.ext import commands, tasks
 
 from config import MANUAL_CACHE_FILE, MODELS_CHANNEL_ID
+from utils.http import ensure_session
+from utils.state_store import get_state, set_state
 from utils.cache import (
     download_single_image,
 )
@@ -63,8 +64,6 @@ async def _url_is_image(url: str) -> bool:
     Check if a URL actually serves an image by inspecting Content-Type.
     The CSU server returns 200+HTML for missing files instead of 404.
     """
-    from utils.http import ensure_session
-    import aiohttp
     try:
         session = await ensure_session()
         async with session.head(url, timeout=aiohttp.ClientTimeout(total=8)) as resp:

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -281,8 +281,8 @@ class FailoverCog(commands.Cog):
         for ext in ALL_EXTENSIONS:
             try:
                 await self.bot.unload_extension(ext)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"[FAILOVER] Could not unload {ext} during demote: {e}")
         self._primary_failures = 0
 
 

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -44,6 +44,9 @@ import uuid
 import aiohttp
 from discord.ext import commands, tasks
 
+from cogs import ALL_EXTENSIONS
+from utils import state_store
+
 logger = logging.getLogger("spc_bot")
 
 UPSTASH_URL = os.getenv("UPSTASH_REDIS_REST_URL", "")
@@ -59,8 +62,6 @@ MAX_FAILURES = max(5, HEARTBEAT_TTL // (2 * SYNC_INTERVAL))
 UPSTASH_HEADERS = {"Authorization": f"Bearer {UPSTASH_TOKEN}"}
 
 LEASE_KEY = "spcbot:primary_url"
-
-from cogs import ALL_EXTENSIONS
 
 
 def _require_failover_token() -> str:
@@ -214,7 +215,6 @@ class FailoverCog(commands.Cog):
         self.bot.state.is_primary = True
 
         # Drop stale cache so fresh reads re-hit Upstash.
-        from utils import state_store
         state_store.invalidate_all_caches()
 
         # Claim the lease immediately (before loading cogs so there's no
@@ -259,8 +259,6 @@ class FailoverCog(commands.Cog):
         we need them to reflect what the outgoing primary wrote to
         Upstash, not what we snapshotted at boot.
         """
-        from utils import state_store
-
         st = self.bot.state
         st.auto_cache = await state_store.get_all_hashes("auto")
         st.manual_cache = await state_store.get_all_hashes("manual")

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -82,6 +82,8 @@ def _node_identity() -> str:
 
 
 class FailoverCog(commands.Cog):
+    MANAGED_TASK_NAMES = [("sync_loop", "sync_loop")]
+
     def __init__(self, bot):
         self.bot = bot
         self._primary_failures = 0

--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -1,5 +1,6 @@
 # cogs/hodograph.py
 import asyncio
+import difflib
 import logging
 import os
 import sys
@@ -103,7 +104,6 @@ class HodographCog(commands.Cog):
         site = site.upper().strip()
 
         if site not in VALID_RADARS:
-            import difflib
             suggestions = difflib.get_close_matches(site, VALID_RADARS, n=3, cutoff=0.5)
             if suggestions:
                 view = RadarSuggestionView(suggestions)

--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -128,8 +128,8 @@ class HodographCog(commands.Cog):
                     f"⚠️ Unexpected error for `{site}`. Please try again.",
                     ephemeral=True,
                 )
-            except Exception:
-                pass
+            except discord.HTTPException as send_err:
+                logger.debug(f"[HODO] Could not send error message: {send_err}")
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/iembot.py
+++ b/cogs/iembot.py
@@ -42,7 +42,7 @@ async def get_cached_md_text(md_number: str) -> Optional[str]:
 
 def _parse_watch_text(raw: str) -> Optional[str]:
     """Parse SEL product text into a formatted summary string."""
-    lines = [l.strip() for l in raw.splitlines() if l.strip()]
+    lines = [line.strip() for line in raw.splitlines() if line.strip()]
     parts = []
     for i, line in enumerate(lines):
         if re.search(r"Watch for portions of", line, re.IGNORECASE):
@@ -80,7 +80,7 @@ def _parse_md_text(raw: str) -> Optional[str]:
     concerning = re.search(r"(CONCERNING[^\n]{10,120})", raw, re.IGNORECASE)
     if concerning:
         return concerning.group(1).strip()
-    lines = [l.strip() for l in raw.splitlines() if l.strip()]
+    lines = [line.strip() for line in raw.splitlines() if line.strip()]
     return " ".join(lines[:3])[:200] if lines else None
 
 

--- a/cogs/iembot.py
+++ b/cogs/iembot.py
@@ -97,9 +97,13 @@ async def _fetch_product_text(product_id: str) -> Optional[str]:
 
 
 class IEMBotCog(commands.Cog):
+    MANAGED_TASK_NAMES = [("poll_iembot_feed", "poll_iembot_feed")]
+
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._seqnum_loaded = False
+
+    async def cog_load(self):
         self.poll_iembot_feed.start()
 
     def cog_unload(self):

--- a/cogs/iembot.py
+++ b/cogs/iembot.py
@@ -11,6 +11,7 @@ between issuance and SPC/IEM REST API availability.
 Only the last-seen seqnum is persisted to DB to avoid reprocessing on restart.
 """
 import asyncio
+import json as _json
 import logging
 import re
 from typing import Optional
@@ -128,7 +129,6 @@ class IEMBotCog(commands.Cog):
             self._seqnum_loaded = True
 
         try:
-            import json as _json
             url = f"{IEMBOT_FEED_URL}?seqnum={self.bot.state.iembot_last_seqnum}"
             content, status = await http_get_bytes(url, retries=2, timeout=10)
             if not content or status != 200:

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -263,6 +263,34 @@ class MesoscaleCog(commands.Cog):
         except Exception as e:
             logger.debug(f"[MD] Could not parse probability for MD #{md_num}: {e}")
 
+    async def _upgrade_md_message(
+        self, md_num: str, message: discord.Message, header: str
+    ):
+        """
+        Polls for the MD graphic and edits the message to include it once available.
+        Retries every 30s for up to 5 minutes.
+        """
+        image_url = f"https://www.spc.noaa.gov/products/md/mcd{md_num}.png"
+        for attempt in range(10):
+            await asyncio.sleep(30)
+            try:
+                # download_single_image uses conditional GET / validators
+                cache_path, _, _ = await download_single_image(
+                    image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
+                )
+                if cache_path:
+                    try:
+                        await message.edit(
+                            content=header, attachments=[discord.File(cache_path)]
+                        )
+                        logger.info(f"[MD] Upgraded MD #{md_num} with graphic")
+                        break
+                    except discord.HTTPException as e:
+                        logger.warning(f"[MD] Failed to edit MD message for #{md_num}: {e}")
+                        break
+            except Exception as e:
+                logger.debug(f"[MD] Upgrade poll error for #{md_num}: {e}")
+
     async def post_md_now(self, md_num: str):
         """
         Immediately post a specific MD if it hasn't been posted yet.
@@ -295,10 +323,14 @@ class MesoscaleCog(commands.Cog):
         header += f"\n<{md_page_url}>"
 
         try:
+            msg = None
             if cache_path:
-                await channel.send(header, files=[discord.File(cache_path)])
+                msg = await channel.send(header, files=[discord.File(cache_path)])
             else:
-                await channel.send(header)
+                msg = await channel.send(header)
+                # Graphic missing (likely 403 index-lag), try to fetch it later
+                asyncio.create_task(self._upgrade_md_message(md_num, msg, header))
+
             self.bot.state.posted_mds.add(md_num)
             await add_posted_md(str(md_num))
             await prune_posted_mds()
@@ -324,8 +356,23 @@ class MesoscaleCog(commands.Cog):
 
             # ── MD cancellations ───────────────────────────────────────────
             if current_mds:
+                current_max = max(int(m) for m in current_mds)
                 for md_num in list(self.bot.state.active_mds):
                     if md_num not in current_mds:
+                        # Protect against index lag: if the active MD is newer than
+                        # anything on the index, it means the index hasn't caught up.
+                        num_int = int(md_num)
+                        # Handle year wraparound (e.g. 0001 is newer than 9999)
+                        is_newer = (num_int > current_max and num_int - current_max < 1000) or \
+                                   (num_int < current_max and current_max - num_int > 8000)
+                        
+                        if is_newer:
+                            logger.info(
+                                f"[MD] Index lagging (highest is {current_max:04d}) — "
+                                f"sparing #{md_num} from cancellation"
+                            )
+                            continue
+
                         self.bot.state.active_mds.discard(md_num)
                         logger.info(
                             f"[MD] MD #{md_num} no longer on index — "
@@ -384,12 +431,16 @@ class MesoscaleCog(commands.Cog):
                 header += f"\n<{md_page_url}>"
 
                 try:
+                    msg = None
                     if cache_path:
-                        await channel.send(
+                        msg = await channel.send(
                             header, files=[discord.File(cache_path)]
                         )
                     else:
-                        await channel.send(header)
+                        msg = await channel.send(header)
+                        # Graphic missing (likely 403), try to fetch it later
+                        asyncio.create_task(self._upgrade_md_message(md_num, msg, header))
+
                     self.bot.state.posted_mds.add(md_num)
                     await add_posted_md(str(md_num))
                     await prune_posted_mds()

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -117,7 +117,7 @@ async def fetch_md_details_iem(md_number: str) -> Tuple[Optional[str], Optional[
                     if concerning:
                         summary = concerning.group(1).strip()
                     else:
-                        lines = [l.strip() for l in text.splitlines() if l.strip()]
+                        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
                         summary = " ".join(lines[:3])[:200]
                     break
     except Exception as e:

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -168,8 +168,8 @@ async def fetch_md_details(
             if pending:
                 try:
                     iem_result = await pending.pop()
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"[MD] IEM fallback also failed for #{md_number}: {e}")
     else:
         iem_result = first.result()
         try:

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -1,5 +1,6 @@
 # cogs/mesoscale.py
 import asyncio
+import json
 import logging
 import os
 import re
@@ -8,9 +9,10 @@ from typing import Dict, List, Optional, Tuple
 
 import discord
 from discord.ext import commands, tasks
-from utils.backoff import TaskBackoff
 
+from cogs.iembot import get_cached_md_text
 from config import AUTO_CACHE_FILE, SPC_CHANNEL_ID, SPC_MD_INDEX_URL
+from utils.backoff import TaskBackoff
 from utils.cache import (
     download_single_image,
 )
@@ -48,14 +50,13 @@ async def fetch_latest_md_numbers() -> List[str]:
     # If SPC is unreachable, try to scrape from IEM's nwstext API
     if not html:
         logger.warning("[MD] SPC index unreachable — falling back to IEM for active MD list")
-        import json as _json_fallback
         try:
             content, status = await http_get_bytes(
                 "https://mesonet.agron.iastate.edu/api/1/nwstext.json?product=MCD&limit=40",
                 retries=2, timeout=15
             )
             if content and status == 200:
-                data = _json_fallback.loads(content)
+                data = json.loads(content)
                 md_nums = set()
                 for entry in data.get("data", []):
                     m = re.search(r"MESOSCALE DISCUSSION\s+(\d+)", entry.get("data", ""), re.IGNORECASE)
@@ -87,7 +88,6 @@ async def fetch_md_details_iem(md_number: str) -> Tuple[Optional[str], Optional[
     IEM mirrors SPC MCD images at a predictable URL.
     Returns (image_url, summary_text, raw_text).
     """
-    import json as _json_iem
     padded = md_number.zfill(4)
     num_int = int(md_number)
 
@@ -105,7 +105,7 @@ async def fetch_md_details_iem(md_number: str) -> Tuple[Optional[str], Optional[
             retries=2, timeout=15
         )
         if content and status == 200:
-            data = _json_iem.loads(content)
+            data = json.loads(content)
             for entry in data.get("data", []):
                 text = entry.get("data", "")
                 if (
@@ -139,7 +139,9 @@ async def fetch_md_details(
         return await http_get_text(page_url)
 
     async def _fetch_iem_early():
-        import cogs.mesoscale as _self
+        # Self-import via module object so tests can monkeypatch
+        # cogs.mesoscale.fetch_md_details_iem at runtime.
+        import cogs.mesoscale as _self  # noqa: PLC0415
         iem_img, iem_summary, iem_raw = await _self.fetch_md_details_iem(md_number)
         return (iem_img, iem_summary, iem_raw)
 
@@ -206,7 +208,6 @@ async def fetch_md_details(
     summary = None
 
     # Check iembot real-time cache first (populated within seconds of issuance)
-    from cogs.iembot import get_cached_md_text
     summary = await get_cached_md_text(md_number)
     if summary:
         logger.info(f"[MD] Got summary from iembot cache for #{md_number}")

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -236,6 +236,8 @@ class MesoscaleCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._md_backoff = TaskBackoff("auto_post_md")
+
+    async def cog_load(self):
         self.auto_post_md.start()
 
     def cog_unload(self):
@@ -340,6 +342,7 @@ class MesoscaleCog(commands.Cog):
                         embed.set_footer(text="SPC MD Monitor")
                         try:
                             await channel.send(embed=embed)
+                            self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
                             logger.info(
                                 f"[MD] Posted cancellation for #{md_num}"
                             )

--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -142,6 +142,8 @@ class OutlooksCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._spc_backoff = TaskBackoff("auto_post_spc")
+
+    async def cog_load(self):
         self.auto_post_spc.start()
         self.aggressive_check_spc.start()
         self.auto_post_spc48.start()

--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import discord
 from discord.ext import commands, tasks
 
-from config import SPC_CHANNEL_ID, SPC_URLS
+from config import AUTO_CACHE_FILE, SPC_CHANNEL_ID, SPC_URLS, SPC_URLS_FALLBACK
 from utils.backoff import TaskBackoff
 from utils.state_store import set_posted_urls
 from utils.cache import (
@@ -25,8 +25,6 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
     Detects partial updates and waits up to 20 minutes for all images before
     posting whatever is available.
     """
-    from config import AUTO_CACHE_FILE, SPC_URLS_FALLBACK
-
     urls = await get_spc_urls(day)
     day_key = f"day{day}"
 
@@ -116,8 +114,6 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
             f"[Day {day}] All images ready after {elapsed:.1f} min. Posting."
         )
         state.partial_update_state.pop(day_key, None)
-
-    from config import AUTO_CACHE_FILE
 
     files = await save_downloaded_images(
         urls, downloaded_data, AUTO_CACHE_FILE, state.auto_cache
@@ -214,8 +210,6 @@ class OutlooksCog(commands.Cog):
             await check_partial_updates_parallel(urls, self.bot.state.auto_cache)
         )
         if updated_count > 0:
-            from config import AUTO_CACHE_FILE
-
             files = await save_downloaded_images(
                 urls, downloaded_data, AUTO_CACHE_FILE, self.bot.state.auto_cache
             )

--- a/cogs/radar/__init__.py
+++ b/cogs/radar/__init__.py
@@ -18,6 +18,8 @@ logger = logging.getLogger("spc_bot")
 
 
 class RadarCog(commands.Cog):
+    MANAGED_TASK_NAMES = [("periodic_cleanup", "periodic_cleanup")]
+
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.periodic_cleanup.start()

--- a/cogs/radar/__init__.py
+++ b/cogs/radar/__init__.py
@@ -1,9 +1,10 @@
 # cogs/radar/__init__.py
 """NEXRAD Level 2 radar data downloader from NOAA AWS S3."""
 
-from datetime import datetime, timedelta, timezone
 import logging
+import re
 import time
+from datetime import datetime, timedelta, timezone
 
 import discord
 from discord.app_commands import Choice
@@ -11,7 +12,7 @@ from discord.ext import commands, tasks
 
 from cogs.radar.downloads import cleanup_old_files, run_download, OUTPUT_DIR, CLEANUP_AGE_THRESHOLD
 from cogs.radar.s3 import _s3
-from cogs.radar.views import StartView
+from cogs.radar.views import StartView, TimeRangeView
 
 logger = logging.getLogger("spc_bot")
 
@@ -77,7 +78,6 @@ class RadarCog(commands.Cog):
             return
 
         # Parse site codes — accept space or comma separated, uppercase
-        import re
         raw_sites = re.split(r"[,\s]+", sites.strip().upper())
         radar_sites = [s for s in raw_sites if s]
 
@@ -101,7 +101,6 @@ class RadarCog(commands.Cog):
 
         # Sites only (or 'custom' selected) — show time preset buttons
         if not time or time.value == "custom":
-            from cogs.radar.views import TimeRangeView
             await interaction.response.defer()
             view = TimeRangeView(
                 radar_sites=radar_sites,

--- a/cogs/radar/downloads.py
+++ b/cogs/radar/downloads.py
@@ -492,8 +492,8 @@ async def download_and_zip(
                     )
                     try:
                         await message.edit(embed=embed)
-                    except Exception:
-                        pass
+                    except discord.HTTPException as e:
+                        logger.debug(f"[RADAR] Could not update progress embed: {e}")
 
         if not file_paths:
             embed.title = "Download Failed"
@@ -540,8 +540,8 @@ async def download_and_zip(
                 for old_zip in Path(output_dir).glob("*.zip"):
                     try:
                         old_zip.unlink()
-                    except Exception:
-                        pass
+                    except OSError as e:
+                        logger.debug(f"[RADAR] Could not remove old zip {old_zip}: {e}")
                 zip_paths = await split_and_zip_files(
                     file_paths, radar_sites, attempt_size, output_dir
                 )
@@ -648,8 +648,8 @@ async def download_and_zip(
         embed.color = discord.Color.red()
         try:
             await message.edit(embed=embed)
-        except Exception:
-            pass
+        except discord.HTTPException as edit_err:
+            logger.debug(f"[RADAR] Could not post error embed: {edit_err}")
 
     finally:
         for file_path, _ in file_paths:

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -6,6 +6,7 @@ Supports city names, radar site codes, and RAOB station IDs.
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -13,20 +14,23 @@ import discord
 from discord.ext import commands, tasks
 
 from cogs.sounding_utils import (
-    get_acars_profiles_near,
-    get_available_sounding_times_iem,
-    get_watch_area_centroid,
+    fetch_acars_sounding,
+    fetch_sounding,
     filter_stations_with_data,
     find_nearest_stations,
+    generate_plot,
+    get_acars_profiles_near,
+    get_available_sounding_times_iem,
+    get_md_area_centroid,
     get_raob_stations,
     get_user_dark_mode,
+    get_watch_area_centroid,
     parse_sounding_time,
     resolve_location,
     set_user_dark_mode,
 )
-import os
-from cogs.sounding_views import post_sounding
-from cogs.sounding_utils import fetch_acars_sounding, fetch_sounding, generate_plot
+from cogs.sounding_views import CombinedSoundingView, post_sounding
+from config import CACHE_DIR, SOUNDING_CHANNEL_ID
 
 logger = logging.getLogger("spc_bot")
 
@@ -48,7 +52,6 @@ class SoundingCog(commands.Cog):
         Background task to 'warm' the cache for soundings near an MD.
         Triggered when MesoscaleCog detects a high probability of watch issuance.
         """
-        from cogs.sounding_utils import get_md_area_centroid
         centroid = await get_md_area_centroid(raw_text)
         if not centroid:
             logger.debug(f"[SOUNDING-PREWARM] No centroid for MD #{md_num}")
@@ -83,8 +86,6 @@ class SoundingCog(commands.Cog):
         if watch_num in self._handled_watches:
             return
 
-        from config import CACHE_DIR, SOUNDING_CHANNEL_ID
-        
         # Use SOUNDING_CHANNEL_ID if configured, fallback to passed channel
         target_channel = self.bot.get_channel(SOUNDING_CHANNEL_ID) or channel
         
@@ -193,8 +194,6 @@ class SoundingCog(commands.Cog):
     async def auto_sounding_watches(self):
         """Post soundings for RAOB stations near active watches at 00z/12z."""
         await self.bot.wait_until_ready()
-        from config import SOUNDING_CHANNEL_ID
-
         now = datetime.now(timezone.utc)
         hour = now.hour
 
@@ -463,7 +462,6 @@ class SoundingCog(commands.Cog):
         mode_str = "\U0001f319 Dark" if dark_mode else "\u2600\ufe0f Light"
         embed.set_footer(text="Mode: {} | Select below".format(mode_str))
 
-        from cogs.sounding_views import CombinedSoundingView
         view = CombinedSoundingView(
             raob_stations=nearest,
             acars_profiles=acars_profiles,

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -11,11 +11,13 @@ import asyncio
 import logging
 import math
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import aiohttp
 import matplotlib
+import numpy as np
+from metpy.units import units
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
@@ -232,7 +234,6 @@ def get_recent_sounding_times(n: int = 4) -> list[tuple[str, str, str, str]]:
     """
     Return the n most recent 00z/12z sounding times that are in the past.
     """
-    from datetime import timedelta
     now = datetime.now(timezone.utc)
     times = []
     for days_back in range(5):
@@ -258,7 +259,6 @@ async def get_watch_area_centroid(affected_zones: list) -> tuple[float, float] |
     Fetch zone polygons from NWS and return the centroid of the watch area.
     Returns (lat, lon) or None on failure.
     """
-    import aiohttp
     all_lats = []
     all_lons = []
 
@@ -350,8 +350,6 @@ def _iem_to_clean_data(profile: dict, station_id: str, station_name: str,
     IEM fields: pres, hght, tmpc, dwpc, drct, sknt
     SounderPy fields: p, z, T, Td, u, v, site_info, titles
     """
-    import numpy as np
-    from metpy.units import units
 
     # Filter for levels that have both thermodynamic and wind data
     # Missing winds (None) are the primary cause of jagged/broken hodographs
@@ -377,7 +375,6 @@ def _iem_to_clean_data(profile: dict, station_id: str, station_name: str,
 
     # Parse valid time
     try:
-        from datetime import datetime, timezone
         if "Z" in valid:
             dt = datetime.fromisoformat(valid.replace("Z", "+00:00"))
         else:
@@ -470,7 +467,6 @@ async def get_available_sounding_times_iem(
     Checks all hours concurrently for speed. Results are cached for 15 minutes.
     Use skip_cache=True for auto-posting tasks that need fresh data.
     """
-    from datetime import timedelta
     now = datetime.now(timezone.utc)
 
     # Check cache (skip for auto-post tasks)
@@ -535,8 +531,9 @@ async def get_acars_profiles_near(
     Find available ACARS profiles near a location.
     Returns list of dicts sorted by distance.
     """
-    import sounderpy as spy
-    from datetime import timedelta
+    # sounderpy import is deferred: importing it eagerly triggers
+    # network I/O (station list fetch) that we want to avoid at startup.
+    import sounderpy as spy  # noqa: PLC0415
 
     now = datetime.now(timezone.utc)
     results = []
@@ -604,7 +601,7 @@ async def fetch_acars_sounding(
     year: str, month: str, day: str, hour: str,
 ) -> Optional[dict]:
     """Fetch an ACARS sounding profile and return SounderPy clean_data."""
-    import sounderpy as spy
+    import sounderpy as spy  # noqa: PLC0415  # deferred; see fetch_sounding
     loop = asyncio.get_running_loop()
     try:
         acars = await loop.run_in_executor(
@@ -632,7 +629,6 @@ async def filter_stations_with_data(stations: list[dict], n_times: int = 1) -> l
     are checked concurrently to keep total wait time minimal.
     Returns only stations that have at least one available sounding.
     """
-    import asyncio
     times = get_recent_sounding_times(n_times)
 
     async def has_data(station: dict) -> tuple[dict, bool]:
@@ -675,7 +671,6 @@ def validate_sounding_data(data: Optional[dict], min_levels: int = 5) -> bool:
         
     # Check for sufficient valid data (prevent crashes in SounderPy/ecape-parcel)
     try:
-        import numpy as np
         # Check if we have at least SOME non-zero wind data (prevent jagged hodographs)
         u_vals = np.array(data["u"])
         v_vals = np.array(data["v"])

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -55,7 +55,8 @@ async def get_user_dark_mode(user_id: int) -> bool:
     try:
         raw = await get_state(f"sounding_dark_{user_id}")
         return raw == "1" if raw is not None else False
-    except Exception:
+    except Exception as e:
+        logger.debug(f"[SOUNDING] Dark mode lookup failed for {user_id}: {e}")
         return False
 
 async def set_user_dark_mode(user_id: int, dark: bool):
@@ -326,7 +327,8 @@ async def get_md_area_centroid(raw_text: str) -> tuple[float, float] | None:
 
             lats.append(lat)
             lons.append(lon)
-        except Exception:
+        except Exception as e:
+            logger.debug(f"[CENTROID] Coordinate parse failed for part {part!r}: {e}")
             continue
 
     if not lats:
@@ -385,7 +387,8 @@ def _iem_to_clean_data(profile: dict, station_id: str, station_name: str,
             
         run_time = [str(dt.year), str(dt.month).zfill(2),
                     str(dt.day).zfill(2), f"{dt.hour:02d}:{dt.minute:02d}"]
-    except Exception:
+    except Exception as e:
+        logger.debug(f"[IEM] Datetime parse failed for {valid!r}: {e}")
         run_time = ["none", "none", "none", "none"]
 
     return {
@@ -572,7 +575,8 @@ async def get_acars_profiles_near(
                     )
                     airport_latlon = (float(latlon[0]), float(latlon[1]))
                     _ACARS_STATION_COORDS[airport_code] = airport_latlon
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"[ACARS] Airport lookup failed for {airport_code!r}: {e}")
                     continue
 
             dist = haversine(lat, lon, airport_latlon[0], airport_latlon[1])
@@ -667,7 +671,8 @@ def validate_sounding_data(data: Optional[dict], min_levels: int = 5) -> bool:
         for key in ("z", "T", "Td", "u", "v"):
             if len(data[key]) != p_len:
                 return False
-    except (TypeError, KeyError):
+    except (TypeError, KeyError) as e:
+        logger.debug(f"[SOUNDING] Structural validation failed: {e}")
         return False
         
     # Check for sufficient valid data (prevent crashes in SounderPy/ecape-parcel)

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -155,8 +155,8 @@ async def resolve_location(location: str) -> tuple[float, float, str]:
             if not match.empty:
                 row = match.iloc[0]
                 return float(row["lat"]), float(row["lon"]), f"RAOB station {loc}"
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"[SOUNDING] RAOB lookup for {loc!r} failed: {e}")
 
         # Try as METAR/radar site (K-prefix 4-letter)
         if len(loc) == 4 and loc.startswith("K"):
@@ -165,8 +165,8 @@ async def resolve_location(location: str) -> tuple[float, float, str]:
                     None, spy.get_latlon, "metar", loc
                 )
                 return float(latlon[0]), float(latlon[1]), f"radar site {loc}"
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"[SOUNDING] METAR lookup for {loc!r} failed: {e}")
 
     # Fall back to Nominatim geocoding
     lat, lon, display = await geocode_city(location)
@@ -498,8 +498,8 @@ async def get_available_sounding_times_iem(
                     str(dt.day).zfill(2),
                     str(dt.hour).zfill(2),
                 )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"[SOUNDING] IEM profile probe failed for {station_id}: {e}")
         return None
 
     times_to_check = [
@@ -681,8 +681,8 @@ def validate_sounding_data(data: Optional[dict], min_levels: int = 5) -> bool:
         t_vals = np.array(data["T"])
         if np.all(np.isnan(t_vals)):
             return False
-    except Exception:
-        pass
+    except (KeyError, TypeError, ValueError) as e:
+        logger.debug(f"[SOUNDING] Data validation check failed (accepting): {e}")
 
     return True
 

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -8,34 +8,35 @@ Utility functions for the sounding cog:
 """
 
 import asyncio
+import io
 import logging
 import math
 import re
+import sys
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import aiohttp
 import matplotlib
 import numpy as np
-from metpy.units import units
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-
-# Lock to serialize matplotlib plot generation (plt is not thread-safe)
-_PLOT_LOCK = asyncio.Lock()
 import pandas as pd
-import io
-import sys
+from metpy.units import units
 
-# Suppress SounderPy's startup banner
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402  # must follow matplotlib.use()
+
+# Suppress SounderPy's startup banner by redirecting stdout during import.
 _stdout = sys.stdout
 sys.stdout = io.StringIO()
 try:
-    import sounderpy as spy
+    import sounderpy as spy  # noqa: E402  # silenced banner import
 finally:
     sys.stdout = _stdout
 
-from utils.state_store import get_state, set_state
+from utils.state_store import get_state, set_state  # noqa: E402  # follows sounderpy import
+
+# Lock to serialize matplotlib plot generation (plt is not thread-safe)
+_PLOT_LOCK = asyncio.Lock()
 
 logger = logging.getLogger("spc_bot")
 

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -132,8 +132,8 @@ async def post_sounding(
                     color=discord.Color.green(),
                 )
                 await status_msg.edit(embed=done_embed, view=None)
-            except Exception:
-                pass
+            except discord.HTTPException as e:
+                logger.debug(f"[SOUNDING] Could not update status message: {e}")
 
     except Exception as e:
         logger.exception(f"[SOUNDING] Failed to post: {e}")
@@ -521,8 +521,8 @@ async def _post_from_clean_data(
             for msg in messages_to_delete:
                 try:
                     await msg.delete()
-                except Exception:
-                    pass
+                except discord.HTTPException as e:
+                    logger.debug(f"[SOUNDING] Could not delete message: {e}")
         await interaction.channel.send(caption, files=[discord.File(png_path)])
         logger.info(f"[SOUNDING] Posted {station_id} {year}/{month}/{day} {hour}z")
     except Exception as e:

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -21,8 +21,6 @@ from utils.spc_urls import get_spc_urls
 
 logger = logging.getLogger("spc_bot")
 
-BOT_START_TIME: Optional[datetime] = None
-
 
 async def send_with_handling(source, content: str, file_paths=None):
     file_paths = file_paths or []
@@ -371,8 +369,8 @@ class StatusCog(commands.Cog):
             "",
         ]
 
-        if BOT_START_TIME:
-            uptime = now - BOT_START_TIME
+        if self.bot.state.bot_start_time:
+            uptime = now - self.bot.state.bot_start_time
             lines.append(f"Uptime         : {format_timedelta(uptime)}")
         else:
             lines.append("Uptime         : unknown")

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -65,8 +65,8 @@ async def fetch_and_send_weather_images(
                 await source.followup.send(msg)
             else:
                 await source.send(msg)
-        except Exception:
-            pass
+        except discord.HTTPException as e:
+            logger.debug(f"[STATUS] Could not send fallback message: {e}")
         return
 
     files = await download_images_parallel(
@@ -88,8 +88,8 @@ async def fetch_and_send_weather_images(
                 await source.followup.send(msg)
             else:
                 await source.send(msg)
-        except Exception:
-            pass
+        except discord.HTTPException as e:
+            logger.debug(f"[STATUS] Could not send fallback message: {e}")
 
 
 class StatusCog(commands.Cog):

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -8,6 +8,7 @@ from typing import Optional
 import discord
 from discord.ext import commands, tasks
 
+from cogs.mesoscale import fetch_latest_md_numbers, fetch_md_details
 from config import MANUAL_CACHE_FILE, SCP_IMAGE_URLS, SPC_URLS, WPC_IMAGE_URLS, __version__
 import utils.http as _http
 from utils.cache import (
@@ -301,8 +302,6 @@ class StatusCog(commands.Cog):
     )
     async def md_slash(self, interaction: discord.Interaction):
         await interaction.response.defer()
-        from cogs.mesoscale import fetch_latest_md_numbers, fetch_md_details
-
         md_numbers = await fetch_latest_md_numbers()
         if not md_numbers:
             await interaction.followup.send(

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple
 
 import discord
 from discord.ext import commands, tasks
+from cogs.iembot import get_cached_watch_text
 from utils.backoff import TaskBackoff
 
 from config import (
@@ -156,8 +157,6 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
     including states, probabilities, hail size, and wind gusts.
     Returns (text_summary, image_url).
     """
-    import json as _json_iem
-    from datetime import datetime, timezone
     num_int = int(watch_number)
     year = datetime.now(timezone.utc).year
 
@@ -167,7 +166,7 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
         url = f"https://mesonet.agron.iastate.edu/json/watches.py?year={year}"
         content, status = await http_get_bytes(url, retries=2, timeout=15)
         if content and status == 200:
-            data = _json_iem.loads(content)
+            data = _json.loads(content)
             for event in data.get("events", []):
                 if event.get("num") == num_int:
                     states = event.get("states", "")
@@ -392,7 +391,6 @@ async def fetch_watch_details(
             )
 
     # Check iembot real-time cache first (populated within seconds of issuance)
-    from cogs.iembot import get_cached_watch_text
     cached_text = await get_cached_watch_text(watch_number)
     if cached_text and not text_summary:
         text_summary = cached_text

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -623,6 +623,8 @@ class WatchesCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._watches_backoff = TaskBackoff("auto_post_watches")
+
+    async def cog_load(self):
         self.auto_post_watches.start()
 
     def cog_unload(self):

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -96,8 +96,8 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
                     expires_dt = datetime.fromisoformat(expires_str).astimezone(
                         timezone.utc
                     )
-                except Exception:
-                    pass
+                except (ValueError, TypeError) as e:
+                    logger.debug(f"[WATCH] Could not parse expires {expires_str!r}: {e}")
             logger.debug(
                 f"[WATCH] NWS API: #{watch_num} ({wtype}) expires {expires_dt}"
             )
@@ -554,8 +554,8 @@ class WatchPaginatorView(discord.ui.View):
         if self.message:
             try:
                 await self.message.edit(view=self)
-            except Exception:
-                pass
+            except discord.HTTPException as e:
+                logger.debug(f"[WATCH] Could not disable view on timeout: {e}")
 
 
 async def _execute_watches(interaction: discord.Interaction, bot: commands.Bot):

--- a/main.py
+++ b/main.py
@@ -141,6 +141,7 @@ _task_alerted = set()
 # have been scheduled by the event loop, producing a spurious
 # startup "task is down" alert immediately followed by "recovered".
 _task_seen_running = set()
+_session_probe_failures = 0
 
 
 async def send_bot_alert(
@@ -218,6 +219,7 @@ async def on_command_error(ctx, error):
 # ── Watchdog ─────────────────────────────────────────────────────────────────
 @tasks.loop(minutes=2)
 async def watchdog_task():
+    global _session_probe_failures
     await bot.wait_until_ready()
 
     # If we are in STANDBY, do not monitor or restart tasks as they
@@ -228,26 +230,38 @@ async def watchdog_task():
     # Probe an endpoint we actually depend on. NWS API works as a liveness
     # check and tells us something about SPC/NWS reachability — the things
     # that would silently break posts. HEAD keeps the check cheap.
-    session_healthy = False
+    probe_healthy = False
     probe_url = "https://api.weather.gov/"
     if utils.http.http_session is not None and not utils.http.http_session.closed:
         try:
             async with utils.http.http_session.head(
                 probe_url,
-                timeout=aiohttp.ClientTimeout(total=5),
+                timeout=aiohttp.ClientTimeout(total=20),
                 allow_redirects=True,
             ) as r:
-                session_healthy = r.status < 500
+                probe_healthy = r.status < 500
         except Exception as e:
             logger.warning(f"[WATCHDOG] Session probe to {probe_url} failed: {e!r}")
 
-    if not session_healthy:
-        logger.warning(
-            "[WATCHDOG] Session is dead or unreachable — "
-            "tearing down and recreating"
-        )
-        await utils.http.close_session()
-        await utils.http.ensure_session()
+    if probe_healthy:
+        if _session_probe_failures > 0:
+            logger.info(f"[WATCHDOG] Session probe recovered after {_session_probe_failures} failure(s)")
+        _session_probe_failures = 0
+    else:
+        _session_probe_failures += 1
+        if _session_probe_failures >= 3:
+            logger.warning(
+                f"[WATCHDOG] Session probe failed {_session_probe_failures} consecutive times — "
+                "tearing down and recreating"
+            )
+            await utils.http.close_session()
+            await utils.http.ensure_session()
+            _session_probe_failures = 0
+        else:
+            logger.info(
+                f"[WATCHDOG] Session probe failed ({_session_probe_failures}/3) — "
+                "waiting for next cycle"
+            )
 
     # Grace period for startup race: tasks need a few ticks to schedule
     # their first iteration after wait_until_ready() unblocks.

--- a/main.py
+++ b/main.py
@@ -10,9 +10,8 @@ import aiohttp
 import discord
 from discord.ext import commands, tasks
 
-import cogs.status as status_cog
 from config import CACHE_DIR, CONFIG, HEALTH_CHANNEL_ID, TOKEN
-from utils.http import close_session, ensure_session, http_session
+import utils.http
 from utils.state_store import (
     check_integrity, close_db, get_db,
     get_all_hashes, get_posted_urls, get_posted_mds, get_posted_watches,
@@ -172,11 +171,11 @@ async def send_bot_alert(
 # ── Events ───────────────────────────────────────────────────────────────────
 @bot.event
 async def on_ready():
-    status_cog.BOT_START_TIME = datetime.now(timezone.utc)
+    bot.state.bot_start_time = datetime.now(timezone.utc)
 
     logger.info(f"Logged in as {bot.user} (id={bot.user.id})")
 
-    await ensure_session()
+    await utils.http.ensure_session()
 
     # Slash command sync
     try:
@@ -226,14 +225,14 @@ async def watchdog_task():
     if not bot.state.is_primary:
         return
 
-    # Probe an endpoint we actually depend on. Google works as a liveness
-    # check but tells us nothing about SPC/NWS reachability — the things
+    # Probe an endpoint we actually depend on. NWS API works as a liveness
+    # check and tells us something about SPC/NWS reachability — the things
     # that would silently break posts. HEAD keeps the check cheap.
     session_healthy = False
     probe_url = "https://api.weather.gov/"
-    if http_session is not None and not http_session.closed:
+    if utils.http.http_session is not None and not utils.http.http_session.closed:
         try:
-            async with http_session.head(
+            async with utils.http.http_session.head(
                 probe_url,
                 timeout=aiohttp.ClientTimeout(total=5),
                 allow_redirects=True,
@@ -247,8 +246,13 @@ async def watchdog_task():
             "[WATCHDOG] Session is dead or unreachable — "
             "tearing down and recreating"
         )
-        await close_session()
-        await ensure_session()
+        await utils.http.close_session()
+        await utils.http.ensure_session()
+
+    # Grace period for startup race: tasks need a few ticks to schedule
+    # their first iteration after wait_until_ready() unblocks.
+    if watchdog_task.current_loop == 0:
+        await asyncio.sleep(5)
 
     # Dynamically discover tasks from currently loaded cogs
     current_managed_tasks = []
@@ -272,16 +276,6 @@ async def watchdog_task():
                 )
             continue
 
-        # Suppress "stopped" alerts for tasks we've never seen running —
-        # the watchdog's first iteration can beat the cog task loops
-        # to the event loop after startup.
-        if name not in _task_seen_running:
-            logger.debug(
-                f"[WATCHDOG] Task '{name}' not yet running "
-                f"— deferring alert until first run observed"
-            )
-            continue
-
         _task_fail_counts[name] = _task_fail_counts.get(name, 0) + 1
         fail_count = _task_fail_counts[name]
         
@@ -296,11 +290,7 @@ async def watchdog_task():
             except (asyncio.CancelledError, asyncio.InvalidStateError) as e:
                 logger.debug(f"[WATCHDOG] Could not read task exception: {e}")
 
-        logger.warning(
-            f"[WATCHDOG] Task '{name}' has stopped "
-            f"(attempt #{fail_count}) — restarting. Error: {error_detail or 'None'}"
-        )
-
+        # Attempt to (re)start the task quietly
         try:
             task.cancel()
             inner = task.get_task()
@@ -312,33 +302,37 @@ async def watchdog_task():
                 except Exception as e:
                     logger.debug(f"[WATCHDOG] Error while awaiting cancelled task: {e}")
             task.start()
-            logger.info(f"[WATCHDOG] Successfully restarted '{name}'")
+            
+            log_fn = logger.info if name in _task_seen_running else logger.debug
+            log_fn(f"[WATCHDOG] Attempted to {'re' if name in _task_seen_running else ''}start '{name}'")
         except Exception as e:
             logger.exception(
                 f"[WATCHDOG] Failed to restart '{name}': {e}"
             )
 
-        is_critical_task = name in ("auto_post_watches", "auto_post_md")
-        alert_threshold = 1 if is_critical_task else 2
+        # Alerts — only for tasks we've seen running before to avoid startup noise
+        if name in _task_seen_running:
+            is_critical_task = name in ("auto_post_watches", "auto_post_md")
+            alert_threshold = 1 if is_critical_task else 2
 
-        if fail_count >= alert_threshold and name not in _task_alerted:
-            _task_alerted.add(name)
-            critical = is_critical_task
-            await send_bot_alert(
-                f"{name} is down",
-                f"The `{name}` task has stopped and the watchdog is "
-                f"attempting to restart it (attempt #{fail_count})."
-                f"{error_detail}\n\n"
-                + (
-                    "**Watch and MD alerts may be delayed — check "
-                    "[SPC directly](https://www.spc.noaa.gov) "
-                    "if severe weather is ongoing.**"
-                    if critical
-                    else "Outlook posts may be delayed until the "
-                    "task recovers."
-                ),
-                critical=critical,
-            )
+            if fail_count >= alert_threshold and name not in _task_alerted:
+                _task_alerted.add(name)
+                critical = is_critical_task
+                await send_bot_alert(
+                    f"{name} is down",
+                    f"The `{name}` task has stopped and the watchdog is "
+                    f"attempting to restart it (attempt #{fail_count})."
+                    f"{error_detail or ' Error: None'}\n\n"
+                    + (
+                        "**Watch and MD alerts may be delayed — check "
+                        "[SPC directly](https://www.spc.noaa.gov) "
+                        "if severe weather is ongoing.**"
+                        if critical
+                        else "Outlook posts may be delayed until the "
+                        "task recovers."
+                    ),
+                    critical=critical,
+                )
 
 
 # ── Graceful shutdown ────────────────────────────────────────────────────────
@@ -368,7 +362,7 @@ async def _shutdown():
     # 2. Close DB and HTTP session
     try:
         await asyncio.wait_for(
-            asyncio.gather(close_session(), close_db(), return_exceptions=True),
+            asyncio.gather(utils.http.close_session(), close_db(), return_exceptions=True),
             timeout=3.0,
         )
     except asyncio.TimeoutError:

--- a/main.py
+++ b/main.py
@@ -106,8 +106,8 @@ async def setup_hook():
             if csu_data.get("date") == today:
                 bot.state.csu_posted.update(str(d) for d in csu_data.get("days", []))
                 logger.info(f"[DB] Restored {len(bot.state.csu_posted)} CSU posted days")
-        except Exception:
-            pass
+        except (ValueError, KeyError, TypeError) as e:
+            logger.debug(f"[DB] CSU state parse failed (ignored): {e}")
 
     for day_key, urls in zip(["day1", "day2", "day3"], [d1_urls, d2_urls, d3_urls], strict=True):
         if isinstance(urls, list) and urls:
@@ -277,8 +277,8 @@ async def watchdog_task():
                 exc = inner_task.exception()
                 if exc:
                     error_detail = f"\n**Last Error:** `{type(exc).__name__}: {exc}`"
-            except Exception:
-                pass
+            except (asyncio.CancelledError, asyncio.InvalidStateError) as e:
+                logger.debug(f"[WATCHDOG] Could not read task exception: {e}")
 
         logger.warning(
             f"[WATCHDOG] Task '{name}' has stopped "
@@ -293,8 +293,8 @@ async def watchdog_task():
                     await asyncio.wait_for(asyncio.shield(inner), timeout=5.0)
                 except (asyncio.CancelledError, asyncio.TimeoutError):
                     pass
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"[WATCHDOG] Error while awaiting cancelled task: {e}")
             task.start()
             logger.info(f"[WATCHDOG] Successfully restarted '{name}'")
         except Exception as e:

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 # main.py
 import asyncio
+import json as _json
 import logging
 import os
 import signal
@@ -9,8 +10,9 @@ import aiohttp
 import discord
 from discord.ext import commands, tasks
 
-from config import CACHE_DIR, TOKEN, CONFIG
-from utils.http import close_session, ensure_session
+import cogs.status as status_cog
+from config import CACHE_DIR, CONFIG, HEALTH_CHANNEL_ID, TOKEN
+from utils.http import close_session, ensure_session, http_session
 from utils.state_store import (
     check_integrity, close_db, get_db,
     get_all_hashes, get_posted_urls, get_posted_mds, get_posted_watches,
@@ -51,8 +53,6 @@ bot.state.is_primary = IS_PRIMARY
 
 async def setup_hook():
     """Hydrate state from DB before any cogs are loaded."""
-    import json as _json
-
     # Initialize database
     db_ok = await check_integrity()
     if not db_ok:
@@ -143,8 +143,6 @@ async def send_bot_alert(
     title: str, description: str, critical: bool = False
 ):
     """Post a health alert embed to the health/SPC channel."""
-    from config import HEALTH_CHANNEL_ID
-
     try:
         channel = bot.get_channel(HEALTH_CHANNEL_ID)
         if not channel:
@@ -169,8 +167,6 @@ async def send_bot_alert(
 # ── Events ───────────────────────────────────────────────────────────────────
 @bot.event
 async def on_ready():
-    import cogs.status as status_cog
-
     status_cog.BOT_START_TIME = datetime.now(timezone.utc)
 
     logger.info(f"Logged in as {bot.user} (id={bot.user.id})")
@@ -224,8 +220,6 @@ async def watchdog_task():
     # are suppressed by the failover mechanism.
     if not bot.state.is_primary:
         return
-
-    from utils.http import http_session
 
     # Probe an endpoint we actually depend on. Google works as a liveness
     # check but tells us nothing about SPC/NWS reachability — the things

--- a/main.py
+++ b/main.py
@@ -137,6 +137,11 @@ bot.setup_hook = setup_hook
 # Watchdog state
 _task_fail_counts = {}
 _task_alerted = set()
+# Only alert when a task goes from running → stopped. Without this,
+# the first watchdog iteration can fire before the cog task loops
+# have been scheduled by the event loop, producing a spurious
+# startup "task is down" alert immediately followed by "recovered".
+_task_seen_running = set()
 
 
 async def send_bot_alert(
@@ -256,6 +261,7 @@ async def watchdog_task():
 
     for task, name in current_managed_tasks:
         if task.is_running():
+            _task_seen_running.add(name)
             if name in _task_alerted:
                 _task_alerted.discard(name)
                 _task_fail_counts[name] = 0
@@ -264,6 +270,16 @@ async def watchdog_task():
                     f"✅ The `{name}` task is running again.",
                     critical=False,
                 )
+            continue
+
+        # Suppress "stopped" alerts for tasks we've never seen running —
+        # the watchdog's first iteration can beat the cog task loops
+        # to the event loop after startup.
+        if name not in _task_seen_running:
+            logger.debug(
+                f"[WATCHDOG] Task '{name}' not yet running "
+                f"— deferring alert until first run observed"
+            )
             continue
 
         _task_fail_counts[name] = _task_fail_counts.get(name, 0) + 1

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+# Ruff configuration for spc-bot.
+# Keep this file minimal — ignores need a reason, not a vibe.
+
+line-length = 100
+
+# lib/vad_plotter is vendored third-party code. Not ours, not linted.
+extend-exclude = ["lib", "venv", ".venv"]
+
+[lint]
+# Per-iteration try/except in loops is deliberate error isolation
+# (e.g. cogs/failover.py loading extensions — one bad ext must not
+# abort the rest). The "performance" cost is nanoseconds on loops of
+# a dozen items; restructuring would change semantics.
+ignore = ["PERF203"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,3 +12,10 @@ extend-exclude = ["lib", "venv", ".venv"]
 # abort the rest). The "performance" cost is nanoseconds on loops of
 # a dozen items; restructuring would change semantics.
 ignore = ["PERF203"]
+
+[lint.per-file-ignores]
+# Tests and scripts routinely import inside functions: pytest fixtures,
+# per-test monkeypatching, and top-level import-time side effects that
+# must be deferred until a test sets up the environment.
+"tests/*" = ["PLC0415"]
+"scripts/*" = ["PLC0415"]

--- a/tests/test_main_lifecycle.py
+++ b/tests/test_main_lifecycle.py
@@ -50,7 +50,7 @@ async def test_shutdown_guard_ignores_duplicate_signals():
     # Patch the expensive / I/O-bound things `_shutdown` touches so the
     # test runs offline.
     with patch.object(main.bot, "close", new=AsyncMock(side_effect=_fake_close)), \
-         patch("main.close_session", new=AsyncMock()), \
+         patch("utils.http.close_session", new=AsyncMock()), \
          patch("main.close_db", new=AsyncMock()):
 
         # First invocation: runs cleanup.
@@ -107,8 +107,8 @@ async def test_watchdog_restart_awaits_cancelled_inner_task(monkeypatch):
     fake_cog.fake_task = fake_loop_task
 
     monkeypatch.setattr(main, "bot", _fake_bot_with_cogs({"fake_cog": fake_cog}))
-    monkeypatch.setattr(main, "ensure_session", AsyncMock())
-    monkeypatch.setattr(main, "close_session", AsyncMock())
+    monkeypatch.setattr(main.utils.http, "ensure_session", AsyncMock())
+    monkeypatch.setattr(main.utils.http, "close_session", AsyncMock())
     monkeypatch.setattr(main, "send_bot_alert", AsyncMock())
     monkeypatch.setattr("utils.http.http_session", None)
 
@@ -156,8 +156,8 @@ async def test_watchdog_standby_does_nothing(monkeypatch):
     cls = AsyncMock()
 
     monkeypatch.setattr(main, "bot", _fake_bot_with_cogs({}, is_primary=False))
-    monkeypatch.setattr(main, "ensure_session", ens)
-    monkeypatch.setattr(main, "close_session", cls)
+    monkeypatch.setattr(main.utils.http, "ensure_session", ens)
+    monkeypatch.setattr(main.utils.http, "close_session", cls)
 
     await main.watchdog_task.coro()
 

--- a/tests/test_main_lifecycle.py
+++ b/tests/test_main_lifecycle.py
@@ -114,6 +114,11 @@ async def test_watchdog_restart_awaits_cancelled_inner_task(monkeypatch):
 
     main._task_fail_counts.clear()
     main._task_alerted.clear()
+    # Simulate the task having been seen running before, so the
+    # watchdog treats its current 'stopped' state as a regression
+    # rather than a startup race.
+    main._task_seen_running.clear()
+    main._task_seen_running.add("fake_task")
 
     # Drive the watchdog. With a 5s wait_for and a never-finishing
     # inner, the wait must time out and the code must still reach

--- a/utils/backoff.py
+++ b/utils/backoff.py
@@ -67,7 +67,9 @@ class TaskBackoff:
         # Send alert at threshold
         if self._failures == 5 and bot:
             try:
-                from main import send_bot_alert
+                # main imports utils.* at module load, so importing
+                # main at the top of this file would deadlock.
+                from main import send_bot_alert  # noqa: PLC0415
                 await send_bot_alert(
                     f"{self.name} degraded",
                     f"Task `{self.name}` has failed **{self._failures}** times "

--- a/utils/db.py
+++ b/utils/db.py
@@ -14,6 +14,7 @@ Tables:
 """
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -369,7 +370,6 @@ async def get_posted_urls(day_key: str) -> list:
         ) as cursor:
             row = await cursor.fetchone()
             if row:
-                import json
                 return json.loads(row["urls"])
     except Exception as e:
         logger.warning(f"[DB] get_posted_urls failed for {day_key}: {e}")
@@ -378,7 +378,6 @@ async def get_posted_urls(day_key: str) -> list:
 
 async def set_posted_urls(day_key: str, urls: list):
     """Store last posted URLs for a day key."""
-    import json
     await _write(
         """INSERT INTO posted_urls (day_key, urls)
            VALUES (?, ?)

--- a/utils/http.py
+++ b/utils/http.py
@@ -15,8 +15,10 @@ _session_lock = asyncio.Lock()
 def _default_user_agent() -> str:
     # NWS/SPC require an identifying UA with contact info. Pulling the
     # version here keeps the string aligned with the release tag.
+    # Local import with try/except: falls back to "dev" if config
+    # import fails (e.g. during test collection without env vars).
     try:
-        from config import __version__
+        from config import __version__  # noqa: PLC0415
     except Exception:
         __version__ = "dev"
     contact = "https://github.com/full-bars/spc-bot"

--- a/utils/http.py
+++ b/utils/http.py
@@ -81,7 +81,7 @@ def _get_retry_after(response: aiohttp.ClientResponse) -> Optional[float]:
 async def http_get_bytes(
     url: str,
     retries: int = 3,
-    timeout: int = 10,
+    timeout: int = 30,
     headers: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[bytes], Optional[int]]:
     """Unconditional GET. Thin wrapper over the conditional variant with
@@ -102,7 +102,7 @@ async def http_get_bytes_conditional(
     etag: Optional[str] = None,
     last_modified: Optional[str] = None,
     retries: int = 3,
-    timeout: int = 10,
+    timeout: int = 30,
     extra_headers: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[bytes], Optional[int], Optional[Dict[str, str]]]:
     """Conditional GET. Returns (content, status, validators).
@@ -156,7 +156,7 @@ async def http_get_bytes_conditional(
 
 
 async def http_get_text(
-    url: str, retries: int = 3, timeout: int = 10
+    url: str, retries: int = 3, timeout: int = 30
 ) -> Optional[str]:
     content, status = await http_get_bytes(url, retries=retries, timeout=timeout)
     if content and status == 200:
@@ -164,7 +164,7 @@ async def http_get_text(
     return None
 
 
-async def http_head_ok(url: str, timeout: int = 5) -> bool:
+async def http_head_ok(url: str, timeout: int = 20) -> bool:
     """Cheap liveness check. HEAD only; no full-GET fallback (that defeats the point)."""
     try:
         session = await ensure_session()
@@ -177,7 +177,7 @@ async def http_head_ok(url: str, timeout: int = 5) -> bool:
         return False
 
 
-async def http_head_meta(url: str, timeout: int = 5) -> Optional[Dict[str, str]]:
+async def http_head_meta(url: str, timeout: int = 20) -> Optional[Dict[str, str]]:
     try:
         session = await ensure_session()
         async with session.head(

--- a/utils/state.py
+++ b/utils/state.py
@@ -102,6 +102,7 @@ class BotState:
     def __init__(self):
         self.is_primary: bool = True  # overridden by IS_PRIMARY env var in main.py
         self.iembot_last_seqnum: int = 0
+        self.bot_start_time: Optional[datetime] = None
 
         self.hashes = HashStore()
         self.posting = PostingLog()

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -92,6 +92,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import aiohttp
 
 from utils import db as sqlite_backend
+from utils.http import ensure_session
 
 logger = logging.getLogger("spc_bot")
 
@@ -164,8 +165,6 @@ async def _upstash_cmd(*args: Any) -> Any:
     for a in args:
         if a is None:
             raise ValueError("_upstash_cmd: None is not a valid argument")
-
-    from utils.http import ensure_session
 
     session = await ensure_session()
     try:


### PR DESCRIPTION
This PR consolidates several robustness and code quality improvements to handle high-latency environments, harden startup logic, and improve maintainability.

### 1. Robustness & Stability (Congested Networks)
- **Watchdog Improvements:**
    - Increased probe timeout from 5s to 20s.
    - Added a failure counter; requires 3 consecutive probe failures before recreating the HTTP session.
    - **Startup Race Fix:** Suppressed 'task is down' alerts during the initial startup race where tasks haven't scheduled their first iteration yet.
- **HTTP Timeouts:** Increased default GET timeouts to 30s and HEAD timeouts to 20s across the bot.
- **Session Handling:** Hardened aiohttp session lifecycle and startup reliability.

### 2. Mesoscale Discussion (MD) Reliability
- **Index Lag Protection:** Updated cancellation logic to recognize when the SPC website index lags behind the real-time feed, preventing "false cancellations".
- **Graphic Recovery:** Added an automatic background task to poll for and attach graphics to MD posts if they are missing at the time of issuance (resolving 403 Forbidden issues during fast-feed triggers).

### 3. Code Quality & Linting
- **Linting:** Added `ruff.toml` with project-specific rules (ignoring PERF203, excluding vendored libraries).
- **Import Cleanup:** Hoisted local imports where safe and used `noqa: PLC0415` for intentional ones; reordered imports in `sounding_utils`.
- **Error Handling:** Added debug logging to previously silent `except/pass` sites.
- **Refactoring:** Renamed ambiguous variables (e.g., 'l' to 'line') for better readability.