### PR TITLE
build(docker): use wheel builder pattern for multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Set working directory
 WORKDIR /build
 
 # Upgrade pip and install build-time requirements
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
-# Copy requirements file
 COPY requirements.txt .
 
-# Install dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+# Build wheels for all dependencies
+RUN pip wheel --no-cache-dir --no-deps --wheel-dir /build/wheels -r requirements.txt
 
 # Runtime stage
 FROM python:3.12-slim-bookworm
@@ -62,12 +60,12 @@ ENV PYTHONUNBUFFERED=1 \
     CACHE_DIR=/app/cache \
     LOG_FILE=/app/cache/spc_bot.log
 
-# Create app directory
 WORKDIR /app
 
-# Copy installed python packages from builder
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+# Install dependencies from wheels built in builder stage
+COPY --from=builder /build/wheels /wheels
+RUN pip install --no-cache-dir /wheels/* \
+    && rm -rf /wheels
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
Improves the multi-stage Docker build by using the standard `pip wheel` pattern instead of copying site-packages wholesale. This prevents build artifacts and misaligned metadata from leaking into the final runtime container.