### PR TITLE
feat(sounding): list all applicable watches; fix ACARS channel; v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.2.0] — 2026-04-23
+
+### Fixed
+- **Failover race on primary reboot.** The primary node loaded all cogs
+  immediately based on the `IS_PRIMARY` env var, opening a ~30 s window
+  before the failover sync loop's first tick during which cogs ran MD /
+  watch / outlook scans against stale in-memory state. This caused
+  duplicate posts when the primary rebooted while the standby held the
+  Upstash lease (2026-04-23 incident: MD #0505 was posted twice within
+  13 s). New `startup_lease_check()` synchronously probes
+  `spcbot:manual_primary` and the lease key during `setup_hook` and
+  yields to standby if another node owns either.
+- **`_rehydrate_bot_state()` now refreshes `csu_mlp_posted`** on
+  promotion so CSU-MLP panels aren't re-posted after a failover.
+- **Sounding dedup scoped by `watch_num`** caused the same RAOB/ACARS
+  profile to post once per geographically-overlapping watch (e.g. ACARS
+  OMA posted three times for TOR #0134 + SVR #0135 + TOR #0136). Dedup
+  keys are now `raob:{sid}:{time}` / `acars:{airport}:{time}` — watch-
+  agnostic — and the set is persisted to Upstash under
+  `posted_watch_soundings` keyed by UTC date so a restart mid-event
+  doesn't replay every already-posted station.
+- **Auto ACARS soundings posted to the watches-announcement channel**
+  instead of the observed-soundings channel. `post_soundings_for_watch`
+  used `target_channel` (SOUNDING_CHANNEL_ID) for RAOB posts but fell
+  back to the passed-in `channel` for ACARS. Both now use the sounding
+  channel consistently.
+
+### Changed
+- Auto-sounding captions now list **all active watches near the
+  station**, not just the one that triggered the post. With three
+  overlapping watches and a station in the middle, the caption reads
+  `Near active watches #0134 (Tornado), #0135 (SVR), #0136 (Tornado)`.
+  Radius threshold is 500 km from each watch's centroid. Watch
+  centroids are memoized per-process to avoid N re-fetches of NWS zone
+  geometry when captioning multiple stations.
+
 ## [5.1.6] — 2026-04-22
 
 ### Changed

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -27,11 +27,19 @@ from cogs.sounding_utils import (
     get_raob_stations,
     get_user_dark_mode,
     get_watch_area_centroid,
+    haversine,
     parse_sounding_time,
     resolve_location,
     set_user_dark_mode,
     sounding_quality_warning,
 )
+
+# Max distance from a watch centroid at which we still consider that watch
+# "applicable" to a sounding station. RAOB stations are ~400 km apart
+# across the CONUS and a typical watch parallelogram is ~300 km wide, so
+# 500 km comfortably covers "this sounding represents the environment
+# around the watch" without reaching obviously-unrelated systems.
+WATCH_APPLICABLE_RADIUS_KM = 500.0
 from cogs.sounding_views import CombinedSoundingView, post_sounding
 from config import CACHE_DIR, SOUNDING_CHANNEL_ID
 
@@ -49,6 +57,10 @@ class SoundingCog(commands.Cog):
         # each trigger a post of the same station at the same valid time.
         self._posted_watch_soundings: set = set()
         self._handled_watches: set = set()
+        # Memoized watch_num → (lat, lon). Centroid resolution is an async
+        # fetch over NWS zone geometry; caching avoids N re-fetches when
+        # building captions that consider every active watch.
+        self._watch_centroids: dict = {}
         self.auto_sounding_watches.start()
 
     async def cog_load(self):
@@ -87,6 +99,65 @@ class SoundingCog(commands.Cog):
             await set_state("posted_watch_soundings", payload)
         except Exception as e:
             logger.debug(f"[SOUNDING-AUTO] Could not persist dedup state: {e}")
+
+    async def _resolve_watch_centroid(
+        self, watch_num: str, info: dict
+    ) -> Optional[tuple]:
+        """Memoized centroid lookup for a watch. Returns (lat, lon) or None."""
+        if watch_num in self._watch_centroids:
+            return self._watch_centroids[watch_num]
+        zones = info.get("affected_zones", []) if isinstance(info, dict) else []
+        if not zones:
+            return None
+        centroid = await get_watch_area_centroid(zones)
+        if centroid:
+            self._watch_centroids[watch_num] = centroid
+        return centroid
+
+    async def _watches_near(
+        self,
+        station_lat: float,
+        station_lon: float,
+        max_km: float = WATCH_APPLICABLE_RADIUS_KM,
+    ) -> list:
+        """Return [(watch_num, label, distance_km), ...] for every active
+        watch whose centroid is within `max_km` of (station_lat, station_lon),
+        sorted by watch_num ascending.
+
+        Centroids are resolved lazily and memoized, so a caption that asks
+        about three stations for three overlapping watches still only
+        fetches each watch's geometry once per process lifetime.
+        """
+        applicable = []
+        active = getattr(self.bot.state, "active_watches", {}) or {}
+        for watch_num, info in list(active.items()):
+            centroid = await self._resolve_watch_centroid(watch_num, info)
+            if not centroid:
+                continue
+            lat, lon = centroid
+            dist = haversine(station_lat, station_lon, lat, lon)
+            if dist > max_km:
+                continue
+            wtype = info.get("type", "SVR") if isinstance(info, dict) else "SVR"
+            label = "Tornado" if wtype == "TORNADO" else "SVR"
+            applicable.append((watch_num, label, dist))
+        applicable.sort(key=lambda x: x[0])
+        return applicable
+
+    def _format_watches_caption(
+        self, applicable: list, fallback_num: str, fallback_label: str
+    ) -> str:
+        """Build the 'Near active …' caption fragment. With multiple
+        applicable watches this lists all of them; with one (or zero —
+        the triggering watch is always in-scope), it degrades to the
+        single-watch phrasing we had before."""
+        if not applicable:
+            return f"Near active {fallback_label} #{fallback_num}"
+        if len(applicable) == 1:
+            wn, lbl, _ = applicable[0]
+            return f"Near active {lbl} Watch #{wn}"
+        parts = [f"#{wn} ({lbl})" for wn, lbl, _ in applicable]
+        return "Near active watches " + ", ".join(parts)
 
     async def cog_unload(self):
         self.auto_sounding_watches.cancel()
@@ -209,9 +280,13 @@ class SoundingCog(commands.Cog):
             png_path = opath + ".png"
             if not success or not os.path.exists(png_path):
                 continue
+            applicable = await self._watches_near(station["lat"], station["lon"])
+            watches_frag = self._format_watches_caption(
+                applicable, watch_num, watch_label
+            )
             caption = (
                 f"**Auto Sounding — {station['name']} ({sid})**\n"
-                f"Valid: {mo}-{d}-{y} {h}z | Near active {watch_label} #{watch_num}"
+                f"Valid: {mo}-{d}-{y} {h}z | {watches_frag}"
             )
             qwarn = sounding_quality_warning(data)
             if qwarn:
@@ -260,12 +335,20 @@ class SoundingCog(commands.Cog):
             png_path = opath + ".png"
             if not success or not os.path.exists(png_path):
                 continue
+            applicable = await self._watches_near(p["lat"], p["lon"])
+            watches_frag = self._format_watches_caption(
+                applicable, watch_num, watch_label
+            )
             caption = (
                 f"**Auto ACARS — {p['airport']}**\n"
-                f"Valid: {p['time_label']} | Near active {watch_label} #{watch_num}"
+                f"Valid: {p['time_label']} | {watches_frag}"
             )
             try:
-                await channel.send(caption, files=[discord.File(png_path)])
+                # ACARS must post to the observed-soundings channel, same as
+                # the RAOB posts above. Prior versions used the passed-in
+                # `channel` (the watches-announcement channel), which
+                # caused ACARS soundings to land in #weather-chat.
+                await target_channel.send(caption, files=[discord.File(png_path)])
                 logger.info(f"[SOUNDING-AUTO] Posted ACARS {p['airport']} for watch #{watch_num}")
             except Exception as e:
                 logger.exception(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
@@ -372,10 +455,13 @@ class SoundingCog(commands.Cog):
                 png_path = opath + ".png"
                 if not success or not os.path.exists(png_path):
                     continue
+                applicable = await self._watches_near(station["lat"], station["lon"])
+                watches_frag = self._format_watches_caption(
+                    applicable, watch_num, watch_label
+                )
                 caption = (
                     f"**Auto Sounding — {station['name']} ({sid})**\n"
-                    f"Valid: {month}-{day}-{year} {sounding_time}z | "
-                    f"Near active {watch_label} #{watch_num}"
+                    f"Valid: {month}-{day}-{year} {sounding_time}z | {watches_frag}"
                 )
                 qwarn = sounding_quality_warning(data)
                 if qwarn:
@@ -425,9 +511,13 @@ class SoundingCog(commands.Cog):
                 png_path = opath + ".png"
                 if not success or not os.path.exists(png_path):
                     continue
+                applicable = await self._watches_near(p["lat"], p["lon"])
+                watches_frag = self._format_watches_caption(
+                    applicable, watch_num, watch_label
+                )
                 caption = (
                     f"**Auto ACARS \u2014 {p['airport']}**\n"
-                    f"Valid: {p['time_label']} | Near active {watch_label} #{watch_num}"
+                    f"Valid: {p['time_label']} | {watches_frag}"
                 )
                 try:
                     await channel.send(caption, files=[discord.File(png_path)])

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Single source of truth for the release displayed in /help.
 # Bump this in the same commit as the git tag.
-__version__ = "5.1.6"
+__version__ = "5.2.0"
 
 load_dotenv()
 

--- a/tests/test_iem_races.py
+++ b/tests/test_iem_races.py
@@ -352,3 +352,170 @@ class TestSoundingDedupAcrossWatches:
         cog = self._make_cog()
         await cog.cog_load()  # should not raise
         assert cog._posted_watch_soundings == set()
+
+
+# ── Caption: all applicable active watches ─────────────────────────────────
+#
+# When a sounding station is geographically covered by multiple active
+# watches (e.g. TOR #0134 + SVR #0135 + TOR #0136 all in the Plains at
+# once), the caption should list all of them instead of only the watch
+# that happened to trigger the post. The dedup fix prevents duplicate
+# posts; this test covers the user-facing readability of the one post
+# that does go out.
+
+
+class TestWatchesNearAndCaption:
+
+    def _make_cog_with_watches(self, active_watches: dict):
+        from cogs.sounding import SoundingCog
+        bot = MagicMock()
+        bot.state = MagicMock()
+        bot.state.active_watches = active_watches
+        cog = SoundingCog.__new__(SoundingCog)
+        cog.bot = bot
+        cog._watch_centroids = {}
+        return cog
+
+    @pytest.mark.asyncio
+    async def test_watches_near_returns_all_within_radius(self, monkeypatch):
+        """A station at the centroid of three overlapping watches should be
+        reported as 'near' all three, sorted by watch number."""
+        # Station at (41.3, -95.9) — Omaha-ish. Three watches with centroids
+        # all within ~500 km (different neighboring states).
+        active = {
+            "0134": {"type": "TORNADO", "affected_zones": ["x"]},
+            "0135": {"type": "SVR", "affected_zones": ["x"]},
+            "0136": {"type": "TORNADO", "affected_zones": ["x"]},
+        }
+        centroids = {
+            "0134": (42.5, -96.0),  # ~135 km N
+            "0135": (39.8, -94.0),  # ~230 km SE
+            "0136": (44.0, -98.0),  # ~360 km NW
+        }
+
+        from cogs import sounding as sounding_module
+
+        async def fake_centroid(zones):
+            # Called from _resolve_watch_centroid; we can't tell which
+            # watch it's for from zones alone. Cheat: the test invokes
+            # the public _watches_near which calls _resolve_watch_centroid
+            # per watch — so override _resolve_watch_centroid instead.
+            return None
+
+        monkeypatch.setattr(sounding_module, "get_watch_area_centroid", fake_centroid)
+
+        cog = self._make_cog_with_watches(active)
+
+        async def fake_resolve(watch_num, info):
+            return centroids.get(watch_num)
+
+        cog._resolve_watch_centroid = fake_resolve
+
+        applicable = await cog._watches_near(41.3, -95.9, max_km=500.0)
+
+        assert [a[0] for a in applicable] == ["0134", "0135", "0136"]
+        assert {a[1] for a in applicable} == {"Tornado", "SVR"}
+
+    @pytest.mark.asyncio
+    async def test_watches_near_excludes_watches_beyond_radius(self):
+        """Watches whose centroids are far outside the radius must not
+        appear in the caption. Otherwise an OMA sounding would claim to
+        be 'near' a watch in Georgia."""
+        active = {
+            "0134": {"type": "TORNADO", "affected_zones": ["x"]},
+            "0900": {"type": "SVR", "affected_zones": ["x"]},  # far away
+        }
+        centroids = {
+            "0134": (42.5, -96.0),     # near the station
+            "0900": (33.0, -84.0),     # Georgia — thousands of km off
+        }
+
+        cog = self._make_cog_with_watches(active)
+
+        async def fake_resolve(watch_num, info):
+            return centroids.get(watch_num)
+
+        cog._resolve_watch_centroid = fake_resolve
+
+        applicable = await cog._watches_near(41.3, -95.9, max_km=500.0)
+
+        assert [a[0] for a in applicable] == ["0134"]
+
+    @pytest.mark.asyncio
+    async def test_watches_near_skips_watches_with_no_centroid(self):
+        """A watch whose zone geometry can't be resolved (centroid=None)
+        must be dropped, not crash the caption."""
+        active = {
+            "0134": {"type": "TORNADO", "affected_zones": ["x"]},
+            "0135": {"type": "SVR", "affected_zones": []},  # no zones
+        }
+
+        cog = self._make_cog_with_watches(active)
+
+        async def fake_resolve(watch_num, info):
+            if watch_num == "0134":
+                return (42.5, -96.0)
+            return None
+
+        cog._resolve_watch_centroid = fake_resolve
+
+        applicable = await cog._watches_near(41.3, -95.9, max_km=500.0)
+        assert [a[0] for a in applicable] == ["0134"]
+
+    def test_caption_single_watch(self):
+        """One applicable watch → single-watch phrasing, matches pre-fix
+        output so existing readers aren't surprised."""
+        from cogs.sounding import SoundingCog
+        cog = SoundingCog.__new__(SoundingCog)
+
+        applicable = [("0134", "Tornado", 123.4)]
+        frag = cog._format_watches_caption(applicable, "0134", "Tornado Watch")
+        assert frag == "Near active Tornado Watch #0134"
+
+    def test_caption_multi_watch_lists_all(self):
+        """Three applicable watches → all listed, sorted, with type tag."""
+        from cogs.sounding import SoundingCog
+        cog = SoundingCog.__new__(SoundingCog)
+
+        applicable = [
+            ("0134", "Tornado", 100.0),
+            ("0135", "SVR", 200.0),
+            ("0136", "Tornado", 300.0),
+        ]
+        frag = cog._format_watches_caption(applicable, "0134", "Tornado Watch")
+        assert frag == "Near active watches #0134 (Tornado), #0135 (SVR), #0136 (Tornado)"
+
+    def test_caption_empty_applicable_uses_fallback(self):
+        """If the lookup returns nothing (e.g. centroid resolution failed
+        for every active watch) we still caption against the triggering
+        watch so the post isn't mislabeled as free-floating."""
+        from cogs.sounding import SoundingCog
+        cog = SoundingCog.__new__(SoundingCog)
+
+        frag = cog._format_watches_caption([], "0134", "SVR Watch")
+        assert frag == "Near active SVR Watch #0134"
+
+    @pytest.mark.asyncio
+    async def test_resolve_watch_centroid_memoizes(self, monkeypatch):
+        """Three stations in one watch → only one centroid fetch.
+        Critical for not hammering the NWS zones API when a busy day has
+        6+ concurrent watches and we build captions for each station."""
+        from cogs import sounding as sounding_module
+
+        calls = {"n": 0}
+
+        async def fake_centroid(zones):
+            calls["n"] += 1
+            return (42.0, -96.0)
+
+        monkeypatch.setattr(sounding_module, "get_watch_area_centroid", fake_centroid)
+
+        cog = self._make_cog_with_watches({})
+        info = {"affected_zones": ["https://api.weather.gov/zones/county/IAC001"]}
+
+        a = await cog._resolve_watch_centroid("0134", info)
+        b = await cog._resolve_watch_centroid("0134", info)
+        c = await cog._resolve_watch_centroid("0134", info)
+
+        assert a == b == c == (42.0, -96.0)
+        assert calls["n"] == 1, "centroid should be fetched once and cached"


### PR DESCRIPTION
## Summary
- **Multi-watch captions**: sounding posts now list every active watch whose centroid is within 500 km of the station. Three overlapping watches now render as:
  > Near active watches #0134 (Tornado), #0135 (SVR), #0136 (Tornado)
- **Fix**: auto-ACARS posts were going to the watches-announcement channel instead of the observed-soundings channel (`post_soundings_for_watch` used `target_channel` for RAOB but fell back to the passed-in `channel` for ACARS).
- Bump to **v5.2.0** and roll up CHANGELOG entries for today's three bug fixes (PR #123 lease race, PR #124 sounding dedup, plus this PR).

## Implementation notes
- Watch centroids are memoized per-process so a batch of three stations for three watches resolves zone geometry 3× not 9×.
- 500 km threshold chosen to cover "station represents the environment near the watch" without reaching obviously-unrelated systems; matches typical watch-box size (~300 km) + RAOB station spacing (~400 km).
- Single-watch case preserves the old caption wording exactly so existing readers aren't surprised.

## Test plan
- [x] `pytest tests/test_iem_races.py` (22 tests, 7 new in `TestWatchesNearAndCaption`)
- [x] Full suite: 213 passing
- [ ] Deploy + verify multi-watch caption on the next concurrent-watch event
- [ ] Verify ACARS posts now land in #observed-soundings, not #weather-chat