### PR TITLE
perf(plotting): migrate VAD/Hodograph plotter to ProcessPoolExecutor

### DIFF
--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -3,7 +3,6 @@ import asyncio
 import difflib
 import logging
 import os
-import sys
 
 import discord
 from discord.ext import commands
@@ -18,34 +17,42 @@ VAD_SCRIPT = os.path.join("lib", "vad_plotter", "vad.py")
 
 
 async def generate_hodograph(interaction: discord.Interaction, site: str):
-    """Run vad.py as a subprocess and send the resulting image."""
+    """Run vad.py in a ProcessPoolExecutor and send the resulting image."""
     os.makedirs(HODO_OUTPUT_DIR, exist_ok=True)
     output_path = os.path.join(HODO_OUTPUT_DIR, f"{site.lower()}_hodograph.png")
 
-    cmd = [sys.executable, VAD_SCRIPT, "-f", output_path, site]
-    logger.info(f"[HODO] Generating hodograph for {site}: {' '.join(cmd)}")
+    logger.info(f"[HODO] Generating hodograph for {site} in executor pool")
 
-    process = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-
+    from cogs.sounding_utils import _get_plot_executor
+    from lib.vad_plotter.vad import vad_plotter
+    
+    loop = asyncio.get_running_loop()
     try:
-        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60)
+        await asyncio.wait_for(
+            loop.run_in_executor(
+                _get_plot_executor(),
+                vad_plotter,
+                site,           # radar_id
+                'right-mover',  # storm_motion
+                None,           # sfc_wind
+                None,           # time
+                output_path,    # fname
+                None,           # local_path
+                None,           # cache_path
+                False,          # web
+                False           # fixed
+            ),
+            timeout=60
+        )
     except asyncio.TimeoutError:
-        process.kill()
-        await process.communicate()
-        logger.exception(f"[HODO] vad.py timed out for {site}")
+        logger.exception(f"[HODO] vad_plotter timed out for {site}")
         await interaction.followup.send(
             f"⏱️ Timed out fetching data for `{site}`. The radar may be offline or have no recent VWP data.",
             ephemeral=True,
         )
         return
-
-    if process.returncode != 0:
-        err = stderr.decode().strip()
-        logger.error(f"[HODO] vad.py failed for {site}: {err}")
+    except Exception as e:
+        logger.error(f"[HODO] vad_plotter failed for {site}: {e}")
         await interaction.followup.send(
             f"⚠️ Could not generate hodograph for `{site}`. The radar may not have recent data.",
             ephemeral=True,

--- a/tests/test_hodograph.py
+++ b/tests/test_hodograph.py
@@ -54,17 +54,14 @@ class TestGenerateHodograph:
         interaction = MagicMock()
         interaction.followup = AsyncMock()
 
-        mock_process = MagicMock()
-        mock_process.kill = MagicMock()
-        mock_process.communicate = AsyncMock(return_value=(b"", b""))
-
         async def raise_timeout(*args, **kwargs):
             raise asyncio.TimeoutError()
 
-        with patch("cogs.hodograph.asyncio.create_subprocess_exec", return_value=mock_process), \
-             patch("cogs.hodograph.asyncio.wait_for", side_effect=raise_timeout), \
-             patch("cogs.hodograph.os.makedirs"):
-            await generate_hodograph(interaction, "KTLX")
+        with patch("cogs.hodograph.asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = MagicMock()
+            with patch("cogs.hodograph.asyncio.wait_for", side_effect=raise_timeout), \
+                 patch("cogs.hodograph.os.makedirs"):
+                await generate_hodograph(interaction, "KTLX")
 
         interaction.followup.send.assert_called_once()
         call_kwargs = interaction.followup.send.call_args
@@ -78,14 +75,14 @@ class TestGenerateHodograph:
         interaction = MagicMock()
         interaction.followup = AsyncMock()
 
-        mock_process = MagicMock()
-        mock_process.returncode = 1
-        mock_process.communicate = AsyncMock(return_value=(b"", b"some error"))
+        async def raise_exception(*args, **kwargs):
+            raise Exception("Process failed")
 
-        with patch("cogs.hodograph.asyncio.create_subprocess_exec", return_value=mock_process), \
-             patch("cogs.hodograph.asyncio.wait_for", return_value=(b"", b"some error")), \
-             patch("cogs.hodograph.os.makedirs"):
-            await generate_hodograph(interaction, "KTLX")
+        with patch("cogs.hodograph.asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = MagicMock()
+            with patch("cogs.hodograph.asyncio.wait_for", side_effect=raise_exception), \
+                 patch("cogs.hodograph.os.makedirs"):
+                await generate_hodograph(interaction, "KTLX")
 
         interaction.followup.send.assert_called_once()
         call_kwargs = interaction.followup.send.call_args
@@ -98,15 +95,12 @@ class TestGenerateHodograph:
         interaction = MagicMock()
         interaction.followup = AsyncMock()
 
-        mock_process = MagicMock()
-        mock_process.returncode = 0
-        mock_process.communicate = AsyncMock(return_value=(b"", b""))
-
-        with patch("cogs.hodograph.asyncio.create_subprocess_exec", return_value=mock_process), \
-             patch("cogs.hodograph.asyncio.wait_for", return_value=(b"", b"")), \
-             patch("cogs.hodograph.os.makedirs"), \
-             patch("cogs.hodograph.os.path.exists", return_value=False):
-            await generate_hodograph(interaction, "KTLX")
+        with patch("cogs.hodograph.asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = MagicMock()
+            with patch("cogs.hodograph.asyncio.wait_for", return_value=None), \
+                 patch("cogs.hodograph.os.makedirs"), \
+                 patch("cogs.hodograph.os.path.exists", return_value=False):
+                await generate_hodograph(interaction, "KTLX")
 
         interaction.followup.send.assert_called_once()
         call_kwargs = interaction.followup.send.call_args


### PR DESCRIPTION
Instead of spawning a new `python` CLI subprocess for every VAD/Hodograph plot, this submits the plotting task to the existing `ProcessPoolExecutor` pool. This skips the ~1.5s cold-start penalty of importing matplotlib/metpy on every invocation.