### PR TITLE
fix(sounding): dedup by station+time only, persist across restarts

### DIFF
--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -5,6 +5,7 @@ Supports city names, radar site codes, and RAOB station IDs.
 """
 
 import asyncio
+import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -13,6 +14,7 @@ from typing import Optional
 import discord
 from discord.ext import commands, tasks
 
+from utils.state_store import get_state, set_state
 from cogs.sounding_utils import (
     fetch_acars_sounding,
     fetch_sounding,
@@ -41,9 +43,50 @@ class SoundingCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self._posted_watch_soundings: set = set()  # "watch_num:station:time"
-        self._handled_watches: set = set()  # "watch_num"
+        # Keys are "raob:{sid}:{time_key}" or "acars:{airport}:{time_key}" —
+        # deliberately NOT scoped by watch_num. Two geographically-overlapping
+        # watches (e.g. a TOR and SVR covering the same area) would otherwise
+        # each trigger a post of the same station at the same valid time.
+        self._posted_watch_soundings: set = set()
+        self._handled_watches: set = set()
         self.auto_sounding_watches.start()
+
+    async def cog_load(self):
+        """Restore posted-sounding keys from Upstash/SQLite so a restart
+        during active wx doesn't re-post every station/watch combo the
+        bot already covered today. Entries from previous UTC days are
+        dropped on load."""
+        try:
+            raw = await get_state("posted_watch_soundings")
+            if isinstance(raw, str):
+                payload = json.loads(raw)
+                today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+                if payload.get("date") == today:
+                    self._posted_watch_soundings.update(payload.get("keys", []))
+                    self._handled_watches.update(payload.get("handled", []))
+                    logger.info(
+                        f"[SOUNDING-AUTO] Restored {len(self._posted_watch_soundings)} "
+                        f"posted-sounding keys and {len(self._handled_watches)} "
+                        f"handled watches for {today}"
+                    )
+        except (ValueError, TypeError) as e:
+            logger.debug(f"[SOUNDING-AUTO] posted_watch_soundings parse failed: {e}")
+        except Exception as e:
+            logger.warning(f"[SOUNDING-AUTO] Could not restore dedup state: {e}")
+
+    async def _persist_posted_state(self) -> None:
+        """Write the current posted-sounding dedup set to state_store.
+        Called after each successful post so a restart mid-event doesn't
+        clear the set."""
+        try:
+            payload = json.dumps({
+                "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+                "keys": sorted(self._posted_watch_soundings),
+                "handled": sorted(self._handled_watches),
+            })
+            await set_state("posted_watch_soundings", payload)
+        except Exception as e:
+            logger.debug(f"[SOUNDING-AUTO] Could not persist dedup state: {e}")
 
     async def cog_unload(self):
         self.auto_sounding_watches.cancel()
@@ -123,7 +166,7 @@ class SoundingCog(commands.Cog):
                 return None
             y, mo, d, h = avail[0]
             tkey = f"{y}-{mo}-{d}_{h}z"
-            pkey = f"{watch_num}:{sid}:{tkey}"
+            pkey = f"raob:{sid}:{tkey}"
             if pkey in self._posted_watch_soundings:
                 return None
             return station, sid, y, mo, d, h, tkey, pkey
@@ -183,7 +226,7 @@ class SoundingCog(commands.Cog):
         acars_eligible = []
         for profile in acars_profiles[:2]:
             post_key = (
-                f"acars:{watch_num}:{profile['airport']}:"
+                f"acars:{profile['airport']}:"
                 f"{profile['year']}{profile['month']}{profile['day']}_{profile['acars_hour']}z"
             )
             if post_key not in self._posted_watch_soundings:
@@ -226,6 +269,8 @@ class SoundingCog(commands.Cog):
                 logger.info(f"[SOUNDING-AUTO] Posted ACARS {p['airport']} for watch #{watch_num}")
             except Exception as e:
                 logger.exception(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
+
+        await self._persist_posted_state()
 
     @tasks.loop(minutes=30)
     async def auto_sounding_watches(self):
@@ -288,7 +333,7 @@ class SoundingCog(commands.Cog):
             eligible = []
             for station in verified[:3]:
                 station_id = station.get("icao") or station.get("wmo")
-                post_key = f"{watch_num}:{station_id}:{time_key}"
+                post_key = f"raob:{station_id}:{time_key}"
                 if post_key not in self._posted_watch_soundings:
                     self._posted_watch_soundings.add(post_key)
                     eligible.append((station, station_id))
@@ -345,7 +390,7 @@ class SoundingCog(commands.Cog):
             acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
             acars_eligible2 = []
             for profile in acars_profiles[:2]:
-                post_key = f"acars:{watch_num}:{profile['airport']}:{time_key}"
+                post_key = f"acars:{profile['airport']}:{time_key}"
                 if post_key not in self._posted_watch_soundings:
                     self._posted_watch_soundings.add(post_key)
                     acars_eligible2.append(profile)
@@ -389,6 +434,8 @@ class SoundingCog(commands.Cog):
                     logger.info(f"[SOUNDING-AUTO] Posted ACARS {p['airport']} for watch #{watch_num}")
                 except Exception as e:
                     logger.exception(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
+
+            await self._persist_posted_state()
 
     @discord.app_commands.command(
         name="sounding",

--- a/tests/test_iem_races.py
+++ b/tests/test_iem_races.py
@@ -201,3 +201,154 @@ class TestPostSoundingsForWatch:
 
         call_args = mock_sounding_cog.post_soundings_for_watch.call_args[0]
         assert call_args[0] == "0102"
+
+
+# ── Per-station (watch-agnostic) dedup ──────────────────────────────────────
+#
+# The 2026-04-23 regression: two geographically-overlapping watches (e.g. a
+# Tornado Watch and a SVR Watch covering adjacent counties) each triggered a
+# post of the same ACARS profile at the same valid time. The dedup key
+# previously included watch_num, so `acars:OMA:2026-04-23_20z` was one key
+# but `acars:0134:OMA:2026-04-23_20z` and `acars:0135:OMA:...` were not.
+#
+# The fix drops watch_num from the key. These tests pin that contract.
+
+
+class TestSoundingDedupAcrossWatches:
+
+    def _make_cog(self):
+        from cogs.sounding import SoundingCog
+        bot = MagicMock()
+        bot.state = MagicMock()
+        cog = SoundingCog.__new__(SoundingCog)
+        cog.bot = bot
+        cog._posted_watch_soundings = set()
+        cog._handled_watches = set()
+        return cog
+
+    def test_raob_key_is_station_plus_time_only(self):
+        """Same station+time for two different watches must collide."""
+        cog = self._make_cog()
+        time_key = "2026-04-23_00z"
+
+        # Watch #0134 (TOR) processes KOAX first
+        key_a = f"raob:KOAX:{time_key}"
+        assert key_a not in cog._posted_watch_soundings
+        cog._posted_watch_soundings.add(key_a)
+
+        # Watch #0135 (SVR) in an overlapping region finds KOAX too
+        key_b = f"raob:KOAX:{time_key}"
+        assert key_b in cog._posted_watch_soundings, (
+            "RAOB dedup key must NOT include watch_num — otherwise we re-post "
+            "the same sounding once per active watch."
+        )
+
+    def test_acars_key_is_airport_plus_time_only(self):
+        """Same ACARS airport+time for two different watches must collide."""
+        cog = self._make_cog()
+        time_key = "20260423_20z"
+
+        key_a = f"acars:OMA:{time_key}"
+        cog._posted_watch_soundings.add(key_a)
+
+        key_b = f"acars:OMA:{time_key}"
+        assert key_b in cog._posted_watch_soundings
+
+    @pytest.mark.asyncio
+    async def test_persist_posted_state_writes_today_payload(self, monkeypatch):
+        """After posts, the dedup set is persisted to Upstash with today's
+        UTC date. On next cog_load we restore only if date matches, so the
+        set survives a restart but auto-resets at UTC rollover."""
+        import json as _json
+        from datetime import datetime, timezone
+        from cogs import sounding as sounding_module
+
+        captured = {}
+
+        async def fake_set_state(key, value):
+            captured["key"] = key
+            captured["value"] = value
+
+        monkeypatch.setattr(sounding_module, "set_state", fake_set_state)
+
+        cog = self._make_cog()
+        cog._posted_watch_soundings = {"raob:KOAX:2026-04-23_00z", "acars:OMA:20260423_20z"}
+        cog._handled_watches = {"0134", "0135"}
+
+        await cog._persist_posted_state()
+
+        assert captured["key"] == "posted_watch_soundings"
+        payload = _json.loads(captured["value"])
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert payload["date"] == today
+        assert set(payload["keys"]) == {
+            "raob:KOAX:2026-04-23_00z", "acars:OMA:20260423_20z"
+        }
+        assert set(payload["handled"]) == {"0134", "0135"}
+
+    @pytest.mark.asyncio
+    async def test_cog_load_restores_todays_keys(self, monkeypatch):
+        """A restart mid-event must restore the dedup set so we don't
+        re-post every station that was already covered earlier today."""
+        import json as _json
+        from datetime import datetime, timezone
+        from cogs import sounding as sounding_module
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        payload = _json.dumps({
+            "date": today,
+            "keys": ["raob:KOAX:2026-04-23_00z", "acars:OMA:20260423_20z"],
+            "handled": ["0134", "0135"],
+        })
+
+        async def fake_get_state(key):
+            return payload if key == "posted_watch_soundings" else None
+
+        monkeypatch.setattr(sounding_module, "get_state", fake_get_state)
+
+        cog = self._make_cog()
+        await cog.cog_load()
+
+        assert cog._posted_watch_soundings == {
+            "raob:KOAX:2026-04-23_00z", "acars:OMA:20260423_20z"
+        }
+        assert cog._handled_watches == {"0134", "0135"}
+
+    @pytest.mark.asyncio
+    async def test_cog_load_drops_stale_payload_from_yesterday(self, monkeypatch):
+        """At UTC rollover yesterday's dedup keys should NOT be loaded —
+        today's posts haven't happened yet and restoring them would
+        silently suppress the first real post of each station."""
+        import json as _json
+        from cogs import sounding as sounding_module
+
+        stale = _json.dumps({
+            "date": "1999-01-01",
+            "keys": ["raob:KOAX:1999-01-01_00z"],
+            "handled": ["9999"],
+        })
+
+        async def fake_get_state(key):
+            return stale
+
+        monkeypatch.setattr(sounding_module, "get_state", fake_get_state)
+
+        cog = self._make_cog()
+        await cog.cog_load()
+
+        assert cog._posted_watch_soundings == set()
+        assert cog._handled_watches == set()
+
+    @pytest.mark.asyncio
+    async def test_cog_load_tolerates_malformed_payload(self, monkeypatch):
+        """A garbled dedup blob must not crash cog_load."""
+        from cogs import sounding as sounding_module
+
+        async def fake_get_state(key):
+            return "{not valid json"
+
+        monkeypatch.setattr(sounding_module, "get_state", fake_get_state)
+
+        cog = self._make_cog()
+        await cog.cog_load()  # should not raise
+        assert cog._posted_watch_soundings == set()


### PR DESCRIPTION
## Summary
Two bugs observed during today's severe-wx event:

1. **Dedup key scoped by watch_num.** `acars:0134:OMA:20z` and `acars:0135:OMA:20z` are different keys, so the same ACARS profile posted once per overlapping watch. Drop `watch_num` — keys are now `acars:OMA:20z` / `raob:KOAX:00z`.
2. **Dedup set was in-memory only.** A restart mid-event re-posted every station already covered today. Now persisted to Upstash under `posted_watch_soundings`, keyed by UTC date, loaded in `cog_load`, saved after each post batch.

## What you saw
> Auto ACARS — OMA (Near active Tornado Watch #0136)
> Auto ACARS — OMA (Near active SVR Watch #0135)
> Auto ACARS — OMA (Near active Tornado Watch #0134)

Now only the first one posts; the other two are suppressed.

## Test plan
- [x] `pytest tests/test_iem_races.py` (15, includes 6 new)
- [x] Full suite: 206 passing
- [ ] Deploy + watch logs during next 00z/12z window for `[SOUNDING-AUTO] Restored N posted-sounding keys` on boot and absence of duplicate-station posts.