### PR TITLE
fix(failover): probe Upstash lease before loading cogs on primary boot

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -100,6 +100,62 @@ class FailoverCog(commands.Cog):
         self._session = aiohttp.ClientSession()
         self.sync_loop.start()
 
+    async def startup_lease_check(self) -> bool:
+        """Synchronous lease probe run during setup_hook, before other cogs
+        are loaded. Decides whether this node should boot as primary.
+
+        Returns True if this node should load cogs as primary, False if it
+        should stay standby. Updates `bot.state.is_primary` accordingly.
+
+        Closes the 30-second window where a rebooting primary would load
+        cogs and post duplicates before the first sync_loop tick detected
+        another node already held the lease.
+        """
+        # Manual override wins over env var and over the lease.
+        manual = await self._upstash("GET", "spcbot:manual_primary")
+        if manual:
+            if manual == self._identity:
+                logger.info(
+                    f"[FAILOVER] Startup: manual override names us "
+                    f"('{self._identity}') as Primary — claiming lease"
+                )
+                await self._write_lease()
+                self.bot.state.is_primary = True
+                return True
+            logger.info(
+                f"[FAILOVER] Startup: manual override names '{manual}' as "
+                f"Primary — booting as STANDBY"
+            )
+            self.bot.state.is_primary = False
+            return False
+
+        holder = await self._read_lease_holder()
+        if holder and holder != self._identity:
+            logger.warning(
+                f"[FAILOVER] Startup: lease held by '{holder}' — booting as "
+                f"STANDBY regardless of IS_PRIMARY env"
+            )
+            self.bot.state.is_primary = False
+            return False
+
+        # Lease is free or already ours. Safe to boot as primary if that's
+        # what we were configured as. If IS_PRIMARY=false (dedicated
+        # standby), stay standby and let the sync_loop promote us later if
+        # the primary actually dies.
+        if not self.bot.state.is_primary:
+            logger.info(
+                "[FAILOVER] Startup: lease is free but node configured as "
+                "STANDBY — not self-promoting"
+            )
+            return False
+
+        logger.info(
+            f"[FAILOVER] Startup: lease free/ours — claiming as Primary "
+            f"('{self._identity}')"
+        )
+        await self._write_lease()
+        return True
+
     async def cog_unload(self):
         self.sync_loop.cancel()
         if self.bot.state.is_primary:
@@ -297,6 +353,21 @@ class FailoverCog(commands.Cog):
             urls = await state_store.get_posted_urls(day_key)
             if urls:
                 st.last_posted_urls[day_key] = urls
+
+        # Pull today's CSU-MLP posted-days set so we don't re-post panels
+        # the outgoing primary already handled this UTC day.
+        csu_raw = await state_store.get_state("csu_mlp_posted")
+        if isinstance(csu_raw, str):
+            try:
+                import json as _json
+                from datetime import datetime, timezone
+                csu_data = _json.loads(csu_raw)
+                today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+                if csu_data.get("date") == today:
+                    st.csu_posted.update(str(d) for d in csu_data.get("days", []))
+            except (ValueError, KeyError, TypeError) as e:
+                logger.debug(f"[FAILOVER] CSU state parse failed (ignored): {e}")
+
         logger.info("[FAILOVER] Rehydrated BotState from Upstash")
 
     async def _demote(self) -> None:

--- a/main.py
+++ b/main.py
@@ -121,9 +121,26 @@ async def setup_hook():
 
     logger.info("[DB] Database ready")
 
-    # Register failover cog
+    # Register failover cog first so it can probe Upstash for the lease
+    # before we decide whether to load the rest. Without this check, a
+    # primary reboot races its own sync_loop: cogs start posting using
+    # stale in-memory state during the ~30s window before the first
+    # lease probe fires, duplicating anything the current lease holder
+    # posted while we were down.
     await bot.load_extension("cogs.failover")
-    if IS_PRIMARY:
+    failover_cog = bot.get_cog("FailoverCog")
+    should_run_primary = IS_PRIMARY
+    if failover_cog is not None:
+        try:
+            should_run_primary = await failover_cog.startup_lease_check()
+        except Exception as e:
+            logger.warning(
+                f"[FAILOVER] Startup lease check failed ({e!r}) — "
+                f"falling back to IS_PRIMARY env value and deferring to "
+                f"sync_loop for reconciliation"
+            )
+
+    if should_run_primary:
         for ext in ALL_EXTENSIONS:
             await bot.load_extension(ext)
     else:

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -252,3 +252,339 @@ async def test_demote_flips_flag_unloads_cogs(monkeypatch):
     assert cog.bot.state.is_primary is False
     assert cog.bot.unload_extension.call_count == len(failover_module.ALL_EXTENSIONS)
     assert cog._primary_failures == 0
+
+
+# ── Startup lease check (boot-time race prevention) ─────────────────────────
+#
+# These tests cover the window that bit us in prod on 2026-04-23: the
+# rebooting primary loaded cogs as primary based purely on the IS_PRIMARY
+# env var, fired its first MD-scan task, and posted a duplicate ~13s
+# before the failover sync_loop's first tick detected another node owned
+# the lease and demoted. `startup_lease_check` is the synchronous probe
+# that now runs inside setup_hook, before the other cogs are loaded.
+
+
+async def test_startup_lease_free_primary_configured_claims_lease(monkeypatch):
+    """Lease free + IS_PRIMARY=true → claim it and boot as primary."""
+    mock = _stub_upstash({"GET": None})
+    monkeypatch.setattr(FailoverCog, "_upstash", mock)
+
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "me"
+
+    result = await cog.startup_lease_check()
+
+    assert result is True
+    assert cog.bot.state.is_primary is True
+    sets = [c for c in mock.calls if c[0] == "SET" and c[1] == failover_module.LEASE_KEY]
+    assert sets, "expected lease SET after claiming"
+    assert sets[0][2] == "me"
+
+
+async def test_startup_lease_held_by_us_keeps_primary(monkeypatch):
+    """Same node rebooted quickly — TTL hasn't expired yet. Still ours."""
+    mock = _stub_upstash({"GET": "me"})
+    monkeypatch.setattr(FailoverCog, "_upstash", mock)
+
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "me"
+
+    result = await cog.startup_lease_check()
+
+    assert result is True
+    assert cog.bot.state.is_primary is True
+
+
+async def test_startup_lease_held_by_other_forces_standby(monkeypatch):
+    """The exact scenario from the 2026-04-23 incident: 3cape held the
+    lease via manual override, ubunt-server came back with IS_PRIMARY=true
+    and must NOT load cogs."""
+    mock = _stub_upstash({"GET": "3cape"})
+    monkeypatch.setattr(FailoverCog, "_upstash", mock)
+
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "ubunt-server"
+
+    result = await cog.startup_lease_check()
+
+    assert result is False
+    assert cog.bot.state.is_primary is False
+    # And critically, we did NOT overwrite the lease.
+    set_lease = [
+        c for c in mock.calls
+        if c[0] == "SET" and c[1] == failover_module.LEASE_KEY
+    ]
+    assert set_lease == [], "must not clobber another node's lease on boot"
+
+
+async def test_startup_manual_override_for_us_beats_lease(monkeypatch):
+    """/failover set to us: claim the lease even if someone else holds it.
+    This matches the sync_loop manual-override semantics so the boot path
+    doesn't have different rules than steady-state."""
+    mock = _stub_upstash({
+        "GET": None,  # catch-all; responses dict matches by command name
+    })
+    # Custom per-key response — the stub helper only keys by command, so
+    # we roll our own for this case.
+    calls = []
+
+    async def upstash(*args):
+        calls.append(args)
+        if args[0] == "GET" and args[1] == "spcbot:manual_primary":
+            return "me"
+        if args[0] == "GET" and args[1] == failover_module.LEASE_KEY:
+            return "someone-else"
+        return None
+
+    monkeypatch.setattr(FailoverCog, "_upstash", AsyncMock(side_effect=upstash))
+
+    cog = FailoverCog(_make_bot(is_primary=False))  # env says standby
+    cog._identity = "me"
+
+    result = await cog.startup_lease_check()
+
+    assert result is True
+    assert cog.bot.state.is_primary is True
+    set_lease = [
+        c for c in calls
+        if c[0] == "SET" and c[1] == failover_module.LEASE_KEY
+    ]
+    assert set_lease, "manual override for us should claim the lease"
+
+
+async def test_startup_manual_override_for_other_forces_standby(monkeypatch):
+    """/failover set to another node: stay standby even if we're the
+    configured primary and the lease appears free."""
+    calls = []
+
+    async def upstash(*args):
+        calls.append(args)
+        if args[0] == "GET" and args[1] == "spcbot:manual_primary":
+            return "3cape"
+        if args[0] == "GET" and args[1] == failover_module.LEASE_KEY:
+            return None  # lease even looks free
+        return None
+
+    monkeypatch.setattr(FailoverCog, "_upstash", AsyncMock(side_effect=upstash))
+
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "ubunt-server"
+
+    result = await cog.startup_lease_check()
+
+    assert result is False
+    assert cog.bot.state.is_primary is False
+    # Must not have written the lease — would steal from the override target.
+    set_lease = [
+        c for c in calls
+        if c[0] == "SET" and c[1] == failover_module.LEASE_KEY
+    ]
+    assert set_lease == []
+
+
+async def test_startup_lease_free_standby_configured_stays_standby(monkeypatch):
+    """Dedicated standby (IS_PRIMARY=false) must not grab a free lease on
+    boot — the live primary might just be between heartbeats. The
+    sync_loop will still promote after MAX_FAILURES if the primary is
+    actually gone."""
+    mock = _stub_upstash({"GET": None})
+    monkeypatch.setattr(FailoverCog, "_upstash", mock)
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    cog._identity = "3cape"
+
+    result = await cog.startup_lease_check()
+
+    assert result is False
+    assert cog.bot.state.is_primary is False
+    set_lease = [
+        c for c in mock.calls
+        if c[0] == "SET" and c[1] == failover_module.LEASE_KEY
+    ]
+    assert set_lease == []
+
+
+async def test_startup_upstash_unreachable_falls_back_to_env(monkeypatch):
+    """If Upstash is hosed, _upstash returns None for every call. Treat
+    that as 'lease is free' would clobber whatever holder exists when
+    Upstash recovers — so both nodes could end up claiming. The boot
+    path instead trusts IS_PRIMARY=true and writes its own lease, which
+    is the old (pre-fix) behavior and is acceptable because without
+    Upstash coordination is impossible anyway. The test here just pins
+    the current contract so changes to it are intentional."""
+    mock = _stub_upstash({})  # everything returns None
+    monkeypatch.setattr(FailoverCog, "_upstash", mock)
+
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "me"
+
+    result = await cog.startup_lease_check()
+
+    # With IS_PRIMARY=true and nothing in Upstash (looks free), we claim.
+    assert result is True
+    assert cog.bot.state.is_primary is True
+
+
+# ── Incident replay: the 2026-04-23 manual-override-clear sequence ─────────
+
+
+async def test_incident_primary_reboot_during_manual_override_stays_standby(
+    monkeypatch,
+):
+    """Reconstruct the exact failure mode:
+
+      1. User ran /failover 3cape → spcbot:manual_primary = '3cape'.
+      2. 3cape held the lease.
+      3. ubunt-server (the "real" primary, IS_PRIMARY=true) rebooted.
+
+    Pre-fix: ubunt-server loaded cogs immediately, posted dup MDs/watches,
+    demoted ~30s later. Post-fix: ubunt-server must see the manual
+    override and stay standby, no cogs loaded."""
+
+    async def upstash(*args):
+        if args[0] == "GET" and args[1] == "spcbot:manual_primary":
+            return "3cape"
+        if args[0] == "GET" and args[1] == failover_module.LEASE_KEY:
+            return "3cape"
+        return None
+
+    monkeypatch.setattr(FailoverCog, "_upstash", AsyncMock(side_effect=upstash))
+
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "ubunt-server"
+
+    should_run_primary = await cog.startup_lease_check()
+
+    assert should_run_primary is False
+    assert cog.bot.state.is_primary is False
+
+
+async def test_incident_after_override_cleared_standby_until_lease_released(
+    monkeypatch,
+):
+    """Next beat of the incident: the user cleared the override while
+    3cape still held the lease. A restart of ubunt-server at this moment
+    must still stay standby — the lease holder is authoritative, env
+    var is not."""
+
+    async def upstash(*args):
+        if args[0] == "GET" and args[1] == "spcbot:manual_primary":
+            return None  # override cleared
+        if args[0] == "GET" and args[1] == failover_module.LEASE_KEY:
+            return "3cape"  # but 3cape still heartbeating
+        return None
+
+    monkeypatch.setattr(FailoverCog, "_upstash", AsyncMock(side_effect=upstash))
+
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "ubunt-server"
+
+    should_run_primary = await cog.startup_lease_check()
+
+    assert should_run_primary is False
+    assert cog.bot.state.is_primary is False
+
+
+async def test_incident_after_3cape_releases_primary_boots_clean(monkeypatch):
+    """Final beat: override cleared, 3cape shut down and released the
+    lease. ubunt-server now boots → sees no manual, no lease holder,
+    IS_PRIMARY=true → claims the lease and loads cogs. This is the
+    only beat in the sequence where cogs should load."""
+    calls = []
+
+    async def upstash(*args):
+        calls.append(args)
+        if args[0] == "GET" and args[1] == "spcbot:manual_primary":
+            return None
+        if args[0] == "GET" and args[1] == failover_module.LEASE_KEY:
+            return None
+        return None
+
+    monkeypatch.setattr(FailoverCog, "_upstash", AsyncMock(side_effect=upstash))
+
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "ubunt-server"
+
+    should_run_primary = await cog.startup_lease_check()
+
+    assert should_run_primary is True
+    assert cog.bot.state.is_primary is True
+    assert any(
+        c[0] == "SET" and c[1] == failover_module.LEASE_KEY and c[2] == "ubunt-server"
+        for c in calls
+    ), "primary should claim lease once it's free"
+
+
+# ── Rehydrate pulls csu_posted from Upstash ─────────────────────────────────
+
+
+async def test_rehydrate_pulls_csu_posted_for_today(monkeypatch):
+    """Promotion must refresh csu_posted so we don't re-post CSU-MLP
+    panels the outgoing primary already handled this UTC day."""
+    from datetime import datetime, timezone
+    from utils import state_store
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    csu_payload = f'{{"date": "{today}", "days": ["1", "2", "3", "hazard_1_2"]}}'
+
+    async def fake_get_state(key):
+        if key == "csu_mlp_posted":
+            return csu_payload
+        return None
+
+    monkeypatch.setattr(state_store, "get_all_hashes", AsyncMock(return_value={}))
+    monkeypatch.setattr(state_store, "get_posted_mds", AsyncMock(return_value=set()))
+    monkeypatch.setattr(state_store, "get_posted_watches", AsyncMock(return_value=set()))
+    monkeypatch.setattr(state_store, "get_state", AsyncMock(side_effect=fake_get_state))
+    monkeypatch.setattr(state_store, "get_posted_urls", AsyncMock(return_value=[]))
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    await cog._rehydrate_bot_state()
+
+    assert cog.bot.state.csu_posted == {"1", "2", "3", "hazard_1_2"}
+
+
+async def test_rehydrate_ignores_stale_csu_posted_from_yesterday(monkeypatch):
+    """If the Upstash blob is from a previous UTC day, don't load it —
+    today's posts haven't happened yet and loading yesterday's set
+    would suppress them."""
+    from utils import state_store
+
+    stale_payload = '{"date": "1999-01-01", "days": ["1", "2", "3"]}'
+
+    async def fake_get_state(key):
+        if key == "csu_mlp_posted":
+            return stale_payload
+        return None
+
+    monkeypatch.setattr(state_store, "get_all_hashes", AsyncMock(return_value={}))
+    monkeypatch.setattr(state_store, "get_posted_mds", AsyncMock(return_value=set()))
+    monkeypatch.setattr(state_store, "get_posted_watches", AsyncMock(return_value=set()))
+    monkeypatch.setattr(state_store, "get_state", AsyncMock(side_effect=fake_get_state))
+    monkeypatch.setattr(state_store, "get_posted_urls", AsyncMock(return_value=[]))
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    cog.bot.state.csu_posted.clear()
+    await cog._rehydrate_bot_state()
+
+    assert cog.bot.state.csu_posted == set()
+
+
+async def test_rehydrate_tolerates_malformed_csu_state(monkeypatch):
+    """A garbled csu_mlp_posted blob must not break promotion."""
+    from utils import state_store
+
+    async def fake_get_state(key):
+        if key == "csu_mlp_posted":
+            return "{not valid json"
+        return None
+
+    monkeypatch.setattr(state_store, "get_all_hashes", AsyncMock(return_value={}))
+    monkeypatch.setattr(state_store, "get_posted_mds", AsyncMock(return_value=set()))
+    monkeypatch.setattr(state_store, "get_posted_watches", AsyncMock(return_value=set()))
+    monkeypatch.setattr(state_store, "get_state", AsyncMock(side_effect=fake_get_state))
+    monkeypatch.setattr(state_store, "get_posted_urls", AsyncMock(return_value=[]))
+
+    cog = FailoverCog(_make_bot(is_primary=False))
+    # Should not raise.
+    await cog._rehydrate_bot_state()


### PR DESCRIPTION
## Summary
- Adds `startup_lease_check()` to the failover cog and calls it from `setup_hook` **before** loading the rest of the cogs, so a rebooting primary never posts against stale in-memory state while the sync_loop is still 0–30s away from its first tick.
- `_rehydrate_bot_state()` now also pulls today's `csu_mlp_posted` so CSU-MLP panels aren't re-posted on promotion.
- 13 new failover tests (200 passing, up from 187).

## Incident
2026-04-23: `/failover` pinned 3cape as manual primary overnight. When ubunt-server came back online (IS_PRIMARY=true), it loaded cogs immediately, posted MD #0505 at 13:33:04, then demoted at 13:33:04 once the sync_loop read the lease. This happened three times across three quick restarts, plus duplicate sounding auto-posts for the active watches (#0134, #0135, #0136).

## Boot-time decision (new)
1. Read `spcbot:manual_primary`. If it names us → claim lease, boot primary. If it names another node → standby.
2. Read `spcbot:primary_url`. If held by another node → standby, regardless of `IS_PRIMARY`.
3. Lease free/ours + `IS_PRIMARY=true` → claim and boot primary.
4. Lease free + `IS_PRIMARY=false` (dedicated standby) → don't self-promote; sync_loop will still promote after `MAX_FAILURES` if the primary is actually gone.

## Test plan
- [x] `pytest tests/test_failover_coverage.py` (29 tests, all pass)
- [x] Full suite `pytest` (200 tests, all pass)
- [ ] Deploy and watch `spclog` on next primary restart for `[FAILOVER] Startup: ...` lines confirming the chosen branch.
- [ ] Simulate `/failover` + clear override sequence in prod to confirm no dup posts.