### PR TITLE
fix: harden watch upgrade logic and add trigger to auto-post loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.2.3] — 2026-04-23
+
+### Fixed
+- **Persistent watch upgrades.** The `_upgrade_watch_embed` task now
+  continues retrying even if it finds a text summary, as long as the
+  watch graphic is still missing or a placeholder. This ensures that
+  watches posted via the IEMBot fast-path (which often lack images
+  initially) are correctly edited later when SPC generates the GIF.
+- **Auto-post upgrade safety.** Added the upgrade-edit trigger to the
+  `auto_post_watches` loop (previously it was only in the IEMBot path),
+  ensuring that any watch detected first via the 2-minute poll still
+  benefits from the image-backfill logic.
+
 ## [5.2.2] — 2026-04-23
 
 ### Added

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -642,14 +642,23 @@ class WatchesCog(commands.Cog):
             try:
                 image_url, text_summary, probs = await fetch_watch_details(watch_num)
                 has_real_probs = probs and "preliminary" not in probs
-                if not has_real_probs and image_url is None:
-                    continue
-
+                
                 cache_path = None
                 if image_url:
                     cache_path, _, _ = await download_single_image(
                         image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
                     )
+
+                # Keep retrying if:
+                # 1. We have no image yet (or it's a placeholder)
+                # 2. AND we don't have final probabilities yet
+                # Once we have BOTH a real image and real probs, we stop.
+                image_missing = cache_path is None or (
+                    os.path.exists(cache_path) and is_placeholder_image(open(cache_path, "rb").read())
+                )
+                if image_missing or not has_real_probs:
+                    if attempt < 9: # Only continue if we have attempts left
+                        continue
 
                 embed = _build_watch_embed(
                     watch_num,
@@ -855,7 +864,7 @@ class WatchesCog(commands.Cog):
 
                 try:
                     files = _watch_files(watch_num, cache_path)
-                    await channel.send(embed=embed, files=files)
+                    message = await channel.send(embed=embed, files=files)
                     self.bot.state.posted_watches.add(watch_num)
                     await add_posted_watch(str(watch_num))
                     await prune_posted_watches()
@@ -865,6 +874,12 @@ class WatchesCog(commands.Cog):
                     if sounding_cog:
                         asyncio.create_task(
                             sounding_cog.post_soundings_for_watch(watch_num, nws_info, channel)
+                        )
+                    # Schedule upgrade edit once SPC data is available
+                    has_prelim = probs and "preliminary" in probs
+                    if not cache_path or has_prelim:
+                        asyncio.create_task(
+                            self._upgrade_watch_embed(watch_num, message, is_tornado, watch_label, color, expires)
                         )
                 except discord.HTTPException as e:
                     logger.exception(

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -653,9 +653,11 @@ class WatchesCog(commands.Cog):
                 # 1. We have no image yet (or it's a placeholder)
                 # 2. AND we don't have final probabilities yet
                 # Once we have BOTH a real image and real probs, we stop.
-                image_missing = cache_path is None or (
-                    os.path.exists(cache_path) and is_placeholder_image(open(cache_path, "rb").read())
-                )
+                image_missing = True
+                if cache_path and os.path.exists(cache_path):
+                    with open(cache_path, "rb") as f:
+                        image_missing = is_placeholder_image(f.read())
+                
                 if image_missing or not has_real_probs:
                     if attempt < 9: # Only continue if we have attempts left
                         continue

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -2,6 +2,7 @@
 import json as _json
 import asyncio
 import logging
+import os
 import re
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Single source of truth for the release displayed in /help.
 # Bump this in the same commit as the git tag.
-__version__ = "5.2.2"
+__version__ = "5.2.3"
 
 load_dotenv()
 


### PR DESCRIPTION
Ensures watch graphics are backfilled even if text is found first, and wires the upgrade trigger into the main auto-post loop.