### PR TITLE
fix(events-db): set Syncthing folder to sendonly on Primary boot

### DIFF
--- a/main.py
+++ b/main.py
@@ -199,6 +199,11 @@ async def on_ready():
     # Slash command sync
     try:
         if bot.state.is_primary:
+            # Ensure Syncthing folder is in send-only mode on every Primary boot.
+            # _promote() handles this for Standby→Primary transitions; this covers
+            # nodes that start directly as Primary (IS_PRIMARY=true).
+            from utils.events_db import set_syncthing_folder_mode  # noqa: PLC0415
+            await set_syncthing_folder_mode("sendonly")
             try:
                 logger.info("Syncing command tree globally...")
                 synced = await bot.tree.sync()


### PR DESCRIPTION
## Summary
`_promote()` correctly sets the Syncthing folder to `sendonly` for Standby→Primary transitions, but nodes that start directly as Primary (`IS_PRIMARY=true`) never called it. If the Syncthing folder was misconfigured as `receiveonly` at setup time (as happened on the first run), it would stay wrong until a failover cycle occurred.

Fix: call `set_syncthing_folder_mode("sendonly")` in `on_ready` when already Primary. No-op if `SYNCTHING_API_KEY` is not set.