### PR TITLE
fix: guard periodic_sync.start() against duplicate on_ready fires

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,7 +209,8 @@ async def on_ready():
         else:
             logger.info("[FAILOVER] Standby — skipping command sync to preserve primary commands")
         logger.info("All tasks started. Bot is ready.")
-        periodic_sync.start()
+        if not periodic_sync.is_running():
+            periodic_sync.start()
     except Exception as e:
         logger.exception(f"[on_ready] Unhandled error: {e}")
 


### PR DESCRIPTION
## Summary
- `on_ready` fires on every Discord reconnect, not just the initial login
- Calling `periodic_sync.start()` unconditionally throws `RuntimeError: Task is already launched and is not completed.` on the second fire
- Added `if not periodic_sync.is_running():` guard to prevent the crash

## Test plan
- [ ] Deploy to backup/failover instance and confirm no error in logs on reconnect