### PR TITLE
chore: add HTTP recovery logging and bump to v5.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.2.2] — 2026-04-23
+
+### Added
+- **HTTP Recovery Logging.** Successfully completed HTTP requests after
+  one or more failures/timeouts are now logged with a `Successfully
+  recovered` message. This provides visibility into the bot's ability
+  to catch up during intermittent network instability or API outages.
+
 ## [5.2.1] — 2026-04-23
 
 ### Added

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Single source of truth for the release displayed in /help.
 # Bump this in the same commit as the git tag.
-__version__ = "5.2.1"
+__version__ = "5.2.2"
 
 load_dotenv()
 

--- a/utils/http.py
+++ b/utils/http.py
@@ -136,6 +136,10 @@ async def http_get_bytes_conditional(
                         return None, response.status, None
                     await asyncio.sleep(retry_after)
                     continue
+
+                if attempt > 0:
+                    logger.info(f"Successfully recovered {url} after {attempt} failure(s)")
+
                 if response.status == 304:
                     return None, 304, {"etag": etag or "", "last_modified": last_modified or ""}
                 content = await response.read()


### PR DESCRIPTION
Added success logs for HTTP requests that recover after one or more retries, providing better visibility during API instability.