### PR TITLE
fix(md): upgrade poll now also recovers body text, not just graphic

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -396,36 +396,78 @@ class MesoscaleCog(commands.Cog):
         message: discord.Message,
         full_text: Optional[str],
     ):
-        """Poll for the MD graphic and edit the message to attach it.
+        """Poll for the MD graphic and body text, editing the message
+        as either becomes available.
 
-        Retries every 30s for up to 5 minutes. Rebuilds the embeds from
-        ``full_text`` so the body content is preserved alongside the
-        newly-attached graphic.
+        Two separate things can be missing when the iembot fast-path
+        fires: the SPC graphic (slow CDN), and/or the SPC HTML body
+        text (404 until SPC publishes the discussion). Each tick we try
+        to recover whichever is still missing and edit the message
+        immediately on improvement, so the user never sits looking at
+        an empty embed for the full poll window. Stops once we have
+        both the graphic and the body text.
         """
         image_url = f"https://www.spc.noaa.gov/products/md/mcd{md_num}.png"
         filename = f"mcd_{md_num}.png"
+        cache_path: Optional[str] = None
+
+        async def _push_edit():
+            embeds = build_md_embeds(
+                md_num, full_text,
+                image_filename=filename if cache_path else None,
+            )
+            try:
+                if cache_path:
+                    await message.edit(
+                        embeds=embeds,
+                        attachments=[discord.File(cache_path, filename=filename)],
+                    )
+                else:
+                    await message.edit(embeds=embeds)
+                return True
+            except discord.HTTPException as e:
+                logger.warning(f"[MD] Failed to edit MD message for #{md_num}: {e}")
+                return False
+
         for attempt in range(10):
             await asyncio.sleep(30)
-            try:
-                cache_path, _, _ = await download_single_image(
-                    image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
-                )
-                if cache_path:
-                    try:
-                        embeds = build_md_embeds(
-                            md_num, full_text, image_filename=filename
+
+            text_recovered = False
+            if not full_text:
+                try:
+                    _, _, _, raw = await fetch_md_details(md_num)
+                    recovered = extract_md_body(raw)
+                    if recovered:
+                        full_text = recovered
+                        text_recovered = True
+                        logger.info(
+                            f"[MD] Recovered body text for #{md_num} during upgrade"
                         )
-                        await message.edit(
-                            embeds=embeds,
-                            attachments=[discord.File(cache_path, filename=filename)],
-                        )
-                        logger.info(f"[MD] Upgraded MD #{md_num} with graphic")
-                        break
-                    except discord.HTTPException as e:
-                        logger.warning(f"[MD] Failed to edit MD message for #{md_num}: {e}")
-                        break
-            except Exception as e:
-                logger.debug(f"[MD] Upgrade poll error for #{md_num}: {e}")
+                except Exception as e:
+                    logger.debug(f"[MD] Body recovery failed for #{md_num}: {e}")
+
+            image_recovered = False
+            if not cache_path:
+                try:
+                    cp, _, _ = await download_single_image(
+                        image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
+                    )
+                    if cp:
+                        cache_path = cp
+                        image_recovered = True
+                except Exception as e:
+                    logger.debug(f"[MD] Upgrade poll error for #{md_num}: {e}")
+
+            if text_recovered or image_recovered:
+                ok = await _push_edit()
+                if not ok:
+                    break
+                if image_recovered:
+                    logger.info(f"[MD] Upgraded MD #{md_num} with graphic")
+
+            if cache_path and full_text:
+                # We've got both — nothing left to backfill.
+                break
 
     async def post_md_now(self, md_num: str):
         """


### PR DESCRIPTION
## Summary

Live regression caught on MD #0580. The iembot fast-path fired while SPC was still returning 404 for the discussion page (\`<pre>\` body unavailable), so the initial post landed with just the title + URL. The graphic-upgrade poller then attached the image at the next tick — but it never re-fetched the body, so the embed stayed empty of text.

User-visible: \"WXModelBot APP — 4:36 PM 🌩️ SPC Mesoscale Discussion #0580 (link)\" with the graphic edited in later but no discussion body.

### Fix

Each upgrade tick now tries to recover whichever piece is still missing — text, graphic, or both — and pushes an edit as soon as either improves:

1. If \`full_text\` is missing, re-fetch SPC page and try \`extract_md_body\` again. Log on success.
2. If graphic is missing, try the image download.
3. If either improved this tick, edit the message right away so the user doesn't sit on an empty embed.
4. Stop polling once both are present.

So a fast-path MD posted during SPC index lag will now fill in the body within ~30s of SPC publishing, even if the graphic is still delayed.

### Note on #0580

The upgrade poller for #0580 already completed before this fix landed (graphic attached, loop broke). That single MD won't retroactively get its body filled — it's a one-time visual blemish. All future iembot-triggered MDs during SPC lag will work correctly.

## Test plan

- [x] \`pytest tests/\` — 235 passed.
- [x] \`ruff check\` — clean.
- [ ] Watch the next iembot-triggered MD where SPC is lagging: expect title-only embed initially, then \`[MD] Recovered body text for #XXXX during upgrade\` log + body filled in within 30-60s, then graphic attached after that.