### PR TITLE
fix: reliable CSU-MLP daily reset and iembot task exception logging

### DIFF
--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -137,6 +137,7 @@ class CSUMLPCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self._last_reset_date: str = ""
         self.csu_mlp_daily_poll.start()
 
     def cog_unload(self):
@@ -244,14 +245,17 @@ class CSUMLPCog(commands.Cog):
                 self.bot.state.csu_posted.update(str(d) for d in db_posted)
 
         now_utc = datetime.now(timezone.utc)
+        today_str = now_utc.strftime("%Y-%m-%d")
 
-        # Reset at 15 UTC daily before products start appearing
-        if now_utc.hour == 15 and now_utc.minute < 10:
+        # Reset once per day at 15 UTC, tracked by date so the 10-minute
+        # loop interval can't cause the window to be missed.
+        if now_utc.hour >= 15 and self._last_reset_date != today_str:
             if self.bot.state.csu_posted:
                 logger.info("[CSU-MLP] Resetting daily posted state")
                 self.bot.state.csu_posted.clear()
                 _availability_log.clear()
                 await _save_posted_today(self.bot.state.csu_posted)
+            self._last_reset_date = today_str
 
         # Only poll 16-23 UTC
         if not (15 <= now_utc.hour < 22):

--- a/cogs/iembot.py
+++ b/cogs/iembot.py
@@ -30,6 +30,11 @@ logger = logging.getLogger("spc_bot")
 CACHE_TTL = 600  # 10 minutes
 
 
+def _log_task_exception(task: "asyncio.Task") -> None:
+    if not task.cancelled() and (exc := task.exception()):
+        logger.exception("[IEMBOT] Unhandled exception in background task", exc_info=exc)
+
+
 async def get_cached_watch_text(watch_number: str) -> Optional[str]:
     """Return cached watch text if available and not expired."""
     return await get_product_cache(f"watch_{watch_number.zfill(4)}")
@@ -155,9 +160,11 @@ class IEMBotCog(commands.Cog):
                     continue
 
                 if "WWUS20-SEL" in product_id or "WWUS40-SEL" in product_id:
-                    asyncio.create_task(self._handle_watch(product_id))
+                    t = asyncio.create_task(self._handle_watch(product_id))
+                    t.add_done_callback(_log_task_exception)
                 elif "ACUS11-SWOMCD" in product_id:
-                    asyncio.create_task(self._handle_md(product_id))
+                    t = asyncio.create_task(self._handle_md(product_id))
+                    t.add_done_callback(_log_task_exception)
 
             if new_seqnum > self.bot.state.iembot_last_seqnum:
                 self.bot.state.iembot_last_seqnum = new_seqnum
@@ -189,7 +196,8 @@ class IEMBotCog(commands.Cog):
         # Signal WatchesCog to post immediately
         watches_cog = self.bot.cogs.get("WatchesCog")
         if watches_cog:
-            asyncio.create_task(watches_cog.post_watch_now(watch_num, nws_info))
+            t = asyncio.create_task(watches_cog.post_watch_now(watch_num, nws_info))
+            t.add_done_callback(_log_task_exception)
 
     async def _handle_md(self, product_id: str):
         raw = await _fetch_product_text(product_id)
@@ -208,7 +216,8 @@ class IEMBotCog(commands.Cog):
         # Signal MesoscaleCog to post immediately
         mesoscale_cog = self.bot.cogs.get("MesoscaleCog")
         if mesoscale_cog:
-            asyncio.create_task(mesoscale_cog.post_md_now(md_num))
+            t = asyncio.create_task(mesoscale_cog.post_md_now(md_num))
+            t.add_done_callback(_log_task_exception)
 
     @poll_iembot_feed.after_loop
     async def after_poll_loop(self):


### PR DESCRIPTION
## Summary

- **csu_mlp.py**: Replace `hour == 15 and minute < 10` reset window with a `_last_reset_date` flag. The previous approach could miss the reset entirely if the 10-minute loop happened to tick at minute ≥ 10 of hour 15 UTC, causing yesterday's dedup state to persist and silently block today's CSU-MLP posts. Now the reset fires on the first loop tick at or after 15:00 UTC each day, guaranteed.
- **iembot.py**: Add a `_log_task_exception` done-callback to all four `asyncio.create_task()` fire-and-forget calls. Previously, any exception raised inside `post_watch_now` or `post_md_now` was silently dropped. Now they surface in the bot log.

## Test plan

- [ ] CI lint and tests pass
- [ ] Confirm `_last_reset_date` initializes to `""` and updates to today's date string on first 15 UTC tick
- [ ] Confirm bot restart during 15–22 UTC window still triggers reset (state is empty, reset sets the flag)