### PR TITLE
feat(sounding): sweep MDT/HIGH polygon for new soundings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **High-risk-day sounding sweep.** New `monitor_high_risk_soundings`
+  task on `SoundingCog` (15-minute cadence). On SPC Day 1 **Moderate**
+  or **High** Risk days, it pulls the categorical GeoJSON
+  (`day1otlk_cat.nolyr.geojson`), unions the MDT/HIGH polygons, applies
+  a geodesic 100 km buffer (CONUS Albers Equal Area, EPSG:5070), and
+  posts every new RAOB sounding and ACARS profile inside the area as
+  soon as IEM publishes it. Shared dedup keys with the watch-driven
+  paths prevent duplicate posts. Skips immediately when no MDT/HIGH is
+  active. New module `utils/spc_outlook.py`; `shapely` and `pyproj`
+  added as explicit runtime dependencies.
+
 ## [5.2.6] — 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Discord bot for severe weather enthusiasts. Auto-posts SPC convective outlooks
 * NCAR WxNext2 Mean AI convective hazard forecast (Days 1-8), auto-posted daily with `/wxnext` slash command
 * Observed RAOB sounding plots via SounderPy with `/sounding` — supports city names, radar site codes, and station IDs with interactive station and time selection
 * Auto-posts soundings for RAOB stations near active SPC watches — immediately on watch issuance (any hour via IEM) and at 00z/12z synoptic cycles
+* On SPC Day 1 **Moderate** or **High** Risk days, sweeps every RAOB station and ACARS airport inside the categorical polygon (100 km buffer) and posts every new sounding as it arrives — runs alongside the watch-driven path with shared dedup
 * VWP hodograph generation for any NEXRAD or TDWR site (200 sites) via `/hodograph`, with auto ASOS surface wind and storm parameter table
 * NEXRAD Level 2 radar downloader from NOAA AWS S3
   * Single or multi-site downloads with per-site ZIP packaging
@@ -87,6 +88,7 @@ spc-bot/
 │   ├── state_store.py       # Upstash Redis facade: read-through cache → Upstash → SQLite fallback;
 │   │                        # double-writes both backends, retries failed Upstash writes via a reconciler
 │   ├── spc_urls.py          # SPC outlook URL resolution
+│   ├── spc_outlook.py       # SPC Day 1 categorical polygon (MDT/HIGH) with geodesic buffer
 │   ├── backoff.py           # Exponential backoff tracker for task loops
 │   └── db.py                # Async SQLite backend used internally by state_store as the durable mirror; also home of http_validators
 ├── cogs/
@@ -132,7 +134,8 @@ spc-bot/
     ├── test_main_lifecycle.py  # Shutdown guard, watchdog restart, startup smoke
     ├── test_failover_coverage.py  # Lease election, promotion, demotion
     ├── test_hodograph.py    # Hodograph cog
-    └── test_iem_races.py    # IEM/SPC race logic and watch-triggered soundings
+    ├── test_iem_races.py    # IEM/SPC race logic and watch-triggered soundings
+    └── test_spc_outlook.py  # Day 1 categorical polygon parsing + geodesic buffer
 ```
 
 ## Status

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -15,12 +15,14 @@ import discord
 from discord.ext import commands, tasks
 
 from utils.state_store import get_state, set_state
+from utils.spc_outlook import get_high_risk_polygon, is_inside_polygon
 from cogs.sounding_utils import (
     fetch_acars_sounding,
     fetch_sounding,
     filter_stations_with_data,
     find_nearest_stations,
     generate_plot,
+    get_acars_profiles_in_polygon,
     get_acars_profiles_near,
     get_available_sounding_times_iem,
     get_md_area_centroid,
@@ -50,6 +52,7 @@ class SoundingCog(commands.Cog):
     MANAGED_TASK_NAMES = [
         ("auto_sounding_watches", "auto_sounding_watches"),
         ("monitor_special_soundings", "monitor_special_soundings"),
+        ("monitor_high_risk_soundings", "monitor_high_risk_soundings"),
     ]
 
     def __init__(self, bot: commands.Bot):
@@ -73,6 +76,7 @@ class SoundingCog(commands.Cog):
         self._restore_attempted: bool = False
         self.auto_sounding_watches.start()
         self.monitor_special_soundings.start()
+        self.monitor_high_risk_soundings.start()
 
     async def _ensure_restored(self) -> None:
         """Idempotent restore — safe to call from any auto-post entry
@@ -199,6 +203,7 @@ class SoundingCog(commands.Cog):
     async def cog_unload(self):
         self.auto_sounding_watches.cancel()
         self.monitor_special_soundings.cancel()
+        self.monitor_high_risk_soundings.cancel()
 
     @tasks.loop(minutes=15)
     async def monitor_special_soundings(self):
@@ -337,6 +342,224 @@ class SoundingCog(commands.Cog):
                     logger.exception(f"[SOUNDING-MONITOR] Failed to post {sid}: {e}")
 
             await self._persist_posted_state()
+
+    @tasks.loop(minutes=15)
+    async def monitor_high_risk_soundings(self):
+        """Sweep every RAOB station and ACARS airport inside the SPC Day 1
+        MDT/HIGH categorical risk area for new soundings.
+
+        On higher-risk days we want maximum atmospheric coverage, not just
+        the few stations near each watch centroid. This runs alongside
+        ``auto_sounding_watches`` and ``monitor_special_soundings`` —
+        shared dedup keys (``raob:`` / ``acars:`` prefixed) prevent
+        duplicate posts when a station qualifies via multiple paths.
+
+        Skips immediately when no MDT/HIGH polygon is active.
+        """
+        await self.bot.wait_until_ready()
+        if not self.bot.state.is_primary:
+            return
+
+        polygon, labels = await get_high_risk_polygon()
+        if polygon is None:
+            return
+
+        await self._ensure_restored()
+
+        try:
+            stations_df = await get_raob_stations()
+        except Exception as e:
+            logger.exception(f"[SOUNDING-RISK] Failed to load station list: {e}")
+            return
+
+        channel = self.bot.get_channel(SOUNDING_CHANNEL_ID)
+        if not channel:
+            return
+
+        # Filter RAOB stations to those inside the buffered polygon
+        in_area = []
+        for _, row in stations_df.iterrows():
+            sid = (row.get("ICAO") or "").strip() or (row.get("WMO") or "").strip()
+            if not sid:
+                continue
+            if is_inside_polygon(row["lat"], row["lon"], polygon):
+                in_area.append({
+                    "icao": (row.get("ICAO") or "").strip(),
+                    "wmo": (row.get("WMO") or "").strip(),
+                    "name": (row.get("NAME") or "").strip(),
+                    "lat": row["lat"],
+                    "lon": row["lon"],
+                })
+
+        if not in_area:
+            logger.debug(
+                f"[SOUNDING-RISK] No RAOB stations inside Day 1 "
+                f"{sorted(labels)} polygon"
+            )
+            return
+
+        labels_str = "/".join(sorted(labels))
+        logger.info(
+            f"[SOUNDING-RISK] {labels_str} active — "
+            f"{len(in_area)} RAOB stations inside polygon"
+        )
+
+        # ── RAOB sweep ────────────────────────────────────────────────────
+        async def _check_station(station):
+            sid = station.get("icao") or station.get("wmo")
+            avail = await get_available_sounding_times_iem(
+                sid, hours_back=18, skip_cache=True
+            )
+            if not avail:
+                return []
+            new_times = []
+            for y, mo, d, h in avail:
+                tkey = f"{y}-{mo}-{d}_{h}z"
+                pkey = f"raob:{sid}:{tkey}"
+                if pkey not in self._posted_watch_soundings:
+                    new_times.append((station, sid, y, mo, d, h, tkey, pkey))
+            return new_times
+
+        per_station = await asyncio.gather(*[_check_station(s) for s in in_area])
+        to_post: list = []
+        for batch in per_station:
+            to_post.extend(batch)
+
+        if to_post:
+            logger.info(
+                f"[SOUNDING-RISK] Found {len(to_post)} new RAOB sounding(s) "
+                f"inside {labels_str} polygon"
+            )
+
+            # Process in batches of 3 to keep memory and Discord rate-limit happy
+            for i in range(0, len(to_post), 3):
+                batch = to_post[i:i+3]
+                for *_, pkey in batch:
+                    self._posted_watch_soundings.add(pkey)
+
+                async def _fetch(station, sid, y, mo, d, h, tkey, pkey):
+                    data = await fetch_sounding(
+                        sid, y, mo, d, h,
+                        station_name=station["name"],
+                        lat=station["lat"], lon=station["lon"],
+                    )
+                    return station, sid, y, mo, d, h, data
+
+                fetched = await asyncio.gather(*[_fetch(*r) for r in batch])
+
+                plot_jobs = []
+                for station, sid, y, mo, d, h, data in fetched:
+                    if not data:
+                        continue
+                    opath = os.path.join(
+                        CACHE_DIR, f"sounding_{sid}_{y}{mo}{d}_{h}z"
+                    )
+                    plot_jobs.append((station, sid, y, mo, d, h, data, opath))
+
+                if not plot_jobs:
+                    continue
+
+                plot_results = await asyncio.gather(*[
+                    generate_plot(data, opath)
+                    for *_, data, opath in plot_jobs
+                ])
+
+                for (station, sid, y, mo, d, h, data, opath), success in zip(
+                    plot_jobs, plot_results
+                ):
+                    png_path = opath + ".png"
+                    if not success or not os.path.exists(png_path):
+                        continue
+                    caption = (
+                        f"**High-Risk Sounding — {station['name']} ({sid})**\n"
+                        f"Valid: {mo}-{d}-{y} {h}z | Inside SPC Day 1 {labels_str} risk area"
+                    )
+                    qwarn = sounding_quality_warning(data)
+                    if qwarn:
+                        caption += f"\n{qwarn}"
+                    try:
+                        await channel.send(caption, files=[discord.File(png_path)])
+                        logger.info(
+                            f"[SOUNDING-RISK] Posted {sid} {h}z ({labels_str})"
+                        )
+                        self.bot.state.last_post_times["sounding"] = datetime.now(timezone.utc)
+                    except Exception as e:
+                        logger.exception(f"[SOUNDING-RISK] Failed to post {sid}: {e}")
+
+        # ── ACARS sweep ───────────────────────────────────────────────────
+        try:
+            acars_in_poly = await get_acars_profiles_in_polygon(
+                polygon, hours_back=2, max_results=15
+            )
+        except Exception as e:
+            logger.warning(f"[SOUNDING-RISK] ACARS poll failed: {e}")
+            acars_in_poly = []
+
+        acars_to_post = []
+        for p in acars_in_poly:
+            pkey = (
+                f"acars:{p['airport']}:"
+                f"{p['year']}{p['month']}{p['day']}_{p['acars_hour']}z"
+            )
+            if pkey not in self._posted_watch_soundings:
+                self._posted_watch_soundings.add(pkey)
+                acars_to_post.append(p)
+
+        if acars_to_post:
+            logger.info(
+                f"[SOUNDING-RISK] Found {len(acars_to_post)} new ACARS profile(s) "
+                f"inside {labels_str} polygon"
+            )
+
+            async def _fetch_acars(p):
+                data = await fetch_acars_sounding(
+                    p["profile_id"], p["year"], p["month"],
+                    p["day"], p["acars_hour"]
+                )
+                return p, data
+
+            for i in range(0, len(acars_to_post), 3):
+                batch = acars_to_post[i:i+3]
+                fetched = await asyncio.gather(*[_fetch_acars(p) for p in batch])
+
+                acars_plot_jobs = []
+                for p, data in fetched:
+                    if not data:
+                        continue
+                    opath = os.path.join(
+                        CACHE_DIR,
+                        f"acars_{p['airport']}_{p['year']}{p['month']}{p['day']}_{p['acars_hour']}z"
+                    )
+                    acars_plot_jobs.append((p, data, opath))
+
+                if not acars_plot_jobs:
+                    continue
+
+                acars_results = await asyncio.gather(*[
+                    generate_plot(data, opath)
+                    for _, data, opath in acars_plot_jobs
+                ])
+
+                for (p, data, opath), success in zip(acars_plot_jobs, acars_results):
+                    png_path = opath + ".png"
+                    if not success or not os.path.exists(png_path):
+                        continue
+                    caption = (
+                        f"**High-Risk ACARS — {p['airport']}**\n"
+                        f"Valid: {p['time_label']} | Inside SPC Day 1 {labels_str} risk area"
+                    )
+                    try:
+                        await channel.send(caption, files=[discord.File(png_path)])
+                        logger.info(
+                            f"[SOUNDING-RISK] Posted ACARS {p['airport']} ({labels_str})"
+                        )
+                        self.bot.state.last_post_times["sounding"] = datetime.now(timezone.utc)
+                    except Exception as e:
+                        logger.exception(
+                            f"[SOUNDING-RISK] Failed to post ACARS {p['airport']}: {e}"
+                        )
+
+        await self._persist_posted_state()
 
     async def prewarm_soundings_for_md(self, md_num: str, raw_text: str):
         """

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -689,6 +689,89 @@ async def get_acars_profiles_near(
     return results[:5]
 
 
+async def get_acars_profiles_in_polygon(
+    polygon,
+    hours_back: int = 3,
+    max_results: int = 25,
+) -> list[dict]:
+    """Find ACARS profiles whose airport sits inside ``polygon`` (EPSG:4326).
+
+    Mirrors :func:`get_acars_profiles_near` but filters by polygon
+    membership instead of distance. Used on MDT/HIGH risk days to sweep
+    every airport inside the (buffered) categorical polygon — RAOB
+    coverage alone misses the convective boundary layer detail that
+    ACARS provides at hub airports.
+
+    ``polygon`` should already include any desired buffer.
+    """
+    if polygon is None:
+        return []
+
+    import sounderpy as spy  # noqa: PLC0415
+    from shapely.geometry import Point  # noqa: PLC0415
+
+    now = datetime.now(timezone.utc)
+    results: list[dict] = []
+    seen_airports: set[str] = set()
+
+    for h_back in range(hours_back + 1):
+        check_time = now - timedelta(hours=h_back)
+        year = check_time.strftime("%Y")
+        month = check_time.strftime("%m")
+        day = check_time.strftime("%d")
+        hour = check_time.strftime("%H")
+
+        try:
+            loop = asyncio.get_running_loop()
+            acars = await loop.run_in_executor(
+                None, lambda y=year, mo=month, d=day, hr=hour: spy.acars_data(y, mo, d, hr)
+            )
+            profiles = await loop.run_in_executor(None, acars.list_profiles)
+        except Exception as e:
+            logger.debug(f"[ACARS] No profiles for {year}/{month}/{day} {hour}z: {e}")
+            continue
+
+        for profile_id in profiles:
+            airport_code = profile_id.split("_")[0]
+            if airport_code in seen_airports:
+                continue
+
+            airport_latlon = _ACARS_STATION_COORDS.get(airport_code)
+            if airport_latlon is None:
+                try:
+                    metar_code = airport_code if len(airport_code) == 4 else "K" + airport_code
+                    latlon = await loop.run_in_executor(
+                        None, lambda code=metar_code: spy.get_latlon("metar", code)
+                    )
+                    airport_latlon = (float(latlon[0]), float(latlon[1]))
+                    _ACARS_STATION_COORDS[airport_code] = airport_latlon
+                except Exception as e:
+                    logger.debug(f"[ACARS] Airport lookup failed for {airport_code!r}: {e}")
+                    continue
+
+            if not polygon.contains(Point(airport_latlon[1], airport_latlon[0])):
+                continue
+
+            seen_airports.add(airport_code)
+            time_part = profile_id.split("_")[1] if "_" in profile_id else hour + "00"
+            results.append({
+                "profile_id": profile_id,
+                "airport": airport_code,
+                "name": airport_code,
+                "lat": airport_latlon[0],
+                "lon": airport_latlon[1],
+                "year": year,
+                "month": month,
+                "day": day,
+                "acars_hour": hour,
+                "time_label": f"{time_part[:2]}:{time_part[2:]}z" if len(time_part) >= 4 else f"{time_part}z",
+            })
+            if len(results) >= max_results:
+                return results
+
+    return results
+
+
 async def fetch_acars_sounding(
     profile_id: str,
     year: str, month: str, day: str, hour: str,

--- a/config.py
+++ b/config.py
@@ -79,6 +79,7 @@ IEMBOT_FEED_URL = _P["iembot_feed_url"]
 IEM_NWSTEXT_URL = _P["iem_nwstext_url"]
 WXNEXT_BASE = _P["wxnext_base_url"]
 WXNEXT_PAGE = _P["wxnext_page_url"]
+SPC_DAY1_CATEGORICAL_GEOJSON_URL = _P["spc_day1_categorical_geojson_url"]
 
 # Timezones
 CENTRAL = pytz.timezone("America/Chicago")

--- a/config/products.json
+++ b/config/products.json
@@ -45,5 +45,6 @@
   "iembot_feed_url": "https://weather.im/iembot-json/room/spcchat",
   "iem_nwstext_url": "https://mesonet.agron.iastate.edu/api/1/nwstext/{product_id}",
   "wxnext_base_url": "https://www2.mmm.ucar.edu/projects/ncar_ensemble/ainwp/img",
-  "wxnext_page_url": "https://www2.mmm.ucar.edu/projects/ncar_ensemble/ainwp/"
+  "wxnext_page_url": "https://www2.mmm.ucar.edu/projects/ncar_ensemble/ainwp/",
+  "spc_day1_categorical_geojson_url": "https://www.spc.noaa.gov/products/outlook/day1otlk_cat.nolyr.geojson"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ sounderpy>=3.1.0
 metpy>=1.5.0
 aiosqlite>=0.22.1
 aioboto3>=15.5.0
+shapely>=2.0
+pyproj>=3.6

--- a/tests/test_spc_outlook.py
+++ b/tests/test_spc_outlook.py
@@ -1,0 +1,147 @@
+"""Tests for utils.spc_outlook — Day 1 categorical polygon parsing,
+buffering, and point-in-polygon membership."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from utils import spc_outlook
+
+
+def _feature(label, geom):
+    return {
+        "type": "Feature",
+        "properties": {"LABEL": label, "LABEL2": f"{label} Risk"},
+        "geometry": geom,
+    }
+
+
+def _square(lon0, lat0, lon1, lat1):
+    return {
+        "type": "Polygon",
+        "coordinates": [[
+            [lon0, lat0], [lon1, lat0], [lon1, lat1],
+            [lon0, lat1], [lon0, lat0],
+        ]],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    spc_outlook.reset_cache_for_tests()
+    yield
+    spc_outlook.reset_cache_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_no_high_or_moderate_returns_none():
+    """A typical day with only TSTM/MRGL/SLGT/ENH risks must yield no
+    polygon — we only sweep on MDT or HIGH."""
+    payload = {
+        "type": "FeatureCollection",
+        "features": [
+            _feature("TSTM", _square(-100, 35, -90, 40)),
+            _feature("MRGL", _square(-99, 36, -91, 39)),
+            _feature("SLGT", _square(-98, 37, -92, 38)),
+        ],
+    }
+    body = json.dumps(payload).encode()
+
+    async def fake_get(*args, **kwargs):
+        return body, 200
+
+    with patch.object(spc_outlook, "http_get_bytes", side_effect=fake_get):
+        polygon, labels = await spc_outlook.get_high_risk_polygon()
+
+    assert polygon is None
+    assert labels == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_moderate_polygon_is_buffered():
+    """A bare MDT polygon must come back buffered — a station 50 km
+    *outside* the raw polygon should test as inside the buffered one
+    when the default buffer is 100 km."""
+    payload = {
+        "type": "FeatureCollection",
+        "features": [
+            _feature("TSTM", _square(-110, 30, -85, 45)),
+            _feature("MDT", _square(-100, 38, -95, 42)),
+        ],
+    }
+    body = json.dumps(payload).encode()
+
+    async def fake_get(*args, **kwargs):
+        return body, 200
+
+    with patch.object(spc_outlook, "http_get_bytes", side_effect=fake_get):
+        polygon, labels = await spc_outlook.get_high_risk_polygon()
+
+    assert polygon is not None
+    assert labels == frozenset({"MDT"})
+
+    # Center of polygon — must be inside.
+    assert spc_outlook.is_inside_polygon(40.0, -97.5, polygon)
+    # 50 km outside the western edge (at ~40 N, 1 deg lon ≈ 85 km, so
+    # 0.6 deg west of -100 ≈ 51 km outside) — still inside the 100 km buffer.
+    assert spc_outlook.is_inside_polygon(40.0, -100.6, polygon)
+    # 200 km outside the western edge — must NOT be inside.
+    assert not spc_outlook.is_inside_polygon(40.0, -103.0, polygon)
+
+
+@pytest.mark.asyncio
+async def test_high_and_moderate_unioned():
+    """When both MDT and HIGH are active they're combined into a single
+    polygon and both labels are reported."""
+    payload = {
+        "type": "FeatureCollection",
+        "features": [
+            _feature("MDT", _square(-100, 35, -95, 40)),
+            _feature("HIGH", _square(-98, 36, -96, 39)),
+        ],
+    }
+    body = json.dumps(payload).encode()
+
+    async def fake_get(*args, **kwargs):
+        return body, 200
+
+    with patch.object(spc_outlook, "http_get_bytes", side_effect=fake_get):
+        polygon, labels = await spc_outlook.get_high_risk_polygon()
+
+    assert polygon is not None
+    assert labels == frozenset({"MDT", "HIGH"})
+    assert spc_outlook.is_inside_polygon(37.5, -97.0, polygon)
+
+
+@pytest.mark.asyncio
+async def test_fetch_failure_keeps_last_known_polygon():
+    """If the HTTP fetch fails after we already have a cached polygon,
+    we must serve the cached value rather than dropping coverage on a
+    transient SPC outage."""
+    good = {
+        "type": "FeatureCollection",
+        "features": [_feature("MDT", _square(-100, 35, -95, 40))],
+    }
+
+    calls = {"n": 0}
+
+    async def maybe_fail(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return json.dumps(good).encode(), 200
+        return None, 0
+
+    with patch.object(spc_outlook, "http_get_bytes", side_effect=maybe_fail):
+        first, _ = await spc_outlook.get_high_risk_polygon()
+        # Force re-fetch; the second fetch fails — must return prior polygon.
+        second, _ = await spc_outlook.get_high_risk_polygon(force_refresh=True)
+
+    assert first is not None
+    assert second is first  # exact same cached object
+
+
+@pytest.mark.asyncio
+async def test_is_inside_polygon_handles_none():
+    """Defensive: callers may pass None when no MDT/HIGH is active."""
+    assert spc_outlook.is_inside_polygon(40.0, -97.5, None) is False

--- a/utils/spc_outlook.py
+++ b/utils/spc_outlook.py
@@ -1,0 +1,175 @@
+"""SPC Day 1 categorical outlook polygon helper.
+
+Fetches the SPC Day 1 categorical outlook GeoJSON, extracts the MDT/HIGH
+risk areas (the only levels at which we trigger broad sounding sweeps),
+and exposes a buffered polygon plus point-in-polygon membership tests.
+
+The GeoJSON is in EPSG:4326 (lat/lon). To get an accurate ~100 km buffer
+we project to EPSG:5070 (CONUS Albers Equal Area, units = meters), buffer
+in meters, and project the result back to lat/lon. This keeps the buffer
+geometrically meaningful at all CONUS latitudes — a flat-degree buffer
+would be ~30% too large in the south and ~30% too small in the north.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+
+from shapely.geometry import Point, shape
+from shapely.ops import transform, unary_union
+
+from config import SPC_DAY1_CATEGORICAL_GEOJSON_URL
+from utils.http import http_get_bytes
+
+logger = logging.getLogger("spc_bot")
+
+# Risk levels at which we trigger broad sounding coverage. SPC publishes
+# these as `LABEL` values in the categorical GeoJSON.
+HIGH_RISK_LABELS = frozenset({"MDT", "HIGH"})
+
+# Buffer applied to the polygon when filtering RAOB stations / ACARS
+# airports. RAOB stations are sparse (~400 km apart across CONUS) and a
+# tightly-drawn MDT can otherwise miss the only relevant station.
+DEFAULT_BUFFER_KM = 100.0
+
+# Re-fetch interval. SPC issues outlooks at 06z, 13z, 1630z, 20z, 01z.
+# 30 minutes catches every issuance shortly after it lands without
+# hammering the endpoint.
+CACHE_TTL_SECONDS = 30 * 60
+
+_cache: dict = {
+    "fetched_at": 0.0,
+    "polygon_latlon": None,  # buffered polygon in EPSG:4326 (None = no MDT/HIGH)
+    "labels": frozenset(),   # which of MDT/HIGH were active at fetch
+}
+
+
+def _project_to_albers(geom):
+    """Project a lat/lon geometry to EPSG:5070 for buffering in meters."""
+    # Lazy import — pyproj is heavy and only needed when we have a polygon
+    from pyproj import Transformer  # noqa: PLC0415
+
+    fwd = Transformer.from_crs("EPSG:4326", "EPSG:5070", always_xy=True).transform
+    return transform(fwd, geom)
+
+
+def _project_to_latlon(geom):
+    from pyproj import Transformer  # noqa: PLC0415
+
+    rev = Transformer.from_crs("EPSG:5070", "EPSG:4326", always_xy=True).transform
+    return transform(rev, geom)
+
+
+def _build_buffered_polygon(features: list, buffer_km: float):
+    """Return (buffered_polygon_in_latlon, set_of_labels_present) or
+    (None, frozenset()) when no MDT/HIGH polygons are in the feature set."""
+    selected = []
+    labels_present = set()
+    for feat in features:
+        props = feat.get("properties", {}) or {}
+        label = props.get("LABEL", "").strip().upper()
+        if label not in HIGH_RISK_LABELS:
+            continue
+        geom = feat.get("geometry")
+        if not geom:
+            continue
+        try:
+            shp = shape(geom)
+        except Exception as e:
+            logger.warning(f"[OUTLOOK] Could not parse {label} geometry: {e}")
+            continue
+        if shp.is_empty:
+            continue
+        selected.append(shp)
+        labels_present.add(label)
+
+    if not selected:
+        return None, frozenset()
+
+    union_latlon = unary_union(selected)
+    union_albers = _project_to_albers(union_latlon)
+    buffered_albers = union_albers.buffer(buffer_km * 1000.0)
+    buffered_latlon = _project_to_latlon(buffered_albers)
+    return buffered_latlon, frozenset(labels_present)
+
+
+async def get_high_risk_polygon(
+    buffer_km: float = DEFAULT_BUFFER_KM,
+    force_refresh: bool = False,
+):
+    """Return (buffered_polygon, frozenset_of_active_labels).
+
+    The polygon is the union of all MDT and HIGH categorical regions on
+    today's Day 1 outlook, projected to Albers Equal Area, buffered by
+    ``buffer_km`` km, and projected back to lat/lon. ``polygon`` is
+    ``None`` when no MDT/HIGH risk is active.
+
+    Result is cached for ``CACHE_TTL_SECONDS``.
+    """
+    now = time.monotonic()
+    if (
+        not force_refresh
+        and _cache["polygon_latlon"] is not None
+        and now - _cache["fetched_at"] < CACHE_TTL_SECONDS
+    ):
+        return _cache["polygon_latlon"], _cache["labels"]
+    # We also short-circuit a cached *negative* result so we don't refetch
+    # every poll when there's no MDT/HIGH today.
+    if (
+        not force_refresh
+        and _cache["fetched_at"] > 0
+        and _cache["polygon_latlon"] is None
+        and now - _cache["fetched_at"] < CACHE_TTL_SECONDS
+    ):
+        return None, frozenset()
+
+    content, status = await http_get_bytes(
+        SPC_DAY1_CATEGORICAL_GEOJSON_URL, retries=2, timeout=15
+    )
+    if not content or status != 200:
+        logger.warning(
+            f"[OUTLOOK] Day 1 categorical fetch failed (status={status}); "
+            f"keeping last known polygon"
+        )
+        return _cache["polygon_latlon"], _cache["labels"]
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        logger.warning(f"[OUTLOOK] Day 1 GeoJSON parse failed: {e}")
+        return _cache["polygon_latlon"], _cache["labels"]
+
+    features = data.get("features", []) or []
+    polygon, labels = await asyncio.get_running_loop().run_in_executor(
+        None, lambda: _build_buffered_polygon(features, buffer_km)
+    )
+
+    _cache["fetched_at"] = now
+    _cache["polygon_latlon"] = polygon
+    _cache["labels"] = labels
+
+    if polygon is None:
+        logger.debug("[OUTLOOK] No MDT/HIGH on Day 1")
+    else:
+        logger.info(
+            f"[OUTLOOK] Day 1 high-risk polygon refreshed "
+            f"(active: {sorted(labels)}, buffered {buffer_km:.0f} km)"
+        )
+    return polygon, labels
+
+
+def is_inside_polygon(lat: float, lon: float, polygon) -> bool:
+    """True if (lat, lon) lies inside ``polygon`` (EPSG:4326). Returns
+    False when ``polygon`` is None."""
+    if polygon is None:
+        return False
+    return polygon.contains(Point(lon, lat))
+
+
+def reset_cache_for_tests() -> None:
+    """Drop the module-level cache. Tests use this to force a fresh fetch."""
+    _cache["fetched_at"] = 0.0
+    _cache["polygon_latlon"] = None
+    _cache["labels"] = frozenset()


### PR DESCRIPTION
## Summary

On SPC Day 1 **Moderate** or **High** Risk days, post every new RAOB sounding and ACARS profile inside the categorical risk area as soon as IEM publishes it — not just the few near each watch centroid. Runs alongside the existing watch-driven paths; shared dedup keys (\`raob:\` / \`acars:\`) keep things from posting twice.

### How it works

1. **Polygon source.** New \`utils/spc_outlook.py\` fetches \`https://www.spc.noaa.gov/products/outlook/day1otlk_cat.nolyr.geojson\`, filters features to \`LABEL\` of \`MDT\` or \`HIGH\`, and unions them into a single shape.
2. **Geodesic buffer.** Polygon is projected to EPSG:5070 (CONUS Albers Equal Area), buffered by 100 000 m, and projected back to EPSG:4326. A flat-degree buffer would be ~30 % off at the south/north edges of CONUS — Albers keeps it geometrically meaningful.
3. **Refresh.** 30-min TTL covers all SPC issuance times (06z / 13z / 1630z / 20z / 01z) without hammering the endpoint. A failed fetch keeps the last known polygon so a transient SPC outage doesn't drop coverage.
4. **Sweep.** New \`monitor_high_risk_soundings\` task on \`SoundingCog\` (15-min cadence). When a polygon is active, it filters the RAOB station list by point-in-polygon, polls IEM availability per station, and posts new soundings via the existing fetch/plot pipeline. Then it pulls all ACARS profiles inside the polygon and posts those too.
5. **Dedup.** Reuses \`_posted_watch_soundings\` so a station that's both inside the polygon and near a watch posts exactly once.
6. **Skip path.** When no MDT/HIGH is active, the task returns immediately after the (cached) polygon fetch — no station-list load, no IEM polls.

### Dependencies

\`shapely\` and \`pyproj\` are now explicit runtime deps. Both were already installed transitively via \`metpy\`/\`sounderpy\`/\`cartopy\`.

## Test plan

- [x] \`pytest tests/test_spc_outlook.py\` — 5 new tests (no-risk skip, single MDT buffered, MDT+HIGH unioned, fetch-failure preserves polygon, None handling). All pass.
- [x] \`pytest tests/\` — 220 passed.
- [x] \`ruff check\` — clean.
- [ ] Live verification on the next MDT/HIGH day: expect \`[OUTLOOK] Day 1 high-risk polygon refreshed\` and \`[SOUNDING-RISK] X RAOB stations inside polygon\` log lines, then \`High-Risk Sounding\` / \`High-Risk ACARS\` posts in the soundings channel.