### PR TITLE
feat(events-db): separate tornado archive from bot_state.db with Syncthing sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,10 @@ FAILOVER_TOKEN=your-shared-secret-here
 # Manual Failover Admin
 # The Discord user ID authorized to use the /failover command.
 ADMIN_USER_ID=977054521035472906
+
+# Syncthing integration — events.db cross-node sync (optional)
+# Install Syncthing on both nodes, pair them, and create a shared folder with
+# id matching SYNCTHING_FOLDER_ID (send-only on Primary, receive-only on Standby).
+# The bot flips the folder mode automatically on promotion/demotion.
+# SYNCTHING_API_KEY=your_local_syncthing_api_key
+# SYNCTHING_FOLDER_ID=spcbot-events

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -345,6 +345,11 @@ class FailoverCog(commands.Cog):
         logger.warning("[FAILOVER] !!! PROMOTING TO PRIMARY !!!")
         self.bot.state.is_primary = True
 
+        # Restore events.db from Syncthing snapshot before cogs load.
+        from utils.events_db import restore_from_sync, set_syncthing_folder_mode  # noqa: PLC0415
+        restore_from_sync()
+        await set_syncthing_folder_mode("sendonly")
+
         # Drop stale cache so fresh reads re-hit Upstash.
         state_store.invalidate_all_caches()
 
@@ -424,6 +429,8 @@ class FailoverCog(commands.Cog):
     async def _demote(self) -> None:
         logger.info("[FAILOVER] Demoting to STANDBY")
         self.bot.state.is_primary = False
+        from utils.events_db import set_syncthing_folder_mode  # noqa: PLC0415
+        await set_syncthing_folder_mode("receiveonly")
         failed = []
         for ext in ALL_EXTENSIONS:
             try:

--- a/main.py
+++ b/main.py
@@ -212,6 +212,8 @@ async def on_ready():
         logger.info("All tasks started. Bot is ready.")
         if not periodic_sync.is_running():
             periodic_sync.start()
+        if not snapshot_events_task.is_running():
+            snapshot_events_task.start()
     except Exception as e:
         logger.exception(f"[on_ready] Unhandled error: {e}")
 
@@ -368,6 +370,15 @@ async def watchdog_task():
                 )
 
 
+# ── Events DB snapshot (every 5 min, Primary only) ───────────────────────────
+@tasks.loop(minutes=5)
+async def snapshot_events_task():
+    if not bot.state.is_primary:
+        return
+    from utils.events_db import snapshot_for_sync  # noqa: PLC0415
+    await snapshot_for_sync()
+
+
 # ── Graceful shutdown ────────────────────────────────────────────────────────
 _shutting_down = False
 
@@ -391,6 +402,8 @@ async def _shutdown():
     watchdog_task.cancel()
     if periodic_sync.is_running():
         periodic_sync.cancel()
+    if snapshot_events_task.is_running():
+        snapshot_events_task.cancel()
 
     # 2. Close DB, HTTP session, and plot worker pool
     try:
@@ -399,8 +412,9 @@ async def _shutdown():
     except Exception:
         pass
     try:
+        from utils.events_db import close_events_db  # noqa: PLC0415
         await asyncio.wait_for(
-            asyncio.gather(utils.http.close_session(), close_db(), return_exceptions=True),
+            asyncio.gather(utils.http.close_session(), close_db(), close_events_db(), return_exceptions=True),
             timeout=3.0,
         )
     except asyncio.TimeoutError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,3 +134,21 @@ async def isolated_db(tmp_path, monkeypatch):
     yield conn
 
     await db_mod.close_db()
+
+
+@pytest.fixture
+async def isolated_events_db(tmp_path, monkeypatch):
+    """Point `utils.events_db` at a fresh SQLite file for one test."""
+    from utils import events_db as edb_mod
+
+    if edb_mod._db is not None:
+        await edb_mod.close_events_db()
+
+    db_file = tmp_path / "test_events.db"
+    monkeypatch.setattr(edb_mod, "_EVENTS_DB_PATH", str(db_file))
+    monkeypatch.setattr(edb_mod, "_SYNC_PATH", str(tmp_path / "events_sync.db"))
+
+    conn = await edb_mod.get_events_db()
+    yield conn
+
+    await edb_mod.close_events_db()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,3 +152,22 @@ async def isolated_events_db(tmp_path, monkeypatch):
     yield conn
 
     await edb_mod.close_events_db()
+
+
+@pytest.fixture(autouse=True, scope="session")
+def close_events_db_after_session():
+    """Ensure the events_db connection is closed at end of session.
+
+    Without this, aiosqlite's worker thread keeps the process alive after
+    pytest completes, causing CI to hang indefinitely.
+    """
+    yield
+    import asyncio
+    from utils import events_db as edb_mod
+    if edb_mod._db is not None:
+        try:
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(edb_mod.close_events_db())
+            loop.close()
+        except Exception:
+            pass

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -161,98 +161,63 @@ async def test_concurrent_writes_serialized(isolated_db):
     assert len(await db.get_posted_mds()) == 50
 
 
-# ── Significant Events ──────────────────────────────────────────────────────
+# ── Significant Events (now in utils.events_db) ─────────────────────────────
 
-async def test_significant_events_roundtrip(isolated_db):
-    await db.add_significant_event(
-        event_id="TEST:1",
-        event_type="Tornado",
-        location="Somewhere, OK",
-        magnitude="Confirmed",
-        source="OUN",
-        timestamp=1000.0,
-        raw_text="Test tornado"
-    )
-    
-    events = await db.get_recent_significant_events(event_type="Tornado", since_hours=24)
-    assert len(events) == 0 # because timestamp 1000.0 is way in the past
-    
+async def test_significant_events_roundtrip(isolated_events_db):
+    from utils import events_db
     import time
-    now = time.time()
-    await db.add_significant_event(
-        event_id="TEST:2",
-        event_type="Tornado",
-        location="Near Moore, OK",
-        magnitude="Confirmed",
-        source="OUN",
-        timestamp=now,
-        raw_text="Recent tornado"
+    await events_db.add_significant_event(
+        event_id="TEST:1", event_type="Tornado", location="Somewhere, OK",
+        magnitude="Confirmed", source="OUN", timestamp=1000.0, raw_text="Test tornado"
     )
-    
-    events = await db.get_recent_significant_events(event_type="Tornado", since_hours=1)
+    events = await events_db.get_recent_significant_events(event_type="Tornado", since_hours=24)
+    assert len(events) == 0  # timestamp 1000.0 is way in the past
+
+    now = time.time()
+    await events_db.add_significant_event(
+        event_id="TEST:2", event_type="Tornado", location="Near Moore, OK",
+        magnitude="Confirmed", source="OUN", timestamp=now, raw_text="Recent tornado"
+    )
+    events = await events_db.get_recent_significant_events(event_type="Tornado", since_hours=1)
     assert len(events) == 1
     assert events[0]["location"] == "Near Moore, OK"
     assert events[0]["event_id"] == "TEST:2"
 
 
-async def test_significant_events_conflict_update(isolated_db):
-    await db.add_significant_event(
-        event_id="CONFLICT:1",
-        event_type="Tornado",
-        location="Old Location",
-        magnitude="Confirmed",
-        source="OUN",
-        timestamp=2000.0
+async def test_significant_events_conflict_update(isolated_events_db):
+    from utils import events_db
+    await events_db.add_significant_event(
+        event_id="CONFLICT:1", event_type="Tornado", location="Old Location",
+        magnitude="Confirmed", source="OUN", timestamp=2000.0
     )
-    
-    # Update same ID with new info (e.g. EF rating from survey)
-    await db.add_significant_event(
-        event_id="CONFLICT:1",
-        event_type="Tornado",
-        location="New Location",
-        magnitude="EF-2",
-        source="OUN",
-        timestamp=2000.0
+    await events_db.add_significant_event(
+        event_id="CONFLICT:1", event_type="Tornado", location="New Location",
+        magnitude="EF-2", source="OUN", timestamp=2000.0
     )
-    
-    events = await db.get_recent_significant_events(event_type="Tornado", since_hours=999999)
+    events = await events_db.get_recent_significant_events(event_type="Tornado", since_hours=999999)
     assert len(events) == 1
     assert events[0]["location"] == "New Location"
     assert events[0]["magnitude"] == "EF-2"
 
 
-async def test_find_matching_tornado(isolated_db):
-    now = 1714300000.0 # arbitrary
-    await db.add_significant_event(
-        event_id="LSR:1",
-        event_type="Tornado",
-        location="3 SE FLORENCE",
-        source="HUN",
-        timestamp=now
+async def test_find_matching_tornado(isolated_events_db):
+    from utils import events_db
+    now = 1714300000.0
+    await events_db.add_significant_event(
+        event_id="LSR:1", event_type="Tornado", location="3 SE FLORENCE",
+        source="HUN", timestamp=now
     )
-    
-    # Matching case: same WFO, close time, similar location words
-    match_id = await db.find_matching_tornado(
-        source="HUN",
-        timestamp=now + 600, # 10 mins later
-        location_query="LAUDERDALE COUNTY TORNADO" # Florence is in Lauderdale
+    match_id = await events_db.find_matching_tornado(
+        source="HUN", timestamp=now + 600, location_query="LAUDERDALE COUNTY TORNADO"
     )
-    # Florence and Lauderdale don't overlap, but they are in the same WFO and time window.
-    # If it's the only one, it matches.
     assert match_id == "LSR:1"
-    
-    # Non-matching case: different WFO
-    no_match = await db.find_matching_tornado(
-        source="OUN",
-        timestamp=now,
-        location_query="3 SE FLORENCE"
+
+    no_match = await events_db.find_matching_tornado(
+        source="OUN", timestamp=now, location_query="3 SE FLORENCE"
     )
     assert no_match is None
-    
-    # Non-matching case: different time
-    no_match_time = await db.find_matching_tornado(
-        source="HUN",
-        timestamp=now + 86400, # 24 hours later
-        location_query="3 SE FLORENCE"
+
+    no_match_time = await events_db.find_matching_tornado(
+        source="HUN", timestamp=now + 86400, location_query="3 SE FLORENCE"
     )
     assert no_match_time is None

--- a/utils/db.py
+++ b/utils/db.py
@@ -133,18 +133,6 @@ async def _create_tables(db: aiosqlite.Connection):
             posted_at REAL NOT NULL DEFAULT 0
         );
 
-        CREATE TABLE IF NOT EXISTS significant_events (
-            event_id    TEXT PRIMARY KEY,
-            event_type  TEXT NOT NULL,
-            location    TEXT NOT NULL,
-            magnitude   TEXT,
-            vtec_id     TEXT,
-            coords      TEXT,
-            timestamp   REAL NOT NULL,
-            source      TEXT NOT NULL,
-            raw_text    TEXT
-        );
-
         CREATE TABLE IF NOT EXISTS posted_warnings (
             vtec_id    TEXT PRIMARY KEY,
             message_id INTEGER NOT NULL DEFAULT 0,
@@ -383,111 +371,6 @@ async def prune_posted_surveys(max_size: int = 100):
         (max_size,),
         "prune_posted_surveys",
     )
-
-
-# ── Significant Events (Tornadoes, etc.) ────────────────────────────────────
-
-async def add_significant_event(
-    event_id: str,
-    event_type: str,
-    location: str,
-    magnitude: str = "",
-    vtec_id: str = "",
-    coords: str = "",
-    timestamp: float = 0.0,
-    source: str = "",
-    raw_text: str = ""
-):
-    """Log a significant weather event (Confirmed Tornado, Giant Hail, etc.)."""
-    await _write(
-        """INSERT INTO significant_events 
-           (event_id, event_type, location, magnitude, vtec_id, coords, timestamp, source, raw_text)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT(event_id) DO UPDATE SET
-             magnitude=excluded.magnitude,
-             location=excluded.location,
-             coords=excluded.coords,
-             raw_text=excluded.raw_text""",
-        (event_id, event_type, location, magnitude, vtec_id, coords, timestamp or time.time(), source, raw_text),
-        f"add_significant_event({event_id})",
-    )
-
-
-async def get_recent_significant_events(
-    event_type: Optional[str] = None,
-    since_hours: int = 24,
-    limit: int = 50
-) -> list:
-    """Retrieve recent significant events."""
-    try:
-        db = await get_db()
-        now = time.time()
-        start_ts = now - (since_hours * 3600)
-        
-        sql = "SELECT * FROM significant_events WHERE timestamp >= ?"
-        params = [start_ts]
-        
-        if event_type:
-            sql += " AND event_type = ?"
-            params.append(event_type)
-            
-        sql += " ORDER BY timestamp DESC LIMIT ?"
-        params.append(limit)
-        
-        async with db.execute(sql, tuple(params)) as cursor:
-            rows = await cursor.fetchall()
-            return [dict(row) for row in rows]
-    except Exception as e:
-        logger.warning(f"[DB] get_recent_significant_events failed: {e}")
-        return []
-
-
-async def find_matching_tornado(
-    source: str, timestamp: float, location_query: str, window_hours: float = 12.0
-) -> Optional[str]:
-    """Attempt to find an existing Tornado event ID that matches a survey or another LSR.
-    Matches by WFO (source) and a configurable time window, then fuzzy location.
-    """
-    try:
-        db = await get_db()
-        # Look +/- window_hours from the detected timestamp
-        window_seconds = window_hours * 3600
-        start_ts = timestamp - window_seconds
-        end_ts = timestamp + window_seconds
-        
-        sql = """
-            SELECT event_id, location FROM significant_events 
-            WHERE event_type = 'Tornado' 
-              AND source = ? 
-              AND timestamp BETWEEN ? AND ?
-        """
-        async with db.execute(sql, (source, start_ts, end_ts)) as cursor:
-            rows = await cursor.fetchall()
-            
-        if not rows:
-            return None
-        
-        # Simple fuzzy match on location: if survey location is in LSR location or vice versa
-        if len(rows) == 1:
-            return rows[0]["event_id"]
-        
-        # If multiple, try matching location words
-        import re as _re
-        query_words = set(_re.findall(r"\w+", location_query.upper()))
-        best_id = None
-        best_score = -1
-        
-        for row in rows:
-            loc_words = set(_re.findall(r"\w+", row["location"].upper()))
-            overlap = len(query_words.intersection(loc_words))
-            if overlap > best_score:
-                best_score = overlap
-                best_id = row["event_id"]
-                
-        return best_id
-    except Exception as e:
-        logger.warning(f"[DB] find_matching_tornado failed: {e}")
-        return None
 
 
 # ── Posted warnings ───────────────────────────────────────────────────────────

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -1,0 +1,231 @@
+# utils/events_db.py
+"""
+Standalone SQLite database for the significant weather events archive.
+
+Intentionally separate from bot_state.db / Upstash so the historical
+tornado record never touches the Redis free-tier budget and can grow
+indefinitely without impacting operational state sync.
+
+File location: cache/events.db  (configurable via EVENTS_DB_PATH env var)
+Sync snapshot:  cache/events_sync/events.db  — written every snapshot cycle,
+                watched by Syncthing for cross-node replication.
+"""
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+import time
+from typing import Optional
+
+import aiosqlite
+
+logger = logging.getLogger("spc_bot")
+
+_EVENTS_DB_PATH = os.getenv("EVENTS_DB_PATH", "cache/events.db")
+_SYNC_DIR = os.getenv("EVENTS_SYNC_DIR", "cache/events_sync")
+_SYNC_PATH = os.path.join(_SYNC_DIR, "events.db")
+
+_db: Optional[aiosqlite.Connection] = None
+_db_lock = asyncio.Lock()
+
+
+async def get_events_db() -> aiosqlite.Connection:
+    global _db
+    if _db is not None:
+        return _db
+    async with _db_lock:
+        if _db is not None:
+            return _db
+        os.makedirs(os.path.dirname(_EVENTS_DB_PATH), exist_ok=True)
+        conn = await aiosqlite.connect(_EVENTS_DB_PATH)
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute("PRAGMA busy_timeout=5000")
+        await _create_tables(conn)
+        await conn.commit()
+        _db = conn
+        logger.info(f"[EVENTS-DB] Connected to {_EVENTS_DB_PATH}")
+        return _db
+
+
+async def close_events_db() -> None:
+    global _db
+    if _db is not None:
+        await _db.close()
+        _db = None
+
+
+async def _create_tables(db: aiosqlite.Connection) -> None:
+    await db.executescript("""
+        CREATE TABLE IF NOT EXISTS significant_events (
+            event_id    TEXT PRIMARY KEY,
+            event_type  TEXT NOT NULL,
+            location    TEXT NOT NULL,
+            magnitude   TEXT,
+            vtec_id     TEXT,
+            coords      TEXT,
+            timestamp   REAL NOT NULL,
+            source      TEXT NOT NULL,
+            raw_text    TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_sig_events_type_ts
+            ON significant_events (event_type, timestamp DESC);
+    """)
+
+
+# ── Writes ───────────────────────────────────────────────────────────────────
+
+async def add_significant_event(
+    event_id: str,
+    event_type: str,
+    location: str,
+    magnitude: str = "",
+    vtec_id: str = "",
+    coords: str = "",
+    timestamp: float = 0.0,
+    source: str = "",
+    raw_text: str = "",
+) -> None:
+    db = await get_events_db()
+    try:
+        await db.execute(
+            """INSERT INTO significant_events
+               (event_id, event_type, location, magnitude, vtec_id, coords,
+                timestamp, source, raw_text)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(event_id) DO UPDATE SET
+                 magnitude = excluded.magnitude,
+                 location  = excluded.location,
+                 coords    = excluded.coords,
+                 raw_text  = excluded.raw_text""",
+            (event_id, event_type, location, magnitude, vtec_id, coords,
+             timestamp or time.time(), source, raw_text),
+        )
+        await db.commit()
+    except Exception as e:
+        logger.warning(f"[EVENTS-DB] add_significant_event({event_id}) failed: {e}")
+
+
+# ── Reads ────────────────────────────────────────────────────────────────────
+
+async def get_recent_significant_events(
+    event_type: Optional[str] = None,
+    since_hours: int = 24,
+    limit: int = 50,
+) -> list:
+    db = await get_events_db()
+    try:
+        start_ts = time.time() - (since_hours * 3600)
+        sql = "SELECT * FROM significant_events WHERE timestamp >= ?"
+        params: list = [start_ts]
+        if event_type:
+            sql += " AND event_type = ?"
+            params.append(event_type)
+        sql += " ORDER BY timestamp DESC LIMIT ?"
+        params.append(limit)
+        async with db.execute(sql, tuple(params)) as cur:
+            rows = await cur.fetchall()
+            return [dict(r) for r in rows]
+    except Exception as e:
+        logger.warning(f"[EVENTS-DB] get_recent_significant_events failed: {e}")
+        return []
+
+
+async def find_matching_tornado(
+    source: str,
+    timestamp: float,
+    location_query: str,
+    window_hours: float = 12.0,
+) -> Optional[str]:
+    db = await get_events_db()
+    try:
+        window = window_hours * 3600
+        async with db.execute(
+            """SELECT event_id, location FROM significant_events
+               WHERE event_type = 'Tornado'
+                 AND source = ?
+                 AND timestamp BETWEEN ? AND ?""",
+            (source, timestamp - window, timestamp + window),
+        ) as cur:
+            rows = await cur.fetchall()
+        if not rows:
+            return None
+        if len(rows) == 1:
+            return rows[0]["event_id"]
+        query_words = set(re.findall(r"\w+", location_query.upper()))
+        best_id, best_score = None, -1
+        for row in rows:
+            overlap = len(query_words & set(re.findall(r"\w+", row["location"].upper())))
+            if overlap > best_score:
+                best_score, best_id = overlap, row["event_id"]
+        return best_id
+    except Exception as e:
+        logger.warning(f"[EVENTS-DB] find_matching_tornado failed: {e}")
+        return None
+
+
+# ── Syncthing snapshot ───────────────────────────────────────────────────────
+
+async def snapshot_for_sync() -> None:
+    """Copy events.db to the Syncthing-watched directory as a clean snapshot."""
+    try:
+        os.makedirs(_SYNC_DIR, exist_ok=True)
+        db = await get_events_db()
+        tmp = _SYNC_PATH + ".tmp"
+        async with aiosqlite.connect(tmp) as dst:
+            await db.backup(dst)
+        os.replace(tmp, _SYNC_PATH)
+        logger.debug("[EVENTS-DB] Snapshot written to sync dir")
+    except Exception as e:
+        logger.warning(f"[EVENTS-DB] Snapshot failed: {e}")
+
+
+def restore_from_sync() -> None:
+    """Copy the Syncthing-received snapshot into events.db before cogs load.
+    Called synchronously at promotion time before the event loop is busy."""
+    if not os.path.exists(_SYNC_PATH):
+        logger.info("[EVENTS-DB] No sync snapshot found — starting fresh events.db")
+        return
+    try:
+        os.makedirs(os.path.dirname(_EVENTS_DB_PATH), exist_ok=True)
+        shutil.copy2(_SYNC_PATH, _EVENTS_DB_PATH)
+        logger.info(f"[EVENTS-DB] Restored events.db from sync snapshot")
+    except Exception as e:
+        logger.warning(f"[EVENTS-DB] Restore from sync failed: {e}")
+
+
+# ── Syncthing folder-mode flipping ───────────────────────────────────────────
+
+async def set_syncthing_folder_mode(mode: str) -> None:
+    """Flip the Syncthing folder to 'sendonly' on promotion or 'receiveonly' on demotion."""
+    api_key = os.getenv("SYNCTHING_API_KEY", "")
+    folder_id = os.getenv("SYNCTHING_FOLDER_ID", "spcbot-events")
+    if not api_key:
+        return
+    import aiohttp as _aiohttp
+    url_base = "http://127.0.0.1:8384"
+    headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
+    try:
+        async with _aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{url_base}/rest/config/folders/{folder_id}", headers=headers, timeout=_aiohttp.ClientTimeout(total=5)
+            ) as resp:
+                if resp.status != 200:
+                    logger.warning(f"[EVENTS-DB] Syncthing folder fetch failed: {resp.status}")
+                    return
+                folder_cfg = await resp.json()
+            folder_cfg["type"] = mode
+            async with session.put(
+                f"{url_base}/rest/config/folders/{folder_id}",
+                headers=headers,
+                json=folder_cfg,
+                timeout=_aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status in (200, 201):
+                    logger.info(f"[EVENTS-DB] Syncthing folder set to {mode}")
+                else:
+                    logger.warning(f"[EVENTS-DB] Syncthing folder update failed: {resp.status}")
+    except Exception as e:
+        logger.warning(f"[EVENTS-DB] Syncthing API call failed: {e}")

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -11,7 +11,6 @@ Sync snapshot:  cache/events_sync/events.db  — written every snapshot cycle,
                 watched by Syncthing for cross-node replication.
 """
 
-import asyncio
 import logging
 import os
 import re
@@ -28,26 +27,22 @@ _SYNC_DIR = os.getenv("EVENTS_SYNC_DIR", "cache/events_sync")
 _SYNC_PATH = os.path.join(_SYNC_DIR, "events.db")
 
 _db: Optional[aiosqlite.Connection] = None
-_db_lock = asyncio.Lock()
 
 
 async def get_events_db() -> aiosqlite.Connection:
     global _db
     if _db is not None:
         return _db
-    async with _db_lock:
-        if _db is not None:
-            return _db
-        os.makedirs(os.path.dirname(_EVENTS_DB_PATH), exist_ok=True)
-        conn = await aiosqlite.connect(_EVENTS_DB_PATH)
-        conn.row_factory = aiosqlite.Row
-        await conn.execute("PRAGMA journal_mode=WAL")
-        await conn.execute("PRAGMA busy_timeout=5000")
-        await _create_tables(conn)
-        await conn.commit()
-        _db = conn
-        logger.info(f"[EVENTS-DB] Connected to {_EVENTS_DB_PATH}")
-        return _db
+    os.makedirs(os.path.dirname(_EVENTS_DB_PATH), exist_ok=True)
+    conn = await aiosqlite.connect(_EVENTS_DB_PATH)
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("PRAGMA journal_mode=WAL")
+    await conn.execute("PRAGMA busy_timeout=5000")
+    await _create_tables(conn)
+    await conn.commit()
+    _db = conn
+    logger.info(f"[EVENTS-DB] Connected to {_EVENTS_DB_PATH}")
+    return _db
 
 
 async def close_events_db() -> None:

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -135,8 +135,6 @@ def _k_posted_surveys() -> str:
     return f"{_PREFIX}:posted_surveys"
 
 
-def _k_significant_events() -> str:
-    return f"{_PREFIX}:significant_events"
 
 
 def _k_posted_warnings() -> str:
@@ -333,14 +331,6 @@ async def _replay(op: str, args: tuple) -> None:
     elif op == "add_posted_survey":
         (dat_guid,) = args
         await _upstash_cmd("SADD", _k_posted_surveys(), dat_guid)
-    elif op == "add_significant_event":
-        event_id, event_type, location, magnitude, vtec_id, coords, ts, source, raw = args
-        data = {
-            "event_type": event_type, "location": location, "magnitude": magnitude,
-            "vtec_id": vtec_id, "coords": coords, "timestamp": ts, "source": source,
-            "raw_text": raw
-        }
-        await _upstash_cmd("HSET", _k_significant_events(), event_id, json.dumps(data))
     elif op == "add_posted_warning":
         vtec_id, message_id, channel_id, _ = args
         data = {"message_id": message_id, "channel_id": channel_id}
@@ -611,7 +601,7 @@ async def prune_posted_surveys(max_size: int = 100) -> None:
     _cache_invalidate("posted_surveys")
 
 
-# ── Significant events ───────────────────────────────────────────────────────
+# ── Significant events — routed to events_db, not Upstash ───────────────────
 
 async def add_significant_event(
     event_id: str,
@@ -622,47 +612,29 @@ async def add_significant_event(
     coords: str = "",
     timestamp: float = 0.0,
     source: str = "",
-    raw_text: str = ""
+    raw_text: str = "",
 ) -> None:
-    """Log a significant weather event. Cache + Upstash + SQLite."""
-    # SQLite first
-    await sqlite_backend.add_significant_event(
-        event_id, event_type, location, magnitude, vtec_id, coords, timestamp, source, raw_text
-    )
-    
-    # Then Upstash
-    try:
-        data = {
-            "event_type": event_type, "location": location, "magnitude": magnitude,
-            "vtec_id": vtec_id, "coords": coords, "timestamp": timestamp or time.time(),
-            "source": source, "raw_text": raw_text
-        }
-        await _upstash_cmd("HSET", _k_significant_events(), event_id, json.dumps(data))
-    except _UpstashUnavailable as e:
-        logger.warning(f"[STATE] add_significant_event({event_id}) queued: {e}")
-        await _enqueue_dirty("add_significant_event", (
-            event_id, event_type, location, magnitude, vtec_id, coords, timestamp, source, raw_text
-        ))
+    from utils.events_db import add_significant_event as _add  # noqa: PLC0415
+    await _add(event_id, event_type, location, magnitude, vtec_id, coords, timestamp, source, raw_text)
 
 
 async def get_recent_significant_events(
     event_type: Optional[str] = None,
     since_hours: int = 24,
-    limit: int = 50
+    limit: int = 50,
 ) -> List[dict]:
-    """Retrieve recent significant events. Always hits SQLite for now
-    to avoid heavy Redis HGETALL/SCAN and complex filtering."""
-    return await sqlite_backend.get_recent_significant_events(event_type, since_hours, limit)
+    from utils.events_db import get_recent_significant_events as _get  # noqa: PLC0415
+    return await _get(event_type, since_hours, limit)
 
 
 async def find_matching_tornado(
     source: str,
     timestamp: float,
     location_query: str,
-    window_hours: float = 12.0
+    window_hours: float = 12.0,
 ) -> Optional[str]:
-    """Find a matching tornado in the local DB."""
-    return await sqlite_backend.find_matching_tornado(source, timestamp, location_query, window_hours)
+    from utils.events_db import find_matching_tornado as _find  # noqa: PLC0415
+    return await _find(source, timestamp, location_query, window_hours)
 
 
 # ── Posted warnings ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Moves `significant_events` out of `bot_state.db` and Upstash entirely into a dedicated `cache/events.db` — stops burning Upstash free-tier budget on an ever-growing historical tornado archive
- New `utils/events_db.py` handles its own SQLite connection, schema, reads/writes, Syncthing snapshot (every 5 min from Primary), and folder-mode flipping via the Syncthing REST API
- Failover promotion restores `events.db` from the Syncthing-received snapshot before loading cogs, then flips the local Syncthing folder to `sendonly`; demotion flips back to `receiveonly`
- Strips all Upstash writes and dirty-queue handling for `significant_events` from `state_store.py`
- Migrates today's 3 misclassified rows (Tstm Wnd Dmg / Hail events stored as Tornado type) into the clean archive, excluding them

## New env vars (optional)
```
SYNCTHING_API_KEY=<local node's Syncthing API key>
SYNCTHING_FOLDER_ID=spcbot-events   # must match on both nodes
```

## Test plan
- [ ] CI passes
- [ ] `/recenttornadoes` and `/significantwx` show correct results after deploy
- [ ] `cache/events.db` created on first run, `cache/events_sync/events.db` appears within 5 min
- [ ] Syncthing syncs snapshot to Standby