### PR TITLE
fix(sounding): high-risk task crashed on first NaN-ICAO row + /status visibility

### DIFF
--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -12,7 +12,10 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import discord
+import pandas as pd
 from discord.ext import commands, tasks
+
+pd_isna = pd.isna
 
 from utils.state_store import get_state, set_state
 from utils.spc_outlook import get_high_risk_polygon, is_inside_polygon
@@ -355,7 +358,18 @@ class SoundingCog(commands.Cog):
         duplicate posts when a station qualifies via multiple paths.
 
         Skips immediately when no MDT/HIGH polygon is active.
+
+        The whole body is wrapped in a single try/except: an unhandled
+        exception inside a ``tasks.Loop`` body silently terminates the
+        loop, and we don't want a single bad station row to disable
+        coverage for the rest of the event.
         """
+        try:
+            await self._tick_high_risk_soundings()
+        except Exception as e:
+            logger.exception(f"[SOUNDING-RISK] Tick failed: {e}")
+
+    async def _tick_high_risk_soundings(self):
         await self.bot.wait_until_ready()
         if not self.bot.state.is_primary:
             return
@@ -376,17 +390,33 @@ class SoundingCog(commands.Cog):
         if not channel:
             return
 
-        # Filter RAOB stations to those inside the buffered polygon
+        # Filter RAOB stations to those inside the buffered polygon. Use
+        # str() coercion (matching find_nearest_stations) because the CSV
+        # has NaN for missing ICAO codes and integer WMO codes — neither
+        # supports .strip() directly.
+        def _clean(val) -> str:
+            if val is None:
+                return ""
+            try:
+                if pd_isna(val):
+                    return ""
+            except (TypeError, ValueError):
+                pass
+            s = str(val).strip()
+            return "" if s.lower() == "nan" or s == "----" else s
+
         in_area = []
         for _, row in stations_df.iterrows():
-            sid = (row.get("ICAO") or "").strip() or (row.get("WMO") or "").strip()
+            icao = _clean(row.get("ICAO"))
+            wmo = _clean(row.get("WMO"))
+            sid = icao or wmo
             if not sid:
                 continue
             if is_inside_polygon(row["lat"], row["lon"], polygon):
                 in_area.append({
-                    "icao": (row.get("ICAO") or "").strip(),
-                    "wmo": (row.get("WMO") or "").strip(),
-                    "name": (row.get("NAME") or "").strip(),
+                    "icao": icao,
+                    "wmo": wmo,
+                    "name": _clean(row.get("NAME")),
                     "lat": row["lat"],
                     "lon": row["lon"],
                 })
@@ -560,6 +590,22 @@ class SoundingCog(commands.Cog):
                         )
 
         await self._persist_posted_state()
+
+    @monitor_high_risk_soundings.after_loop
+    async def after_high_risk_loop(self):
+        if self.monitor_high_risk_soundings.is_being_cancelled():
+            return
+        task = self.monitor_high_risk_soundings.get_task()
+        try:
+            exc = task.exception() if task else None
+        except Exception:
+            exc = None
+        if exc:
+            logger.error(
+                f"[TASK] monitor_high_risk_soundings stopped: "
+                f"{type(exc).__name__}: {exc}",
+                exc_info=exc,
+            )
 
     async def prewarm_soundings_for_md(self, md_num: str, raw_text: str):
         """

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -17,6 +17,7 @@ from utils.cache import (
     download_single_image,
     format_timedelta,
 )
+from utils.spc_outlook import get_high_risk_polygon, peek_active_labels
 from utils.spc_urls import get_spc_urls
 
 logger = logging.getLogger("spc_bot")
@@ -385,6 +386,22 @@ class StatusCog(commands.Cog):
         lines.append(
             f"HTTP Session   : {'OK' if session_ok else 'CLOSED/MISSING'}"
         )
+
+        # Proactively refresh — the 30-min TTL inside get_high_risk_polygon
+        # makes this a no-op most of the time, but it guarantees /status is
+        # accurate immediately after a restart.
+        try:
+            await get_high_risk_polygon()
+        except Exception as e:
+            logger.debug(f"[STATUS] Outlook peek failed: {e}")
+        active_risk = peek_active_labels()
+        if active_risk:
+            risk_str = "/".join(sorted(active_risk))
+            lines.append(
+                f"SPC Day 1 Risk : {risk_str} ACTIVE — high-risk sounding sweep armed"
+            )
+        else:
+            lines.append("SPC Day 1 Risk : no MDT/HIGH active")
         lines.append("")
 
         lines.append("── Tasks ──────────────────────────────")
@@ -401,6 +418,8 @@ class StatusCog(commands.Cog):
             "poll_iembot_feed":     "IEMBot real-time feed",
             "sync_loop":            "Failover standby sync",
             "auto_sounding_watches": "Sounding monitor",
+            "monitor_special_soundings": "Special-release sounding monitor",
+            "monitor_high_risk_soundings": "High-risk sounding sweep",
         }
         for cog_name, cog in self.bot.cogs.items():
             for task_name in dir(cog):

--- a/utils/spc_outlook.py
+++ b/utils/spc_outlook.py
@@ -168,6 +168,17 @@ def is_inside_polygon(lat: float, lon: float, polygon) -> bool:
     return polygon.contains(Point(lon, lat))
 
 
+def peek_active_labels() -> frozenset:
+    """Return whichever of {MDT, HIGH} is currently active per the
+    last-fetched outlook, without triggering a fetch. Empty set when
+    none are active or when the cache hasn't been populated yet.
+
+    Intended for ``/status`` and other read-only consumers that want to
+    surface risk state without paying the GeoJSON fetch latency.
+    """
+    return _cache["labels"]
+
+
 def reset_cache_for_tests() -> None:
     """Drop the module-level cache. Tests use this to force a fresh fetch."""
     _cache["fetched_at"] = 0.0


### PR DESCRIPTION
## Summary

Diagnosed and fixed why \`monitor_high_risk_soundings\` showed STOPPED in /status after deploy on a live MDT day.

### Root cause

The RAOB station CSV has rows with \`NaN\` ICAO codes and integer \`WMO\` codes. My filter used \`(row.get(\"ICAO\") or \"\").strip()\`, but \`NaN\` is truthy in Python and integers have no \`.strip()\` — the iteration crashed on row 89 with \`AttributeError: 'float' object has no attribute 'strip'\`. \`tasks.Loop\` silently terminated the loop on the unhandled exception, so the task ran exactly once (the polygon refreshed correctly: \`[OUTLOOK] Day 1 high-risk polygon refreshed (active: ['MDT'], buffered 100 km)\`) and then died before reaching any \`[SOUNDING-RISK]\` log line.

### Fixes

1. **NaN-safe row coercion.** New \`_clean()\` helper mirrors the existing \`str(row[\"ICAO\"]).strip()\` pattern in \`find_nearest_stations\` — handles \`pd.NA\`, \`NaN\`, integer \`WMO\`, and the \`\"----\"\` placeholder. Verified across all 2374 rows of the live station list.
2. **No more silent task death.** Body wrapped in \`try/except\` so a single bad row can't kill the loop. Added an \`@monitor_high_risk_soundings.after_loop\` handler so any future loop-ending exception actually logs.
3. **/status visibility for the new feature.** New \"SPC Day 1 Risk\" line shows which of MDT/HIGH are active. Friendly labels added for both the high-risk and special-release sounding tasks. /status proactively refreshes the polygon cache (no-op within the 30-min TTL) so it's accurate immediately after a restart.

## Test plan

- [x] \`pytest tests/\` — 220 passed.
- [x] Manual: iterate the full 2374-row station list with \`_clean()\` — 0 failures.
- [ ] Restart and observe \`/status\` shows \`SPC Day 1 Risk : MDT ACTIVE — high-risk sounding sweep armed\` and the high-risk task as \"running\".
- [ ] Watch logs for \`[SOUNDING-RISK] MDT active — N RAOB stations inside polygon\`.