### PR TITLE
chore(deps): update aioboto3 floor to >=15.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests>=2.31
 sounderpy>=3.1.0
 metpy>=1.5.0
 aiosqlite>=0.22.1
-aioboto3>=13.0
+aioboto3>=15.5.0


### PR DESCRIPTION
Picks up dependabot PR #145 after the original branch hit a merge conflict with the sibling dependency bumps that landed first. Floor-only change; venv already runs 15.5.0.