### PR TITLE
fix(sounding): QC IEM RAOB data to stop starburst hodographs (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.1.5] — 2026-04-22
+
+### Fixed
+- IEM RAOB profiles now go through per-level QC (direction 0–360°,
+  speed 0–300 kt, pressure 1–1100 hPa, Td ≤ T). Levels failing QC are
+  dropped before plotting, eliminating the "starburst" hodograph
+  artifacts reported in #87 (e.g. KILX 00z 2026-04-18).
+- IEM profiles are now sorted by pressure (descending) and deduped on
+  near-duplicate pressures (< 0.1 hPa apart). IEM occasionally returns
+  multiple wind vectors at the same pressure which produced radial
+  spokes in the hodograph.
+- `generate_plot` now catches `ValueError: zero-size array to reduction`
+  (and `fmin`/`fmax`) at `WARNING` level instead of surfacing a full
+  traceback.
+
+### Added
+- `sounding_quality_warning()` returns a short human-readable note when
+  a profile is plottable but low-quality (sparse winds or shallow
+  pressure coverage). RAOB captions in `cogs/sounding.py` and
+  `cogs/sounding_views.py` append the warning rather than suppressing
+  the plot.
+- `tests/test_sounding_qc.py`: 16 tests covering per-level QC, dedup,
+  pressure sorting, and the validator/warning split.
+
 ## [5.1.2] — 2026-04-22
 
 ### Changed

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -28,6 +28,7 @@ from cogs.sounding_utils import (
     parse_sounding_time,
     resolve_location,
     set_user_dark_mode,
+    sounding_quality_warning,
 )
 from cogs.sounding_views import CombinedSoundingView, post_sounding
 from config import CACHE_DIR, SOUNDING_CHANNEL_ID
@@ -149,6 +150,9 @@ class SoundingCog(commands.Cog):
                 f"**Auto Sounding — {station['name']} ({station_id})**\n"
                 f"Valid: {month}-{day}-{year} {hour}z | Near active {watch_label} #{watch_num}"
             )
+            qwarn = sounding_quality_warning(clean_data)
+            if qwarn:
+                caption += f"\n{qwarn}"
             try:
                 await target_channel.send(caption, files=[discord.File(png_path)])
                 logger.info(f"[SOUNDING-AUTO] Posted {station_id} for watch #{watch_num}")
@@ -274,6 +278,9 @@ class SoundingCog(commands.Cog):
                     f"Valid: {month}-{day}-{year} {sounding_time}z | "
                     f"Near active {watch_label} #{watch_num}"
                 )
+                qwarn = sounding_quality_warning(clean_data)
+                if qwarn:
+                    caption += f"\n{qwarn}"
                 try:
                     await channel.send(caption, files=[discord.File(png_path)])
                     logger.info(f"[SOUNDING-AUTO] Posted {station_id} for watch #{watch_num}")

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -346,6 +346,37 @@ _AVAILABILITY_CACHE: dict = {}
 AVAILABILITY_CACHE_TTL = 900  # 15 minutes
 
 
+def _iem_level_is_valid(lv: dict) -> bool:
+    """Per-level QC for IEM RAOB data. Rejects levels with physically
+    implausible values that produce jagged hodographs or plot crashes."""
+    try:
+        pres = lv.get("pres")
+        tmpc = lv.get("tmpc")
+        dwpc = lv.get("dwpc")
+        drct = lv.get("drct")
+        sknt = lv.get("sknt")
+        if None in (pres, tmpc, dwpc, drct, sknt):
+            return False
+        pres = float(pres)
+        tmpc = float(tmpc)
+        dwpc = float(dwpc)
+        drct = float(drct)
+        sknt = float(sknt)
+        if not (1.0 <= pres <= 1100.0):
+            return False
+        if not (-120.0 <= tmpc <= 60.0):
+            return False
+        if not (-150.0 <= dwpc <= 60.0) or dwpc > tmpc + 0.5:
+            return False
+        if not (0.0 <= drct <= 360.0):
+            return False
+        if not (0.0 <= sknt <= 300.0):
+            return False
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def _iem_to_clean_data(profile: dict, station_id: str, station_name: str,
                         lat: float, lon: float, elev: float, valid: str) -> dict:
     """
@@ -354,16 +385,34 @@ def _iem_to_clean_data(profile: dict, station_id: str, station_name: str,
     SounderPy fields: p, z, T, Td, u, v, site_info, titles
     """
 
-    # Filter for levels that have both thermodynamic and wind data
-    # Missing winds (None) are the primary cause of jagged/broken hodographs
-    levels = [lv for lv in profile if lv.get("pres") is not None
-              and lv.get("tmpc") is not None
-              and lv.get("dwpc") is not None
-              and lv.get("sknt") is not None
-              and lv.get("drct") is not None]
+    raw_count = len(profile) if profile else 0
+
+    # Per-level QC — reject physically implausible values that cause jagged
+    # hodographs or downstream plot crashes (issue #87).
+    levels = [lv for lv in profile if _iem_level_is_valid(lv)]
 
     if not levels:
         return None
+
+    # Sort by pressure descending (surface → top) and dedupe near-duplicate
+    # pressures. IEM sometimes returns multiple wind vectors at the same
+    # pressure, which produces starburst hodograph artifacts.
+    levels.sort(key=lambda lv: float(lv["pres"]), reverse=True)
+    deduped = []
+    last_p = None
+    for lv in levels:
+        p = float(lv["pres"])
+        if last_p is not None and abs(last_p - p) < 0.1:
+            continue
+        deduped.append(lv)
+        last_p = p
+    levels = deduped
+
+    if len(levels) < raw_count:
+        logger.debug(
+            f"[IEM] QC dropped {raw_count - len(levels)}/{raw_count} levels "
+            f"for {station_id}"
+        )
 
     pres = np.array([lv["pres"] for lv in levels], dtype=float)
     hght = np.array([lv.get("hght") or 0 for lv in levels], dtype=float)
@@ -678,19 +727,47 @@ def validate_sounding_data(data: Optional[dict], min_levels: int = 5) -> bool:
     # Check for sufficient valid data (prevent crashes in SounderPy/ecape-parcel)
     try:
         # Check if we have at least SOME non-zero wind data (prevent jagged hodographs)
-        u_vals = np.array(data["u"])
-        v_vals = np.array(data["v"])
+        u_vals = np.asarray(getattr(data["u"], "magnitude", data["u"]), dtype=float)
+        v_vals = np.asarray(getattr(data["v"], "magnitude", data["v"]), dtype=float)
         if np.all(np.isnan(u_vals) | (u_vals == 0)) and np.all(np.isnan(v_vals) | (v_vals == 0)):
             return False
-            
+
         # Check temperature validity (prevent fmin/fmax errors on empty/NaN arrays)
-        t_vals = np.array(data["T"])
+        t_vals = np.asarray(getattr(data["T"], "magnitude", data["T"]), dtype=float)
         if np.all(np.isnan(t_vals)):
             return False
     except (KeyError, TypeError, ValueError) as e:
         logger.debug(f"[SOUNDING] Data validation check failed (accepting): {e}")
 
     return True
+
+
+def sounding_quality_warning(data: Optional[dict]) -> Optional[str]:
+    """
+    Return a short human-readable warning string if the sounding is plottable
+    but low-quality (sparse winds or shallow pressure coverage). Returns None
+    when data looks healthy. Used to annotate Discord captions rather than
+    suppress the plot entirely (issue #87).
+    """
+    if not data:
+        return None
+    try:
+        u_vals = np.asarray(getattr(data["u"], "magnitude", data["u"]), dtype=float)
+        v_vals = np.asarray(getattr(data["v"], "magnitude", data["v"]), dtype=float)
+        p_vals = np.asarray(getattr(data["p"], "magnitude", data["p"]), dtype=float)
+
+        finite_wind = np.isfinite(u_vals) & np.isfinite(v_vals) & np.isfinite(p_vals)
+        n_wind = int(finite_wind.sum())
+        if n_wind < 8:
+            return f"⚠️ Low-quality data: only {n_wind} valid wind levels — hodograph may be sparse."
+
+        wind_p = p_vals[finite_wind]
+        span = float(wind_p.max() - wind_p.min())
+        if span < 300.0:
+            return f"⚠️ Low-quality data: wind coverage only spans {span:.0f} hPa — hodograph may be shallow."
+    except (KeyError, TypeError, ValueError) as e:
+        logger.debug(f"[SOUNDING] Quality assessment failed: {e}")
+    return None
 
 async def fetch_sounding(
     station_id: str,
@@ -759,6 +836,19 @@ async def generate_plot(
             lambda: _plot_sync(clean_data, output_path, dark_mode)
         )
         return True
+    except ValueError as e:
+        # SounderPy/MetPy raise ValueError with "zero-size array to reduction"
+        # when upstream data quality is insufficient (issue #87). Treat as a
+        # clean failure rather than a crash — validation should have caught
+        # this, but guard in case a profile slips through.
+        msg = str(e)
+        if "zero-size array" in msg or "fmin" in msg or "fmax" in msg:
+            logger.warning(
+                f"[SOUNDING] Plot failed due to insufficient data quality: {e}"
+            )
+            return False
+        logger.exception(f"[SOUNDING] Plot generation failed: {e}")
+        return False
     except Exception as e:
         logger.exception(f"[SOUNDING] Plot generation failed: {e}")
         return False

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -14,6 +14,7 @@ from cogs.sounding_utils import (
     generate_plot,
     get_available_sounding_times_iem,
     get_recent_sounding_times,
+    sounding_quality_warning,
 )
 from config import CACHE_DIR
 
@@ -118,6 +119,9 @@ async def post_sounding(
     caption = "**RAOB Sounding \u2014 {}**\nValid: {} | {} mode{}".format(
         label, time_label, mode_label, fallback_note
     )
+    qwarn = sounding_quality_warning(clean_data)
+    if qwarn:
+        caption += f"\n{qwarn}"
 
     try:
         await interaction.channel.send(caption, files=[discord.File(png_path)])
@@ -515,6 +519,9 @@ async def _post_from_clean_data(
         f"**RAOB Sounding \u2014 {station_name} ({station_id})**\n"
         f"Valid: {month}-{day}-{year} {hour}z | {mode_label} mode"
     )
+    qwarn = sounding_quality_warning(clean_data)
+    if qwarn:
+        caption += f"\n{qwarn}"
     try:
         await status_msg.delete()
         if messages_to_delete:

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Single source of truth for the release displayed in /help.
 # Bump this in the same commit as the git tag.
-__version__ = "5.1.2"
+__version__ = "5.1.5"
 
 load_dotenv()
 

--- a/tests/test_sounding_qc.py
+++ b/tests/test_sounding_qc.py
@@ -1,0 +1,175 @@
+"""
+Tests for IEM RAOB data quality controls (issue #87).
+
+Covers:
+- Per-level QC rejects physically implausible winds / thermo
+- _iem_to_clean_data dedups duplicate-pressure levels and sorts descending
+- validate_sounding_data requires dense winds over a meaningful span
+"""
+
+import numpy as np
+import pytest
+
+
+def _good_level(pres, tmpc=10.0, dwpc=5.0, drct=270.0, sknt=20.0, hght=1000.0):
+    return {
+        "pres": pres, "hght": hght,
+        "tmpc": tmpc, "dwpc": dwpc,
+        "drct": drct, "sknt": sknt,
+    }
+
+
+def _good_profile(n=12):
+    # Surface 1000 hPa → 200 hPa, roughly realistic.
+    pressures = np.linspace(1000, 200, n)
+    return [_good_level(float(p), tmpc=20 - i, dwpc=15 - i,
+                         drct=200 + i * 5, sknt=10 + i * 3,
+                         hght=i * 1000.0)
+            for i, p in enumerate(pressures)]
+
+
+class TestIemLevelQC:
+    def test_rejects_none_winds(self):
+        from cogs.sounding_utils import _iem_level_is_valid
+        assert not _iem_level_is_valid(_good_level(500, drct=None))
+        assert not _iem_level_is_valid(_good_level(500, sknt=None))
+
+    def test_rejects_out_of_range_direction(self):
+        from cogs.sounding_utils import _iem_level_is_valid
+        assert not _iem_level_is_valid(_good_level(500, drct=-10))
+        assert not _iem_level_is_valid(_good_level(500, drct=361))
+
+    def test_rejects_absurd_speed(self):
+        from cogs.sounding_utils import _iem_level_is_valid
+        assert not _iem_level_is_valid(_good_level(500, sknt=-5))
+        assert not _iem_level_is_valid(_good_level(500, sknt=500))
+
+    def test_rejects_bogus_pressure(self):
+        from cogs.sounding_utils import _iem_level_is_valid
+        assert not _iem_level_is_valid(_good_level(0.5))
+        assert not _iem_level_is_valid(_good_level(2000))
+
+    def test_rejects_dewpoint_above_temp(self):
+        from cogs.sounding_utils import _iem_level_is_valid
+        assert not _iem_level_is_valid(_good_level(500, tmpc=-10, dwpc=5))
+
+    def test_accepts_clean_level(self):
+        from cogs.sounding_utils import _iem_level_is_valid
+        assert _iem_level_is_valid(_good_level(500))
+
+
+class TestIemToCleanData:
+    def test_clean_profile_converts(self):
+        from cogs.sounding_utils import _iem_to_clean_data
+        out = _iem_to_clean_data(
+            _good_profile(12), "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert out is not None
+        assert len(out["p"]) == 12
+
+    def test_dedups_duplicate_pressures(self):
+        from cogs.sounding_utils import _iem_to_clean_data
+        profile = _good_profile(10)
+        # Inject a duplicate of level 3 with wildly different winds — the
+        # starburst hodograph failure mode from issue #87.
+        dup = dict(profile[3])
+        dup["drct"] = 90.0
+        dup["sknt"] = 120.0
+        profile.append(dup)
+        out = _iem_to_clean_data(
+            profile, "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert out is not None
+        # Duplicate should have been dropped.
+        assert len(out["p"]) == 10
+
+    def test_drops_corrupted_levels(self):
+        from cogs.sounding_utils import _iem_to_clean_data
+        profile = _good_profile(10)
+        profile.append(_good_level(400, drct=720, sknt=50))  # bad dir
+        profile.append(_good_level(300, drct=180, sknt=500))  # bad speed
+        out = _iem_to_clean_data(
+            profile, "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert out is not None
+        assert len(out["p"]) == 10
+
+    def test_returns_none_when_all_bad(self):
+        from cogs.sounding_utils import _iem_to_clean_data
+        bad = [_good_level(500, drct=720) for _ in range(5)]
+        out = _iem_to_clean_data(
+            bad, "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert out is None
+
+    def test_pressures_sorted_descending(self):
+        from cogs.sounding_utils import _iem_to_clean_data
+        profile = _good_profile(10)
+        profile.reverse()  # scrambled order
+        out = _iem_to_clean_data(
+            profile, "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        p = np.asarray(out["p"].magnitude)
+        assert np.all(np.diff(p) < 0)
+
+
+class TestSoundingQualityWarning:
+    def test_warns_on_sparse_winds(self):
+        from cogs.sounding_utils import _iem_to_clean_data, sounding_quality_warning
+        out = _iem_to_clean_data(
+            _good_profile(5), "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert out is not None
+        warning = sounding_quality_warning(out)
+        assert warning is not None
+        assert "wind" in warning.lower()
+
+    def test_warns_on_shallow_pressure_span(self):
+        from cogs.sounding_utils import _iem_to_clean_data, sounding_quality_warning
+        pressures = np.linspace(1000, 900, 10)
+        profile = [_good_level(float(p), drct=200 + i, sknt=10)
+                   for i, p in enumerate(pressures)]
+        out = _iem_to_clean_data(
+            profile, "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert out is not None
+        warning = sounding_quality_warning(out)
+        assert warning is not None
+        assert "span" in warning.lower() or "shallow" in warning.lower()
+
+    def test_no_warning_for_good_profile(self):
+        from cogs.sounding_utils import _iem_to_clean_data, sounding_quality_warning
+        out = _iem_to_clean_data(
+            _good_profile(12), "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert sounding_quality_warning(out) is None
+
+    def test_validator_still_accepts_good_profile(self):
+        from cogs.sounding_utils import _iem_to_clean_data, validate_sounding_data
+        out = _iem_to_clean_data(
+            _good_profile(12), "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert validate_sounding_data(out) is True
+
+    def test_validator_accepts_sparse_profile(self):
+        """Validator should not withhold plottable data — low quality is a warning, not a rejection."""
+        from cogs.sounding_utils import _iem_to_clean_data, validate_sounding_data
+        out = _iem_to_clean_data(
+            _good_profile(5), "KILX", "Lincoln", 40.15, -89.33, 180,
+            valid="2026-04-18T00:00:00Z",
+        )
+        assert out is not None
+        assert validate_sounding_data(out) is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #87.

## Summary
- Adds per-level QC for IEM RAOB profiles — rejects levels with out-of-range wind direction (0–360°), absurd speeds (>300 kt), bogus pressures, or Td > T. Kills the starburst/radial-spoke hodograph failure mode (KILX 00z 2026-04-18 was the canonical case).
- Sorts IEM levels by pressure descending and dedupes near-duplicate pressures (< 0.1 hPa apart) — IEM occasionally returns multiple wind vectors at the same level.
- Soft quality warning rather than hard rejection: `sounding_quality_warning()` returns a short ⚠️ note appended to Discord RAOB captions when a profile is plottable but sparse or shallow. The plot still renders.
- `generate_plot` now catches the `zero-size array to reduction` / `fmin` / `fmax` ValueErrors at WARNING level instead of surfacing a full traceback.
- Wyoming-first at 00z/12z confirmed intact in existing code (sequential fallback, no race).
- Bumps `config.__version__` → 5.1.5 and adds a CHANGELOG entry.

ACARS paths are untouched — the issue explicitly flagged ACARS as unaffected.

## Test plan
- [x] `pytest tests/test_sounding_qc.py` — 16 new tests pass
- [x] Full suite: 187 passed
- [x] `ruff check` clean on all touched files
- [ ] Smoke-test `/sounding KILX 2026-04-18 00z` in dev once deployed — confirm hodograph renders cleanly (or with warning caption)