### PR TITLE
feat(md): post full MD discussion text + fix high-risk caption prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **High-risk sounding captions match the active risk level.** When
+  only MDT is active the prefix is now `MDT-Risk Sounding` /
+  `MDT-Risk ACARS` instead of misleadingly saying `High-Risk`. HIGH
+  (alone or alongside MDT) still uses `High-Risk` since HIGH is the
+  dominant level.
+
+### Changed
+- **MD posts now include the full discussion text.** SPC mesoscale
+  discussions are posted as a Discord embed whose title links to the
+  SPC page and whose description carries the full MD body in a code
+  block (preserves SPC's column-aligned "Areas affected" / "SUMMARY"
+  formatting). Discussions over 4000 characters split across multiple
+  embeds with `(N/M)` pagination on the title; the graphic stays on
+  the first embed. Previously the post was just the header and the
+  "Concerning" line. The graphic-backfill path (`_upgrade_md_message`)
+  rebuilds the same embed structure when SPC catches up.
+
 ### Added
 - **High-risk-day sounding sweep.** New `monitor_high_risk_soundings`
   task on `SoundingCog` (15-minute cadence). On SPC Day 1 **Moderate**

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -1,5 +1,6 @@
 # cogs/mesoscale.py
 import asyncio
+import html as _html
 import json
 import logging
 import os
@@ -238,6 +239,124 @@ async def fetch_md_details(
     return image_url, summary, False, html
 
 
+# ── MD body extraction & embed formatting ────────────────────────────────────
+
+# Discord embed description max is 4096 chars. We reserve room for the
+# code-block fences (``` + newlines) so the visible body stays inside the
+# limit. Splitting kicks in above this threshold.
+EMBED_BODY_LIMIT = 4000
+
+
+def extract_md_body(raw_text: Optional[str]) -> Optional[str]:
+    """Return the plain-text MD body from ``raw_text``.
+
+    ``raw_text`` may be either the full SPC HTML page (we pull the
+    contents of the first ``<pre>`` block, strip remaining tags, and
+    decode HTML entities) or already-plain IEM text (passed through).
+    Returns ``None`` for empty input, malformed HTML pages with no
+    ``<pre>``, or any other unparseable input.
+    """
+    if not raw_text:
+        return None
+    lowered = raw_text.lower()
+    looks_like_html = ("<html" in lowered) or ("<pre" in lowered) or ("<body" in lowered)
+    if looks_like_html:
+        m = re.search(r"<pre[^>]*>(.*?)</pre>", raw_text, re.DOTALL | re.IGNORECASE)
+        if not m:
+            return None
+        body = m.group(1)
+        body = re.sub(r"<[^>]+>", "", body)
+        body = _html.unescape(body)
+    else:
+        body = raw_text
+    body = body.strip()
+    return body or None
+
+
+def chunk_md_text(text: str, max_chars: int = EMBED_BODY_LIMIT) -> List[str]:
+    """Split ``text`` into chunks that each fit inside ``max_chars``.
+
+    Splits on paragraph boundaries (blank lines) first, then on line
+    boundaries inside any paragraph that's still too large. We never
+    break mid-line because SPC formats areas/threats as fixed-width
+    columns that are unreadable when wrapped.
+    """
+    if not text:
+        return []
+    text = text.strip()
+    if len(text) <= max_chars:
+        return [text]
+
+    paragraphs = re.split(r"\n\s*\n", text)
+    chunks: List[str] = []
+    current = ""
+
+    def _flush():
+        nonlocal current
+        if current.strip():
+            chunks.append(current.rstrip())
+        current = ""
+
+    for p in paragraphs:
+        # Single paragraph too big — fall through to per-line splitting.
+        if len(p) > max_chars:
+            _flush()
+            for line in p.splitlines():
+                # Even a single line might exceed the limit; in that
+                # absurd case we hard-truncate it rather than dropping it.
+                if len(line) > max_chars:
+                    line = line[: max_chars - 3] + "..."
+                if len(current) + len(line) + 1 > max_chars:
+                    _flush()
+                current += line + "\n"
+            _flush()
+            continue
+
+        addition_len = len(p) + (2 if current else 0)
+        if len(current) + addition_len > max_chars:
+            _flush()
+        if current:
+            current += "\n\n"
+        current += p
+
+    _flush()
+    return chunks
+
+
+def build_md_embeds(
+    md_num: str,
+    full_text: Optional[str],
+    image_filename: Optional[str] = None,
+) -> List[discord.Embed]:
+    """Build the list of embeds for an MD post.
+
+    A short MD becomes a single embed: title links to the SPC page,
+    description is a code-block-wrapped body to preserve SPC's column
+    alignment, image attached via ``attachment://``. Long MDs (over
+    ``EMBED_BODY_LIMIT`` chars) split into multiple embeds — paragraph
+    boundaries are preferred. The image lives only on the first embed.
+    """
+    md_page_url = f"https://www.spc.noaa.gov/products/md/mcd{md_num}.html"
+    color = discord.Color.orange()
+    base_title = f"🌩️ SPC Mesoscale Discussion #{md_num}"
+
+    chunks = chunk_md_text(full_text, EMBED_BODY_LIMIT) if full_text else [None]
+    if not chunks:
+        chunks = [None]
+
+    embeds: List[discord.Embed] = []
+    n = len(chunks)
+    for i, chunk in enumerate(chunks):
+        title = base_title if n == 1 else f"{base_title} ({i + 1}/{n})"
+        embed = discord.Embed(title=title, url=md_page_url, color=color)
+        if chunk:
+            embed.description = f"```\n{chunk}\n```"
+        if i == 0 and image_filename:
+            embed.set_image(url=f"attachment://{image_filename}")
+        embeds.append(embed)
+    return embeds
+
+
 class MesoscaleCog(commands.Cog):
     MANAGED_TASK_NAMES = [("auto_post_md", "auto_post_md")]
 
@@ -272,24 +391,33 @@ class MesoscaleCog(commands.Cog):
             logger.debug(f"[MD] Could not parse probability for MD #{md_num}: {e}")
 
     async def _upgrade_md_message(
-        self, md_num: str, message: discord.Message, header: str
+        self,
+        md_num: str,
+        message: discord.Message,
+        full_text: Optional[str],
     ):
-        """
-        Polls for the MD graphic and edits the message to include it once available.
-        Retries every 30s for up to 5 minutes.
+        """Poll for the MD graphic and edit the message to attach it.
+
+        Retries every 30s for up to 5 minutes. Rebuilds the embeds from
+        ``full_text`` so the body content is preserved alongside the
+        newly-attached graphic.
         """
         image_url = f"https://www.spc.noaa.gov/products/md/mcd{md_num}.png"
+        filename = f"mcd_{md_num}.png"
         for attempt in range(10):
             await asyncio.sleep(30)
             try:
-                # download_single_image uses conditional GET / validators
                 cache_path, _, _ = await download_single_image(
                     image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
                 )
                 if cache_path:
                     try:
+                        embeds = build_md_embeds(
+                            md_num, full_text, image_filename=filename
+                        )
                         await message.edit(
-                            content=header, attachments=[discord.File(cache_path)]
+                            embeds=embeds,
+                            attachments=[discord.File(cache_path, filename=filename)],
                         )
                         logger.info(f"[MD] Upgraded MD #{md_num} with graphic")
                         break
@@ -317,9 +445,7 @@ class MesoscaleCog(commands.Cog):
         if raw_text:
             asyncio.create_task(self._check_prewarm(md_num, raw_text))
 
-        # Fall back to the iembot text cache when SPC text was missed too
-        if not summary:
-            summary = await get_cached_md_text(md_num)
+        full_text = extract_md_body(raw_text)
 
         cache_path = None
         if image_url:
@@ -332,19 +458,23 @@ class MesoscaleCog(commands.Cog):
                 f"posting text and backfilling graphic"
             )
 
-        md_page_url = f"https://www.spc.noaa.gov/products/md/mcd{md_num}.html"
-        header = f"**🌩️ SPC Mesoscale Discussion #{md_num}**"
-        if summary:
-            header += f"\n{summary}"
-        header += f"\n<{md_page_url}>"
+        filename = f"mcd_{md_num}.png"
+        embeds = build_md_embeds(
+            md_num, full_text, image_filename=filename if cache_path else None
+        )
 
         try:
             if cache_path:
-                msg = await channel.send(header, files=[discord.File(cache_path)])
+                msg = await channel.send(
+                    embeds=embeds,
+                    files=[discord.File(cache_path, filename=filename)],
+                )
             else:
-                msg = await channel.send(header)
+                msg = await channel.send(embeds=embeds)
                 # Graphic missing (SPC index lag or 403); backfill once SPC catches up
-                asyncio.create_task(self._upgrade_md_message(md_num, msg, header))
+                asyncio.create_task(
+                    self._upgrade_md_message(md_num, msg, full_text)
+                )
 
             self.bot.state.active_mds.add(md_num)
             self.bot.state.posted_mds.add(md_num)
@@ -434,28 +564,30 @@ class MesoscaleCog(commands.Cog):
                 if raw_text:
                     asyncio.create_task(self._check_prewarm(md_num, raw_text))
 
+                full_text = extract_md_body(raw_text)
+
                 cache_path, img_content, h = await download_single_image(
                     image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
                 )
 
-                md_page_url = (
-                    f"https://www.spc.noaa.gov/products/md/mcd{md_num}.html"
+                filename = f"mcd_{md_num}.png"
+                embeds = build_md_embeds(
+                    md_num, full_text,
+                    image_filename=filename if cache_path else None,
                 )
-                header = f"**🌩️ SPC Mesoscale Discussion #{md_num}**"
-                if summary:
-                    header += f"\n{summary}"
-                header += f"\n<{md_page_url}>"
 
                 try:
-                    msg = None
                     if cache_path:
                         msg = await channel.send(
-                            header, files=[discord.File(cache_path)]
+                            embeds=embeds,
+                            files=[discord.File(cache_path, filename=filename)],
                         )
                     else:
-                        msg = await channel.send(header)
+                        msg = await channel.send(embeds=embeds)
                         # Graphic missing (likely 403), try to fetch it later
-                        asyncio.create_task(self._upgrade_md_message(md_num, msg, header))
+                        asyncio.create_task(
+                            self._upgrade_md_message(md_num, msg, full_text)
+                        )
 
                     self.bot.state.posted_mds.add(md_num)
                     await add_posted_md(str(md_num))

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -429,6 +429,11 @@ class SoundingCog(commands.Cog):
             return
 
         labels_str = "/".join(sorted(labels))
+        # Caption prefix mirrors the most severe active level:
+        #  {"MDT"}        → "MDT-Risk"
+        #  {"HIGH"}       → "High-Risk"
+        #  {"MDT","HIGH"} → "High-Risk"  (HIGH dominates; covers both)
+        caption_prefix = "High-Risk" if "HIGH" in labels else "MDT-Risk"
         logger.info(
             f"[SOUNDING-RISK] {labels_str} active — "
             f"{len(in_area)} RAOB stations inside polygon"
@@ -501,7 +506,7 @@ class SoundingCog(commands.Cog):
                     if not success or not os.path.exists(png_path):
                         continue
                     caption = (
-                        f"**High-Risk Sounding — {station['name']} ({sid})**\n"
+                        f"**{caption_prefix} Sounding — {station['name']} ({sid})**\n"
                         f"Valid: {mo}-{d}-{y} {h}z | Inside SPC Day 1 {labels_str} risk area"
                     )
                     qwarn = sounding_quality_warning(data)
@@ -575,7 +580,7 @@ class SoundingCog(commands.Cog):
                     if not success or not os.path.exists(png_path):
                         continue
                     caption = (
-                        f"**High-Risk ACARS — {p['airport']}**\n"
+                        f"**{caption_prefix} ACARS — {p['airport']}**\n"
                         f"Valid: {p['time_label']} | Inside SPC Day 1 {labels_str} risk area"
                     )
                     try:

--- a/tests/test_md_text_embed.py
+++ b/tests/test_md_text_embed.py
@@ -1,0 +1,199 @@
+"""Tests for the MD body extractor and embed-builder helpers in
+cogs.mesoscale — full text rendering and Discord 4096-char-per-embed
+splitting."""
+
+import discord
+
+from cogs.mesoscale import (
+    EMBED_BODY_LIMIT,
+    build_md_embeds,
+    chunk_md_text,
+    extract_md_body,
+)
+
+
+SAMPLE_MD = """\
+Mesoscale Discussion 0579
+   NWS Storm Prediction Center Norman OK
+   0618 PM CDT Mon Apr 27 2026
+
+   Areas affected...southern IL...far southeast MO...eastern
+   KY...northwest TN
+
+   Concerning...Tornado Watch 162...
+
+   Valid 272318Z - 280045Z
+
+   The severe weather threat for Tornado Watch 162 continues.
+
+   SUMMARY...Severe risk is increasing across portions of WW 162.
+   Strong tornadoes, very large hail and damaging gusts remain
+   possible.
+
+   DISCUSSION...Deepening cumulus and a few towering cumulus are noted
+   in GOES-16 DCP imagery recently."""
+
+
+# ── extract_md_body ─────────────────────────────────────────────────────────
+
+
+def test_extract_md_body_from_spc_html():
+    """SPC HTML wraps the MD body in <pre>; we should pull just the
+    text, strip embedded tags, and decode entities."""
+    html = (
+        "<html><head><title>x</title></head><body>"
+        "<pre>Mesoscale Discussion 0579\n"
+        "   <b>Concerning</b>...Tornado Watch 162...\n"
+        "   AT&amp;T weather feed offline.\n"
+        "</pre>"
+        "</body></html>"
+    )
+    body = extract_md_body(html)
+    assert body is not None
+    assert "Mesoscale Discussion 0579" in body
+    assert "<b>" not in body, "HTML tags must be stripped"
+    assert "AT&T" in body, "entities must be decoded"
+    assert "Concerning...Tornado Watch 162..." in body
+
+
+def test_extract_md_body_passes_plain_text_through():
+    """IEM gives us already-plain text — no HTML; we shouldn't try to
+    parse a <pre> block that doesn't exist."""
+    body = extract_md_body(SAMPLE_MD)
+    assert body == SAMPLE_MD.strip()
+
+
+def test_extract_md_body_returns_none_for_empty_input():
+    assert extract_md_body(None) is None
+    assert extract_md_body("") is None
+    assert extract_md_body("   \n  ") is None
+
+
+def test_extract_md_body_returns_none_when_html_has_no_pre():
+    """Defensive: malformed SPC pages without a <pre> shouldn't yield
+    a stray HTML blob as if it were an MD body."""
+    assert extract_md_body("<html><body><p>oops</p></body></html>") is None
+
+
+# ── chunk_md_text ───────────────────────────────────────────────────────────
+
+
+def test_chunk_short_text_single_chunk():
+    chunks = chunk_md_text(SAMPLE_MD)
+    assert len(chunks) == 1
+    assert chunks[0] == SAMPLE_MD.strip()
+
+
+def test_chunk_empty_text_returns_empty_list():
+    assert chunk_md_text("") == []
+    assert chunk_md_text(None) == []
+
+
+def test_chunk_splits_oversized_text_on_paragraph_boundaries():
+    """A long MD must split at blank-line paragraph breaks, not mid-line.
+    SPC formats areas/threats as fixed-width columns and a mid-line
+    break would render unreadably."""
+    # Build a text with paragraphs that fit individually but overflow together.
+    para = ("Line one of paragraph.\n"
+            "Line two extends the paragraph with more words.\n"
+            "Line three closes it out.")
+    paragraphs = [f"Paragraph {i}: {para}" for i in range(60)]
+    text = "\n\n".join(paragraphs)
+    assert len(text) > EMBED_BODY_LIMIT
+
+    chunks = chunk_md_text(text, max_chars=EMBED_BODY_LIMIT)
+    assert len(chunks) >= 2
+    for c in chunks:
+        assert len(c) <= EMBED_BODY_LIMIT, f"chunk too big: {len(c)}"
+    # Concatenating should preserve every paragraph (modulo the
+    # blank-line separator we re-insert when joining).
+    rejoined = "\n\n".join(chunks)
+    for i in range(60):
+        assert f"Paragraph {i}:" in rejoined
+
+
+def test_chunk_handles_single_oversized_paragraph():
+    """When one paragraph alone exceeds the limit we fall through to
+    per-line splitting."""
+    big_para = "\n".join(f"Line {i:04d} with some narrative content." for i in range(200))
+    assert len(big_para) > EMBED_BODY_LIMIT
+
+    chunks = chunk_md_text(big_para, max_chars=EMBED_BODY_LIMIT)
+    assert len(chunks) >= 2
+    for c in chunks:
+        assert len(c) <= EMBED_BODY_LIMIT
+
+
+def test_chunk_hard_truncates_a_single_giant_line():
+    """Sanity: even a pathological 5000-char single line shouldn't
+    crash the splitter — we hard-truncate as a last resort."""
+    line = "x" * (EMBED_BODY_LIMIT + 1000)
+    chunks = chunk_md_text(line, max_chars=EMBED_BODY_LIMIT)
+    assert len(chunks) >= 1
+    for c in chunks:
+        assert len(c) <= EMBED_BODY_LIMIT
+
+
+# ── build_md_embeds ─────────────────────────────────────────────────────────
+
+
+def test_build_embed_single_chunk_with_image():
+    embeds = build_md_embeds("0579", SAMPLE_MD, image_filename="mcd_0579.png")
+    assert len(embeds) == 1
+    e = embeds[0]
+    assert isinstance(e, discord.Embed)
+    assert "0579" in e.title
+    assert e.url == "https://www.spc.noaa.gov/products/md/mcd0579.html"
+    assert e.description.startswith("```")
+    assert e.description.endswith("```")
+    assert "Concerning...Tornado Watch 162..." in e.description
+    assert e.image.url == "attachment://mcd_0579.png"
+
+
+def test_build_embed_multi_chunk_marks_pagination_and_image_only_first():
+    """A long MD splits across multiple embeds; titles get an N/M suffix
+    and only the first embed carries the image so Discord doesn't try
+    to attach a graphic to every fragment."""
+    big_text = "\n\n".join(
+        f"Paragraph {i}: " + ("filler " * 50)
+        for i in range(60)
+    )
+    embeds = build_md_embeds("0599", big_text, image_filename="mcd_0599.png")
+    assert len(embeds) >= 2
+    # Title pagination
+    for i, e in enumerate(embeds):
+        assert f"({i + 1}/{len(embeds)})" in e.title
+        assert e.url == "https://www.spc.noaa.gov/products/md/mcd0599.html"
+    # Image only on first embed
+    assert embeds[0].image.url == "attachment://mcd_0599.png"
+    for e in embeds[1:]:
+        assert e.image.url is None or e.image.url == "" or not e.image.url
+
+
+def test_build_embed_no_text_still_returns_one_embed():
+    """If we can't resolve any body text we still want a clickable
+    title + image embed — better than dropping the post."""
+    embeds = build_md_embeds("0579", None, image_filename="mcd_0579.png")
+    assert len(embeds) == 1
+    assert embeds[0].description is None or embeds[0].description == ""
+    assert embeds[0].image.url == "attachment://mcd_0579.png"
+
+
+def test_build_embed_no_image_filename_omits_image():
+    """Pre-graphic backfill case: text-only embed, no image attribute."""
+    embeds = build_md_embeds("0579", SAMPLE_MD, image_filename=None)
+    assert len(embeds) == 1
+    img_url = embeds[0].image.url
+    assert not img_url, f"expected no image url, got {img_url!r}"
+
+
+def test_build_embed_description_under_4096_with_codeblock_overhead():
+    """Each rendered description (code-block fences included) must
+    stay inside Discord's 4096-char embed-description hard limit."""
+    big_text = "\n\n".join(
+        f"Paragraph {i}: " + ("filler " * 50)
+        for i in range(60)
+    )
+    embeds = build_md_embeds("0599", big_text, image_filename="mcd_0599.png")
+    for e in embeds:
+        assert len(e.description) <= 4096

--- a/tests/test_spc_outlook.py
+++ b/tests/test_spc_outlook.py
@@ -141,6 +141,19 @@ async def test_fetch_failure_keeps_last_known_polygon():
     assert second is first  # exact same cached object
 
 
+def test_caption_prefix_matches_severity_label():
+    """The caption prefix used by monitor_high_risk_soundings must
+    follow the active label set: MDT alone → 'MDT-Risk'; HIGH alone or
+    HIGH+MDT → 'High-Risk' (HIGH is the dominant level)."""
+    # Replicate the prefix-selection rule inline to pin the contract.
+    def prefix(labels):
+        return "High-Risk" if "HIGH" in labels else "MDT-Risk"
+
+    assert prefix(frozenset({"MDT"})) == "MDT-Risk"
+    assert prefix(frozenset({"HIGH"})) == "High-Risk"
+    assert prefix(frozenset({"MDT", "HIGH"})) == "High-Risk"
+
+
 @pytest.mark.asyncio
 async def test_is_inside_polygon_handles_none():
     """Defensive: callers may pass None when no MDT/HIGH is active."""


### PR DESCRIPTION
## Summary

Two bundled changes — primary feature plus a fix the user spotted in the live high-risk sounding posts.

### MD posts now include the full discussion text

Mesoscale discussions become a \`discord.Embed\`: title links to the SPC page, description carries the full MD body in a code block (preserves SPC's column-aligned \"Areas affected\" / \"SUMMARY\" layout), graphic attached as the embed image. Previously the post was just the header and the \"Concerning\" line.

- Long discussions (over 4000 chars) split across multiple embeds with \`(N/M)\` pagination on the title; only the first embed carries the image.
- Splits prefer paragraph boundaries — never mid-line, since SPC's fixed-width areas columns are unreadable when wrapped.
- The graphic-backfill path (\`_upgrade_md_message\`) now rebuilds the same embed structure when SPC catches up after an index lag.
- Live extraction tested against a real MD: 1825-char body → 1 embed with 1833-char description (fences included).

### High-risk caption prefix matches the active level

\`monitor_high_risk_soundings\` hardcoded \"High-Risk\" as the caption prefix regardless of whether MDT, HIGH, or both were active. On a live MDT-only day this produced misleading \`High-Risk ACARS — STL\` posts. Prefix now derives from the active label set: \`{MDT}\` → \`MDT-Risk\`, \`{HIGH}\` (alone or with MDT) → \`High-Risk\`.

## Test plan

- [x] \`pytest tests/\` — 235 passed (was 220 + 15 new).
- [x] \`ruff check\` — clean.
- [x] Live extraction smoke test: real \`md0578.html\` → 1825 chars → 1 embed with image.
- [ ] After deploy, watch the next MD post and confirm: full text rendered, code block aligned, link clickable, image attached.
- [ ] Confirm the next ACARS/Sounding post during MDT shows \`MDT-Risk\` rather than \`High-Risk\`.