### PR TITLE
fix(logging): set propagate=False to prevent duplicate log entries

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from cogs import ALL_EXTENSIONS
 # ── Logging setup ────────────────────────────────────────────────────────────
 logger = logging.getLogger("spc_bot")
 logger.setLevel(logging.INFO)
+logger.propagate = False
 formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
 
 ch = logging.StreamHandler()


### PR DESCRIPTION
## Summary
- Sets `logger.propagate = False` on the `spc_bot` logger in `main.py`
- Prevents any root-level handler added by discord.py, aiohttp, or other libraries at runtime from causing each `spc_bot` record to be emitted twice
- The previous fix (`_plot_worker_init` handler clearing) addressed worker processes inheriting handlers, but same-PID/same-millisecond duplicates observed in production point to the main process propagating records to an accumulated root handler — this closes that path permanently

## Test plan
- [ ] CI passes
- [ ] Confirm no duplicate log lines after deploy