### PR TITLE
feat: GitHub Actions deploy to failovers on merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy to Failovers
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.LEGION }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+
+      - name: Deploy to each failover
+        run: |
+          while IFS= read -r host; do
+            [ -z "$host" ] && continue
+            hostname="${host#*@}"
+            echo "── Deploying to $host ──"
+            ssh-keyscan -H "$hostname" >> ~/.ssh/known_hosts 2>/dev/null
+            ssh -i ~/.ssh/id_rsa "$host" \
+              "cd /home/\$(whoami)/spc-bot && git pull && bash update.sh"
+          done <<< "${{ secrets.FAILOVER_HOSTS }}"

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Lightweight in-place update — for use by CI/CD after git pull.
+# Not a replacement for deploy.sh (first-time setup).
+
+set -e
+
+INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "[update] Installing dependencies..."
+"${INSTALL_DIR}/venv/bin/pip" install -r "${INSTALL_DIR}/requirements.txt" --quiet
+
+echo "[update] Restarting spcbot service..."
+sudo systemctl restart spcbot
+
+echo "[update] Done."


### PR DESCRIPTION
## Summary
- Adds `update.sh` — lightweight in-place update script (pip install + service restart), separate from the full first-time `deploy.sh`
- Adds `.github/workflows/deploy.yml` — runs on every push to `main`, SSHes into each host in `FAILOVER_HOSTS` secret and runs `git pull && bash update.sh`

## Secrets required before merging
- `LEGION` — SSH private key (already added)
- `FAILOVER_HOSTS` — newline-separated list of `user@host` for each failover

## Test plan
- [x] Add `FAILOVER_HOSTS` secret in repo Settings → Secrets → Actions
- [ ] Merge this PR and watch the Actions tab to confirm both failovers update successfully