### PR TITLE
fix(md): deliver iembot fast-path under SPC index lag, dedupe outage logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **iembot MD fast-path now delivers under SPC index lag.** When iembot
+  detects a new MD before the SPC HTML page is published, `post_md_now`
+  no longer bails out on the missing graphic. It posts the header (with
+  the iembot-cached text summary) immediately and queues the existing
+  `_upgrade_md_message` poller to backfill the graphic once SPC catches
+  up — matching the behavior already in place for index-lag 403s after
+  the URL was resolved. Previously these triggers logged
+  `iembot trigger: could not resolve image` and were silently picked up
+  1–3 minutes later by the 30-second poll loop.
+- **Reduced log spam during SPC outages.** `[MD] SPC index unreachable —
+  falling back to IEM for active MD list` now logs once on transition
+  into the outage and once on recovery, instead of every 30 seconds for
+  the entire outage window.
+- **Stop polluting `active_mds` on failed iembot triggers.** `post_md_now`
+  now adds the MD to `active_mds` only after a successful Discord send,
+  so a failed fast-path post can no longer interact with the cancellation
+  logic in `auto_post_md`.
+
 ## [5.2.4] — 2026-04-23
 
 ### Fixed

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -23,6 +23,7 @@ from utils.state_store import add_posted_md, prune_posted_mds
 logger = logging.getLogger("spc_bot")
 
 _md_index_head: Dict[str, str] = {}
+_md_index_unreachable: bool = False
 
 
 async def fetch_latest_md_numbers() -> List[str]:
@@ -46,10 +47,13 @@ async def fetch_latest_md_numbers() -> List[str]:
         _md_index_head.update(meta)
 
     html = await http_get_text(SPC_MD_INDEX_URL)
-    
+
+    global _md_index_unreachable
     # If SPC is unreachable, try to scrape from IEM's nwstext API
     if not html:
-        logger.warning("[MD] SPC index unreachable — falling back to IEM for active MD list")
+        if not _md_index_unreachable:
+            logger.warning("[MD] SPC index unreachable — falling back to IEM for active MD list")
+            _md_index_unreachable = True
         try:
             content, status = await http_get_bytes(
                 "https://mesonet.agron.iastate.edu/api/1/nwstext.json?product=MCD&limit=40",
@@ -68,6 +72,10 @@ async def fetch_latest_md_numbers() -> List[str]:
         except Exception as e:
             logger.exception(f"[MD] IEM fallback for index failed: {e}")
         return []
+
+    if _md_index_unreachable:
+        logger.info("[MD] SPC index reachable again")
+        _md_index_unreachable = False
 
     numbers = re.findall(
         r'href="(?:/products/md/)?md(\d+)\.html"', html, re.IGNORECASE
@@ -303,19 +311,27 @@ class MesoscaleCog(commands.Cog):
         if not channel:
             return
 
-        self.bot.state.active_mds.add(md_num)
         logger.info(f"[MD] iembot-triggered post for #{md_num}")
         image_url, summary, from_cache, raw_text = await fetch_md_details(md_num)
-        if not image_url:
-            logger.warning(f"[MD] iembot trigger: could not resolve image for #{md_num}")
-            return
 
         if raw_text:
             asyncio.create_task(self._check_prewarm(md_num, raw_text))
 
-        cache_path, _, _ = await download_single_image(
-            image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
-        )
+        # Fall back to the iembot text cache when SPC text was missed too
+        if not summary:
+            summary = await get_cached_md_text(md_num)
+
+        cache_path = None
+        if image_url:
+            cache_path, _, _ = await download_single_image(
+                image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
+            )
+        else:
+            logger.info(
+                f"[MD] iembot trigger: no image yet for #{md_num} — "
+                f"posting text and backfilling graphic"
+            )
+
         md_page_url = f"https://www.spc.noaa.gov/products/md/mcd{md_num}.html"
         header = f"**🌩️ SPC Mesoscale Discussion #{md_num}**"
         if summary:
@@ -323,14 +339,14 @@ class MesoscaleCog(commands.Cog):
         header += f"\n<{md_page_url}>"
 
         try:
-            msg = None
             if cache_path:
                 msg = await channel.send(header, files=[discord.File(cache_path)])
             else:
                 msg = await channel.send(header)
-                # Graphic missing (likely 403 index-lag), try to fetch it later
+                # Graphic missing (SPC index lag or 403); backfill once SPC catches up
                 asyncio.create_task(self._upgrade_md_message(md_num, msg, header))
 
+            self.bot.state.active_mds.add(md_num)
             self.bot.state.posted_mds.add(md_num)
             await add_posted_md(str(md_num))
             await prune_posted_mds()


### PR DESCRIPTION
## Summary

Three fixes to the MD pipeline, all surfaced by today's log review (#0559–#0562):

1. **iembot MD fast-path now delivers under SPC index lag.** When iembot detects a new MD before the SPC HTML page is published, `post_md_now` previously logged `iembot trigger: could not resolve image` and returned, leaving the 30-second poll loop to pick it up 1–3 minutes later. It now posts the header with the iembot-cached text summary immediately and queues the existing `_upgrade_md_message` poller to backfill the graphic once SPC catches up — matching the behavior already in place when an `image_url` is resolved but the download 403s.
2. **Dedupe `SPC index unreachable` warnings.** `fetch_latest_md_numbers` now logs the warning once on transition into the outage and once on recovery, instead of every 30 seconds for the entire window.
3. **Don't pollute `active_mds` on failed iembot triggers.** `post_md_now` now adds to `active_mds` only after a successful Discord send, so a failed fast-path post can't interact with the cancellation logic in `auto_post_md`.

## Test plan

- [ ] Watch the next iembot-triggered MD where SPC is lagging — expect a text-only post within a few seconds, then an edit with the graphic when SPC catches up.
- [ ] Force a brief SPC index outage — expect a single `SPC index unreachable` log line on entry and one `SPC index reachable again` on recovery.
- [ ] `pytest tests/ -q` (the 3 pre-existing failures in `test_failover_coverage.py` reproduce on `main` and are unrelated to this change).