### PR TITLE
test(failover): isolate socket.gethostname so tests pass on any host

### DIFF
--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -23,6 +23,19 @@ from cogs.failover import FailoverCog
 from utils.state import BotState
 
 
+@pytest.fixture(autouse=True)
+def _isolate_hostname(monkeypatch):
+    """Pin ``socket.gethostname`` so the bare-hostname fallback in
+    ``_is_our_node`` cannot accidentally match a string used as the
+    "other node" in a test scenario. Without this, tests that hardcode
+    a node name (``"ubunt-server"``, ``"3cape"``, etc.) invert when run
+    on a host whose actual hostname happens to be that string.
+    """
+    monkeypatch.setattr(
+        failover_module.socket, "gethostname", lambda: "_pytest_no_match"
+    )
+
+
 def _make_bot(is_primary: bool = True):
     bot = MagicMock()
     bot.state = BotState()


### PR DESCRIPTION
## Summary

Three tests in `test_failover_coverage.py` (`test_startup_lease_held_by_other_forces_standby`, `test_startup_manual_override_for_other_forces_standby`, `test_incident_primary_reboot_during_manual_override_stays_standby`) failed when the test runner's hostname happened to match a node name they reference as "the other node" (e.g. running on a host named `3cape`).

Root cause: tests set `cog._identity = \"ubunt-server\"`, but `_is_our_node` falls back to `socket.gethostname()` to support the bare-hostname format stored by the `/failover` Discord command. When the real hostname matched a string used as the lease holder in a test, `_is_our_node` returned True and the tests inverted.

Fix: an autouse fixture pins `socket.gethostname` to a sentinel (`"_pytest_no_match"`) for this file, so the fallback can never accidentally match a hardcoded test value. No production code changed; the failover logic itself is unaffected. CI was always green because GitHub runners don't use these hostnames.

## Test plan

- [x] `pytest tests/test_failover_coverage.py` — 29 passed (was 26 passed / 3 failed locally on host `3cape`)
- [x] `pytest tests/` — 215 passed