### PR TITLE
fix(reports): persistent LSR deduplication and atomic event logging

### DIFF
--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -315,7 +315,8 @@ class CSUMLPCog(commands.Cog):
                         if attempt < 2:
                             logger.warning(f"[CSU-MLP] Retrying Day {day} (attempt {attempt+2}) after error: {e}")
                             await asyncio.sleep(2 * (attempt + 1))
-                        else: raise
+                        else:
+                            raise
 
                 self.bot.state.csu_posted.add(str(day))
                 await _save_posted_today(self.bot.state.csu_posted)
@@ -360,7 +361,8 @@ class CSUMLPCog(commands.Cog):
                         if attempt < 2:
                             logger.warning(f"[CSU-MLP] Retrying {label_name} (attempt {attempt+2}) after error: {e}")
                             await asyncio.sleep(2 * (attempt + 1))
-                        else: raise
+                        else:
+                            raise
 
                 self.bot.state.csu_posted.add(state_key)
                 await _save_posted_today(self.bot.state.csu_posted)

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -400,6 +400,7 @@ class FailoverCog(commands.Cog):
         st.manual_cache = await state_store.get_all_hashes("manual")
         st.posted_mds = await state_store.get_posted_mds()
         st.posted_watches = await state_store.get_posted_watches()
+        st.posted_reports = await state_store.get_posted_reports()
 
         last_seq = await state_store.get_state("iembot_last_seqnum")
         if isinstance(last_seq, str) and last_seq.isdigit():

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -10,9 +10,11 @@ from discord.ext import commands, tasks
 from config import WARNINGS_CHANNEL_ID
 from utils.http import http_get_bytes
 from utils.state_store import (
+    add_posted_report,
     add_posted_survey, 
     add_significant_event,
     get_posted_surveys, 
+    prune_posted_reports,
     prune_posted_surveys
 )
 
@@ -21,7 +23,6 @@ logger = logging.getLogger("spc_bot")
 class ReportsCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.posted_reports = set() # Simple dedup
         self.posted_surveys: set[str] = set()
         self._surveys_loaded = False
         self.poll_lsrs.start()
@@ -39,7 +40,7 @@ class ReportsCog(commands.Cog):
 
     async def post_report_now(self, product_id: str, raw_text: str, pil: str):
         """Handle LSR or PNS damage survey posts."""
-        if product_id in self.posted_reports:
+        if product_id in self.bot.state.posted_reports:
             return
         
         if pil == "LSR":
@@ -124,21 +125,14 @@ class ReportsCog(commands.Cog):
             )
             embed.set_footer(text=f"{office} LSR | {time_str} | {coords}")
             
-            await channel.send(embed=embed)
-            self.posted_reports.add(product_id)
+            # --- Persist State Before Sending ---
+            self.bot.state.posted_reports.add(product_id)
+            await add_posted_report(product_id)
+            await prune_posted_reports()
 
-            # Log significant events using the already-parsed event_type and city.
-            # Magnitude line directly follows the header: M<value> or E<value>.
-            lsr_ts = datetime.now(timezone.utc).timestamp()
-            if product_id and len(product_id) >= 12:
-                try:
-                    lsr_ts = datetime.strptime(product_id[:12], "%Y%m%d%H%M").replace(tzinfo=timezone.utc).timestamp()
-                except Exception:
-                    pass
-
+            # Log significant events to DB
             event_upper = event_type.upper()
             if "TORNADO" in event_upper:
-                # Dedup already happened above; if we reach here it's a new tornado
                 await add_significant_event(
                     event_id=f"IEM:LSR:{product_id}",
                     event_type="Tornado",
@@ -168,10 +162,10 @@ class ReportsCog(commands.Cog):
                     except ValueError:
                         pass
             elif "WND" in event_upper or "WIND" in event_upper:
-                m_mag = re.search(r"[ME]([\d]+)", r)
+                m_mag = re.search(r"[ME]([\d.]+)", r)
                 if m_mag:
                     try:
-                        speed = int(m_mag.group(1))
+                        speed = float(m_mag.group(1))
                         if speed >= 80:
                             await add_significant_event(
                                 event_id=f"IEM:LSR:{product_id}:wind",
@@ -185,6 +179,8 @@ class ReportsCog(commands.Cog):
                             )
                     except ValueError:
                         pass
+
+            await channel.send(embed=embed)
 
     async def _handle_pns(self, product_id: str, raw_text: str):
         # Public Information Statement - Damage Survey
@@ -234,7 +230,9 @@ class ReportsCog(commands.Cog):
         embed.set_footer(text=f"{office} PNS | {product_id}")
         
         await channel.send(embed=embed)
-        self.posted_reports.add(product_id)
+        self.bot.state.posted_reports.add(product_id)
+        await add_posted_report(product_id)
+        await prune_posted_reports()
 
         # --- DB Logging & Matching ---
         # Try to find a date in the text to poll for Autoplot 253 tracks.
@@ -373,7 +371,7 @@ class ReportsCog(commands.Cog):
             for feature in data.get("features", []):
                 props = feature.get("properties", {})
                 pid = props.get("product_id")
-                if not pid or pid in self.posted_reports:
+                if not pid or pid in self.bot.state.posted_reports:
                     continue
                 
                 # Check significance
@@ -394,28 +392,37 @@ class ReportsCog(commands.Cog):
                     valid_str = props.get("valid") # 2026-04-28T11:08:00Z
                     ts = 0.0
                     if valid_str:
-                        dt = datetime.strptime(valid_str, "%Y-%m-%dT%H:%M:%SZ")
-                        ts = dt.replace(tzinfo=timezone.utc).timestamp()
-                    else:
+                        try:
+                            dt = datetime.strptime(valid_str, "%Y-%m-%dT%H:%M:%SZ")
+                            ts = dt.replace(tzinfo=timezone.utc).timestamp()
+                        except Exception as e:
+                            logger.warning(f"Failed to parse poll LSR timestamp '{valid_str}': {e}")
+
+                    if ts == 0.0:
                         ts = datetime.now(timezone.utc).timestamp()
 
                     office = props.get("wfo")
                     location = f"{props.get('city')}, {props.get('state')}"
-                    event_type = "Tornado" if typetext == "TORNADO" else ("Hail" if typetext == "HAIL" else "Wind")
-
-                    if event_type == "Tornado":
+                    
+                    if typetext == "TORNADO":
+                        event_type = "Tornado"
                         magnitude = "Confirmed"
-                    elif event_type == "Hail":
-                        magnitude = f"{mag:.2f} Inch" if mag else ""
+                        event_id = f"IEM:LSR:{pid}"
+                    elif typetext == "HAIL":
+                        event_type = "Hail"
+                        magnitude = f"{mag:.2f} Inch"
+                        event_id = f"IEM:LSR:{pid}:hail"
                     else:
-                        magnitude = f"{int(mag)} MPH" if mag else ""
+                        event_type = "Wind"
+                        magnitude = f"{int(mag)} MPH"
+                        event_id = f"IEM:LSR:{pid}:wind"
 
                     # Dedup for tornadoes: if the iembot fast-path already logged
                     # this event, update that entry with the cleaner GeoJSON
                     # location ("City, ST") rather than skipping entirely.
                     if event_type == "Tornado":
                         from utils.state_store import find_matching_tornado  # noqa: PLC0415
-                        match_id = await find_matching_tornado(office, ts, location)
+                        match_id = await find_matching_tornado(office, ts, location, window_hours=1.0)
                         if match_id:
                             await add_significant_event(
                                 event_id=match_id,
@@ -428,11 +435,12 @@ class ReportsCog(commands.Cog):
                                 raw_text=props.get("remark"),
                             )
                             logger.debug(f"[REPORTS] Updated location for {match_id} → {location!r}")
-                            self.posted_reports.add(pid)
+                            self.bot.state.posted_reports.add(pid)
+                            await add_posted_report(pid)
                             continue
 
                     await add_significant_event(
-                        event_id=f"IEM:LSR:{pid}",
+                        event_id=event_id,
                         event_type=event_type,
                         location=location,
                         magnitude=magnitude,
@@ -441,8 +449,10 @@ class ReportsCog(commands.Cog):
                         source=office,
                         raw_text=props.get("remark"),
                     )
-                    # Add to posted_reports to dedup
-                    self.posted_reports.add(pid)
+                    # Persist dedup
+                    self.bot.state.posted_reports.add(pid)
+                    await add_posted_report(pid)
+                    await prune_posted_reports()
 
         except Exception as e:
             logger.warning(f"[REPORTS] LSR poll failed: {e}")

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -57,9 +57,9 @@ def _plot_worker_init():
 
     # Silent inherited loggers
     for name in ("spc_bot", None):  # spc_bot and root
-        l = _logging.getLogger(name)
-        for h in l.handlers[:]:
-            l.removeHandler(h)
+        log_obj = _logging.getLogger(name)
+        for h in log_obj.handlers[:]:
+            log_obj.removeHandler(h)
     _logging.getLogger().setLevel(_logging.WARNING)
 
     import matplotlib as _mpl

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from utils.http import CircuitOpenError
 from utils.state_store import (
     check_integrity, close_db, get_db,
     get_all_hashes, get_posted_urls, get_posted_mds, get_posted_watches,
+    get_posted_reports,
     get_state,
 )
 from utils.cache import hydrate_validators_from_store
@@ -70,6 +71,7 @@ async def setup_hook():
         get_all_hashes("manual"),
         get_posted_mds(),
         get_posted_watches(),
+        get_posted_reports(),
         get_state("csu_mlp_posted"),
         get_posted_urls("day1"),
         get_posted_urls("day2"),
@@ -78,7 +80,7 @@ async def setup_hook():
         return_exceptions=True
     )
     
-    db_auto, db_manual, db_mds, db_watches, csu_raw, d1_urls, d2_urls, d3_urls, last_seq = results
+    db_auto, db_manual, db_mds, db_watches, db_reports, csu_raw, d1_urls, d2_urls, d3_urls, last_seq = results
 
     if isinstance(last_seq, str):
         bot.state.iembot_last_seqnum = int(last_seq)
@@ -99,6 +101,10 @@ async def setup_hook():
     if isinstance(db_watches, (set, list)):
         bot.state.posted_watches.update(db_watches)
         logger.info(f"[DB] Loaded {len(db_watches)} posted watches into cache")
+
+    if isinstance(db_reports, (set, list)):
+        bot.state.posted_reports.update(db_reports)
+        logger.info(f"[DB] Loaded {len(db_reports)} posted reports into cache")
 
     # CSU state
     if isinstance(csu_raw, str):

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,44 @@
+# WxAlert SPCBot v5.4 Development Progress
+
+## ✅ Completed Pull Requests
+
+- **#164: build(docker): Multi-stage Docker optimization**
+  - Implemented `pip wheel` builder pattern.
+  - Stripped build tools from final runtime image for a smaller, more secure container.
+- **#165: chore(storage): Cache Artifact Lifecycle Manager**
+  - Created `cogs/maintenance.py`.
+  - Added daily background task to prune old map images and temporary files (>48h).
+- **#166: perf(plotting): VAD/Hodograph Executor Migration**
+  - Migrated VAD plots from CLI subprocesses to the pre-warmed `ProcessPoolExecutor`.
+  - Eliminated ~1.5s cold-start import penalty for radar requests.
+- **#167: feat(http): Global Circuit Breaker & Retries**
+  - Integrated `tenacity` for exponential backoff.
+  - Implemented `CircuitBreaker` to fail-fast when NWS/SPC APIs are degraded.
+  - Added global Discord error handler for degraded upstream services.
+- **#168: feat(api): Pydantic Models for NWS Alerts**
+  - Introduced strict schema validation at the API boundary.
+  - Replaced unsafe dict traversal with type-safe model access.
+- **#169: fix(core): Critical Alerting & Cleanup**
+  - Fixed `fetch_channel` fallback in `send_bot_alert` (verified production gap).
+  - Resolved several bare `except: pass` blocks in the reporting pipeline.
+
+## 🚧 In Progress
+
+- **#170: fix(reports): Persistent LSR Deduplication**
+  - Moved `posted_reports` to persistent SQLite + Upstash state.
+  - Standardized Hail/Wind `event_id` generation for consistent DB tracking.
+  - Made LSR logging atomic (persist before Discord send).
+  - *Current Status:* Resolving minor test regression in `test_state_split.py`.
+
+## 📋 Remaining v5.4 Tasks
+
+- **#171: fix(warnings): Warning Pipeline Hardening**
+  - Implement atomic check-and-claim for VTEC IDs.
+  - Isolate cancellation edit errors from blocking the poll loop.
+  - Fix MD cancellation logic when the index is empty.
+- **#172: fix(state): State Sync & Failover Tightening**
+  - Cap `_dirty_queue` size to prevent memory leaks during outages.
+  - Tighten Dual-Primary window during failover pre-emption.
+  - Refine CSU-MLP daily reset logic for early UTC restarts.
+- **#173: chore(db): Syncthing Snapshot Consistency**
+  - Add `PRAGMA wal_checkpoint(RESTART)` before database backups.

--- a/tests/test_state_split.py
+++ b/tests/test_state_split.py
@@ -61,6 +61,7 @@ def test_to_dict_output_shape_unchanged():
         "posted_mds",
         "posted_watches",
         "posted_warnings",
+        "posted_reports",
         "csu_posted",
         "active_watches",
         "active_warnings",

--- a/utils/db.py
+++ b/utils/db.py
@@ -133,6 +133,11 @@ async def _create_tables(db: aiosqlite.Connection):
             posted_at REAL NOT NULL DEFAULT 0
         );
 
+        CREATE TABLE IF NOT EXISTS posted_reports (
+            product_id TEXT PRIMARY KEY,
+            posted_at REAL NOT NULL DEFAULT 0
+        );
+
         CREATE TABLE IF NOT EXISTS posted_warnings (
             vtec_id    TEXT PRIMARY KEY,
             message_id INTEGER NOT NULL DEFAULT 0,
@@ -370,6 +375,43 @@ async def prune_posted_surveys(max_size: int = 100):
            )""",
         (max_size,),
         "prune_posted_surveys",
+    )
+
+
+# ── Posted reports (LSRs) ────────────────────────────────────────────────────
+
+async def get_posted_reports() -> set:
+    """Get all posted LSR product IDs."""
+    try:
+        db = await get_db()
+        async with db.execute("SELECT product_id FROM posted_reports") as cursor:
+            rows = await cursor.fetchall()
+            return {row["product_id"] for row in rows}
+    except Exception as e:
+        logger.warning(f"[DB] get_posted_reports failed: {e}")
+        return set()
+
+
+async def add_posted_report(product_id: str, posted_at: float = 0.0):
+    """Mark an LSR as posted."""
+    await _write(
+        "INSERT OR IGNORE INTO posted_reports (product_id, posted_at) VALUES (?, ?)",
+        (product_id, posted_at or time.time()),
+        f"add_posted_report({product_id})",
+    )
+
+
+async def prune_posted_reports(max_size: int = 500):
+    """Keep only the most recent LSR product IDs."""
+    await _write(
+        """DELETE FROM posted_reports
+           WHERE product_id NOT IN (
+               SELECT product_id FROM posted_reports
+               ORDER BY posted_at DESC
+               LIMIT ?
+           )""",
+        (max_size,),
+        "prune_posted_reports",
     )
 
 

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -186,7 +186,7 @@ def restore_from_sync() -> None:
     try:
         os.makedirs(os.path.dirname(_EVENTS_DB_PATH), exist_ok=True)
         shutil.copy2(_SYNC_PATH, _EVENTS_DB_PATH)
-        logger.info(f"[EVENTS-DB] Restored events.db from sync snapshot")
+        logger.info("[EVENTS-DB] Restored events.db from sync snapshot")
     except Exception as e:
         logger.warning(f"[EVENTS-DB] Restore from sync failed: {e}")
 

--- a/utils/state.py
+++ b/utils/state.py
@@ -48,6 +48,7 @@ class PostingLog:
         "active_mds",
         "active_watches",
         "active_warnings",
+        "posted_reports",
     )
 
     def __init__(self):
@@ -61,6 +62,7 @@ class PostingLog:
         self.active_watches: Dict[str, dict] = {}
         # Currently-active VTEC IDs mapping to their latest vtec metadata dict
         self.active_warnings: Dict[str, dict] = {}
+        self.posted_reports: Set[str] = set()
 
 
 class TimingTracker:
@@ -132,6 +134,7 @@ class BotState:
     active_mds = _delegate("posting", "active_mds")
     active_watches = _delegate("posting", "active_watches")
     active_warnings = _delegate("posting", "active_warnings")
+    posted_reports = _delegate("posting", "posted_reports")
 
     last_post_times = _delegate("timing", "last_post_times")
     last_posted_urls = _delegate("timing", "last_posted_urls")
@@ -147,6 +150,7 @@ class BotState:
             "posted_mds": list(self.posted_mds),
             "posted_watches": list(self.posted_watches),
             "posted_warnings": self.posted_warnings,
+            "posted_reports": list(self.posted_reports),
             "csu_posted": list(self.csu_posted),
             "active_warnings": list(self.active_warnings.keys()),
             "active_watches": {

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -135,6 +135,8 @@ def _k_posted_surveys() -> str:
     return f"{_PREFIX}:posted_surveys"
 
 
+def _k_posted_reports() -> str:
+    return f"{_PREFIX}:posted_reports"
 
 
 def _k_posted_warnings() -> str:
@@ -331,6 +333,9 @@ async def _replay(op: str, args: tuple) -> None:
     elif op == "add_posted_survey":
         (dat_guid,) = args
         await _upstash_cmd("SADD", _k_posted_surveys(), dat_guid)
+    elif op == "add_posted_report":
+        (product_id,) = args
+        await _upstash_cmd("SADD", _k_posted_reports(), product_id)
     elif op == "add_posted_warning":
         vtec_id, message_id, channel_id, _ = args
         data = {"message_id": message_id, "channel_id": channel_id}
@@ -601,6 +606,40 @@ async def prune_posted_surveys(max_size: int = 100) -> None:
     _cache_invalidate("posted_surveys")
 
 
+# ── Posted reports (LSRs) ────────────────────────────────────────────────────
+
+async def get_posted_reports() -> Set[str]:
+    cache_key = "posted_reports"
+    hit, val = _cache_get(cache_key)
+    if hit:
+        return set(val)
+    try:
+        result = await _upstash_cmd("SMEMBERS", _k_posted_reports())
+        members = set(result or [])
+        _cache_set(cache_key, members)
+        return set(members)
+    except _UpstashUnavailable as e:
+        logger.debug(f"[STATE] get_posted_reports falling back to SQLite: {e}")
+        val = await sqlite_backend.get_posted_reports()
+        _cache_set(cache_key, val, ttl=CACHE_TTL_SECONDS / 2)
+        return val
+
+
+async def add_posted_report(product_id: str) -> None:
+    _cache_invalidate("posted_reports")
+    await sqlite_backend.add_posted_report(product_id)
+    try:
+        await _upstash_cmd("SADD", _k_posted_reports(), product_id)
+    except _UpstashUnavailable as e:
+        logger.warning(f"[STATE] add_posted_report({product_id}) queued: {e}")
+        await _enqueue_dirty("add_posted_report", (product_id,))
+
+
+async def prune_posted_reports(max_size: int = 500) -> None:
+    await sqlite_backend.prune_posted_reports(max_size)
+    _cache_invalidate("posted_reports")
+
+
 # ── Significant events — routed to events_db, not Upstash ───────────────────
 
 async def add_significant_event(
@@ -809,7 +848,7 @@ async def resync_to_upstash() -> Dict[str, int]:
     dirty list) still make it up. Returns counts of items pushed per
     category for logging.
     """
-    counts = {"hashes": 0, "posted_mds": 0, "posted_watches": 0, "posted_surveys": 0, "state": 0, "urls": 0}
+    counts = {"hashes": 0, "posted_mds": 0, "posted_watches": 0, "posted_surveys": 0, "posted_reports": 0, "state": 0, "urls": 0}
     try:
         for cache_type in ("auto", "manual"):
             hashes = await sqlite_backend.get_all_hashes(cache_type)
@@ -835,6 +874,11 @@ async def resync_to_upstash() -> Dict[str, int]:
         if surveys:
             await _upstash_cmd("SADD", _k_posted_surveys(), *surveys)
             counts["posted_surveys"] = len(surveys)
+
+        reports = await sqlite_backend.get_posted_reports()
+        if reports:
+            await _upstash_cmd("SADD", _k_posted_reports(), *reports)
+            counts["posted_reports"] = len(reports)
 
         states = await sqlite_backend.get_all_state()
         if states:


### PR DESCRIPTION
## Summary
- **Persistent dedup**: `posted_reports` moved from in-memory set to SQLite + Upstash state — LSR dedup now survives bot restarts
- **Consistent event IDs**: Hail/wind event IDs standardized between the iembot fast-path and GeoJSON poll path so the poll path correctly triggers `ON CONFLICT UPDATE` on existing entries instead of creating duplicate rows
- **Atomic logging**: `add_significant_event()` now called before `channel.send()` in `_handle_lsr` — eliminates the window where a crash between Discord send and DB write could cause a repost
- **Test fix**: `test_to_dict_output_shape_unchanged` updated to include `posted_reports` in expected keys