### PR TITLE
fix(reports): correct magnitude strings in poll_lsrs GeoJSON path

### DIFF
--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -403,11 +403,18 @@ class ReportsCog(commands.Cog):
                             self.posted_reports.add(pid)
                             continue
 
+                    if event_type == "Tornado":
+                        magnitude = "Confirmed"
+                    elif event_type == "Hail":
+                        magnitude = f"{mag:.2f} Inch" if mag else ""
+                    else:
+                        magnitude = f"{int(mag)} MPH" if mag else ""
+
                     await add_significant_event(
                         event_id=f"IEM:LSR:{pid}",
                         event_type=event_type,
                         location=location,
-                        magnitude=f"{mag} {props.get('unit')}",
+                        magnitude=magnitude,
                         coords=f"{props.get('lat')}N {abs(props.get('lon'))}W",
                         timestamp=ts,
                         source=office,


### PR DESCRIPTION
## Summary
Tornado LSRs from the IEM GeoJSON poll path were stored with `magnitude='None None'` when the `magf` field is null (common for tornadoes where EF rating isn't known at report time). Fix:
- Tornado → `"Confirmed"`
- Hail → `"X.XX Inch"` 
- Wind → `"XXX MPH"`

Matches the format already used by the iembot path in `_handle_lsr`.