### PR TITLE
fix(tests): isolate test_surveys from real events.db

### DIFF
--- a/tests/test_surveys.py
+++ b/tests/test_surveys.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from cogs.reports import ReportsCog
 
 @pytest.mark.asyncio
-async def test_pns_triggers_survey_check():
+async def test_pns_triggers_survey_check(isolated_events_db):
     bot = MagicMock()
     bot.get_channel.return_value = AsyncMock()
     cog = ReportsCog(bot)


### PR DESCRIPTION
## Summary
`test_pns_triggers_survey_check` calls `_handle_pns` → `add_significant_event` → opens the real `cache/events.db` without any test isolation. Each local test run was silently overwriting the production events archive. Adding `isolated_events_db` fixture routes all DB writes to a tmp path for the duration of the test.