### PR TITLE
chore: consolidate v5.2.1 and v5.2.2 into v5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
-## [5.2.2] — 2026-04-23
+## [5.2.1] — 2026-04-23
 
 ### Added
 - **Special Sounding Monitor.** Added `monitor_special_soundings` task
@@ -15,8 +15,6 @@ version numbers follow [SemVer](https://semver.org/).
   new sounding release (not just 00z/12z). This ensures that 18z, 20z,
   and other intermediate "special" releases requested by WFOs/SPC are
   automatically detected and posted during the lifetime of a watch.
-
-## [5.2.1] — 2026-04-23
 
 ### Fixed
 - **State restoration robustness.** Added idempotent `_ensure_restored`

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Single source of truth for the release displayed in /help.
 # Bump this in the same commit as the git tag.
-__version__ = "5.2.2"
+__version__ = "5.2.1"
 
 load_dotenv()
 


### PR DESCRIPTION
Consolidating intermediate fixes and the special sounding monitor into a single v5.2.1 release.