### PR TITLE
fix: split-brain lease reclaim, interaction hijack, stale manual cache

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -293,7 +293,28 @@ class FailoverCog(commands.Cog):
             )
             await self._demote()
             return
-        await self._write_lease()
+        if holder is not None:
+            # We hold the lease (or it was empty and readable) — renew normally.
+            await self._write_lease()
+            return
+        # holder is None: either the key expired or Upstash read failed.  A
+        # plain SET here would silently overwrite a standby that promoted during
+        # a connectivity gap.  Use SET NX so we only claim the key if it is
+        # genuinely absent; if another node holds it, the NX write returns null.
+        result = await self._upstash(
+            "SET", LEASE_KEY, self._identity, "NX", "EX", str(HEARTBEAT_TTL)
+        )
+        if result is None:
+            # NX write failed: key already held by another node (or Upstash error).
+            # Re-read to check and demote if necessary.
+            holder = await self._read_lease_holder()
+            if holder and holder != self._identity:
+                logger.warning(
+                    f"[FAILOVER] Another node ({holder}) holds the lease after NX — demoting"
+                )
+                await self._demote()
+            return
+        logger.info("[FAILOVER] Reclaimed expired lease via NX write")
 
     def _in_startup_grace(self) -> bool:
         if self._cog_load_monotonic is None:

--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -23,15 +23,11 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
 
     logger.info(f"[HODO] Generating hodograph for {site} in executor pool")
 
-    from cogs.sounding_utils import _get_plot_executor
     from lib.vad_plotter.vad import vad_plotter
-    
-    loop = asyncio.get_running_loop()
+
     try:
         await asyncio.wait_for(
-            loop.run_in_executor(
-                _get_plot_executor(),
-                vad_plotter,
+            vad_plotter(
                 site,           # radar_id
                 'right-mover',  # storm_motion
                 None,           # sfc_wind

--- a/lib/vad_plotter/asos.py
+++ b/lib/vad_plotter/asos.py
@@ -1,6 +1,10 @@
-import requests
+import json
 import math
+import logging
 from datetime import datetime, timezone
+from utils.http import http_get_bytes
+
+logger = logging.getLogger("spc_bot")
 
 def _haversine_km(lat1, lon1, lat2, lon2):
     R = 6371
@@ -9,7 +13,7 @@ def _haversine_km(lat1, lon1, lat2, lon2):
     a = math.sin(dlat/2)**2 + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(dlon/2)**2
     return R * 2 * math.asin(math.sqrt(a))
 
-def get_asos_surface_wind(radar_lat, radar_lon, vwp_time=None, radius_km=150):
+async def get_asos_surface_wind(radar_lat, radar_lon, vwp_time=None, radius_km=150):
     """
     Find the nearest ASOS surface wind valid at or just before the VWP scan time.
     vwp_time: datetime object (UTC) of the VWP scan. If None, uses current time.
@@ -22,13 +26,23 @@ def get_asos_surface_wind(radar_lat, radar_lon, vwp_time=None, radius_km=150):
         'hours': 2,
     }
 
+    # Use aiohttp via our shared utility
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    full_url = f"{url}?{query}"
+    
     try:
-        r = requests.get(url, params=params, timeout=10,
-                         headers={'User-Agent': 'hodobot/1.0'})
-        r.raise_for_status()
-        stations = r.json()
+        content, status = await http_get_bytes(
+            full_url, 
+            headers={'User-Agent': 'WxAlertSPCBot/1.0'},
+            retries=2,
+            timeout=10
+        )
+        if status != 200 or not content:
+            logger.warning(f"[ASOS] Fetch failed with status {status}")
+            return None
+        stations = json.loads(content)
     except Exception as e:
-        print(f"ASOS fetch failed: {e}")
+        logger.warning(f"[ASOS] Fetch failed: {e}")
         return None
 
     if vwp_time is None:

--- a/lib/vad_plotter/vad.py
+++ b/lib/vad_plotter/vad.py
@@ -15,9 +15,13 @@ from lib.vad_plotter.asos import get_asos_surface_wind
 
 import re
 import argparse
+import asyncio
+import logging
 from datetime import datetime, timedelta
 import json
 import glob
+
+logger = logging.getLogger("spc_bot")
 
 """
 vad.py
@@ -127,7 +131,6 @@ def main():
     np.seterr(all='ignore')
 
     try:
-        import asyncio
         asyncio.run(vad_plotter(args.radar_id,
             storm_motion=args.storm_motion,
             sfc_wind=args.sfc_wind,

--- a/lib/vad_plotter/vad.py
+++ b/lib/vad_plotter/vad.py
@@ -57,7 +57,7 @@ def parse_time(time_str):
     return plot_time
 
 
-def vad_plotter(radar_id, storm_motion='right-mover', sfc_wind=None, time=None,
+async def vad_plotter(radar_id, storm_motion='right-mover', sfc_wind=None, time=None,
                 fname=None, local_path=None, cache_path=None, web=False, fixed=False):
     plot_time = None
     if time:
@@ -66,10 +66,10 @@ def vad_plotter(radar_id, storm_motion='right-mover', sfc_wind=None, time=None,
         raise ValueError("'-t' ('--time') argument is required when loading from the local disk.")
 
     if not web:
-        print("Plotting VAD for %s ..." % radar_id)
+        logger.info("Plotting VAD for %s ..." % radar_id)
 
     if local_path is None:
-        vad = download_vad(radar_id, time=plot_time, cache_path=cache_path)
+        vad = await download_vad(radar_id, time=plot_time, cache_path=cache_path)
     else:
         iname = build_has_name(radar_id, plot_time)
         vad = VADFile(open("%s/%s" % (local_path, iname), 'rb'))
@@ -77,7 +77,7 @@ def vad_plotter(radar_id, storm_motion='right-mover', sfc_wind=None, time=None,
     vad.rid = radar_id
 
     if not web:
-        print("Valid time:", vad['time'].strftime("%d %B %Y %H%M UTC"))
+        logger.info("Valid time: %s" % vad['time'].strftime("%d %B %Y %H%M UTC"))
 
     sfc_wind_str = None
     if sfc_wind:
@@ -88,20 +88,27 @@ def vad_plotter(radar_id, storm_motion='right-mover', sfc_wind=None, time=None,
         try:
             radar_lat = vad._radar_latitude
             radar_lon = vad._radar_longitude
-            asos = get_asos_surface_wind(radar_lat, radar_lon, vwp_time=vad['time'])
+            asos = await get_asos_surface_wind(radar_lat, radar_lon, vwp_time=vad['time'])
             if asos is not None:
                 wdir, wspd, sid = asos
                 vad.add_surface_wind((wdir, wspd))
                 sfc_wind_str = "Surface Wind: %03d/%02d (%s)" % (wdir, wspd, sid)
                 if not web:
-                    print(sfc_wind_str)
+                    logger.info(sfc_wind_str)
         except Exception as e:
             if not web:
-                print("Could not fetch ASOS surface wind: %s" % e)
+                logger.warning("Could not fetch ASOS surface wind: %s" % e)
 
     params = compute_parameters(vad, storm_motion)
-    plot_hodograph(vad, params, fname=fname, web=web, fixed=fixed,
-                   archive=(local_path is not None), sfc_wind_str=sfc_wind_str)
+    
+    # Move CPU-bound plotting to an executor to keep the event loop free.
+    # Note: matplotlib is not thread-safe by default, but plot_hodograph 
+    # creates its own figure and closes it, which is usually okay in a 
+    # thread as long as it's not the main GUI thread.
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, 
+        plot_hodograph, vad, params, fname, web, fixed, (local_path is not None), sfc_wind_str
+    )
 
 
 def main():
@@ -120,7 +127,8 @@ def main():
     np.seterr(all='ignore')
 
     try:
-        vad_plotter(args.radar_id,
+        import asyncio
+        asyncio.run(vad_plotter(args.radar_id,
             storm_motion=args.storm_motion,
             sfc_wind=args.sfc_wind,
             time=args.time,
@@ -129,7 +137,7 @@ def main():
             cache_path=args.cache_path,
             web=args.web,
             fixed=args.fixed
-        )
+        ))
     except Exception:
         if args.web:
             print(json.dumps({'error': 'error'}))

--- a/lib/vad_plotter/vad_reader.py
+++ b/lib/vad_plotter/vad_reader.py
@@ -1,22 +1,16 @@
 from __future__ import print_function
 import numpy as np
-
 import struct
-from datetime import datetime, timedelta
+import re
+import logging
+import asyncio
+from datetime import datetime, timezone, timedelta
+from io import BytesIO
 
 from lib.vad_plotter.wsr88d import build_has_name
+from utils.http import http_get_bytes, http_get_text
 
-try:
-    from urllib.request import urlopen, URLError
-except ImportError:
-    from urllib2 import urlopen, URLError
-
-try:
-    from io import BytesIO
-except ImportError:
-    from BytesIO import BytesIO
-
-import re
+logger = logging.getLogger("spc_bot")
 
 _base_url = "https://tgftp.nws.noaa.gov/SL.us008001/DF.of/DC.radar/DS.48vwp/"
 
@@ -254,19 +248,25 @@ class VADFile(object):
         for key, val in zip(keys, vals):
             self._data[key] = np.append(val, self._data[key])
 
-def find_file_times(rid):
+async def find_file_times(rid):
     url = "%s/SI.%s/" % (_base_url, rid.lower())
 
-    file_text = urlopen(url).read().decode('utf-8')
+    file_text = await http_get_text(url)
+    if not file_text:
+        return []
+
     file_list = re.findall("([\w]{3} [\d]{1,2} [\d]{2}:[\d]{2}) (sn.[\d]{4})", file_text)
+    if not file_list:
+        return []
+    
     file_times, file_names = list(zip(*file_list))
     file_names = list(file_names)
 
-    year = datetime.utcnow().year
+    year = datetime.now(timezone.utc).year
     file_dts = []
     for ft in file_times:
         ft_dt = datetime.strptime("%d %s" % (year, ft), "%Y %b %d %H:%M")
-        if ft_dt > datetime.utcnow():
+        if ft_dt > datetime.now(timezone.utc):
             ft_dt = datetime.strptime("%d %s" % (year - 1, ft), "%Y %b %d %H:%M")
 
         file_dts.append(ft_dt)
@@ -282,7 +282,7 @@ def find_file_times(rid):
 
     return list(zip(file_names, file_dts))[::-1]
 
-def download_vad(rid, time=None, file_id=None, cache_path=None):
+async def download_vad(rid, time=None, file_id=None, cache_path=None):
     if time is None:
         if file_id is None:
             url = "%s/SI.%s/sn.last" % (_base_url, rid.lower())
@@ -290,7 +290,8 @@ def download_vad(rid, time=None, file_id=None, cache_path=None):
             url = "%s/SI.%s/sn.%04d" % (_base_url, rid.lower(), file_id)
     else:
         file_name = ""
-        for fn, ft in find_file_times(rid):
+        times = await find_file_times(rid)
+        for fn, ft in times:
             if ft <= time:
                 file_name = fn
                 break
@@ -301,18 +302,23 @@ def download_vad(rid, time=None, file_id=None, cache_path=None):
         url = "%s/SI.%s/%s" % (_base_url, rid.lower(), file_name)
 
     try:
-        frem = urlopen(url)
-    except URLError:
-        raise ValueError("Could not find radar site '%s'" % rid.upper())
+        content, status = await http_get_bytes(url, retries=2, timeout=10)
+        if status != 200 or not content:
+            raise ValueError("Could not find radar site '%s' (status %s)" % (rid.upper(), status))
+        
+        frem = BytesIO(content)
+    except Exception as e:
+        if "radar site" in str(e):
+            raise
+        raise ValueError("Could not fetch VAD data for '%s': %s" % (rid.upper(), e))
 
     if cache_path is None:
         vad = VADFile(frem)
     else:
-        bio = BytesIO(frem.read())
-        vad = VADFile(bio)
+        vad = VADFile(frem)
 
         iname = build_has_name(rid, vad['time'])
         with open("%s/%s" % (cache_path, iname), 'wb') as floc:
-            floc.write(bio.getvalue())
+            floc.write(content)
 
     return vad

--- a/lib/vad_plotter/vad_reader.py
+++ b/lib/vad_plotter/vad_reader.py
@@ -4,7 +4,7 @@ import struct
 import re
 import logging
 import asyncio
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from io import BytesIO
 
 from lib.vad_plotter.wsr88d import build_has_name
@@ -262,11 +262,12 @@ async def find_file_times(rid):
     file_times, file_names = list(zip(*file_list))
     file_names = list(file_names)
 
-    year = datetime.now(timezone.utc).year
+    now_utc = datetime.utcnow()
+    year = now_utc.year
     file_dts = []
     for ft in file_times:
         ft_dt = datetime.strptime("%d %s" % (year, ft), "%Y %b %d %H:%M")
-        if ft_dt > datetime.now(timezone.utc):
+        if ft_dt > now_utc:
             ft_dt = datetime.strptime("%d %s" % (year - 1, ft), "%Y %b %d %H:%M")
 
         file_dts.append(ft_dt)

--- a/main.py
+++ b/main.py
@@ -260,20 +260,28 @@ async def on_command_error(ctx, error):
 
 @bot.tree.error
 async def on_app_command_error(interaction: discord.Interaction, error: discord.app_commands.AppCommandError):
+    # Standby nodes have no cogs loaded, so they receive CommandNotFound for
+    # every slash command dispatched to them by Discord. Responding here would
+    # pre-acknowledge the interaction and cause the primary's defer() to fail
+    # with 40060 "already acknowledged". Swallow silently.
+    if isinstance(error, discord.app_commands.CommandNotFound):
+        logger.debug(f"AppCommand not found (standby or unknown): {error}")
+        return
+
     original = getattr(error, 'original', error)
     if isinstance(original, CircuitOpenError):
         msg = f"⚠️ The upstream API ({str(original).split('for')[-1].strip()}) is currently degraded or offline. Please try again later."
-        if interaction.response.is_done():
-            await interaction.followup.send(msg, ephemeral=True)
-        else:
-            await interaction.response.send_message(msg, ephemeral=True)
     else:
         logger.error(f"AppCommand error: {error}")
         msg = "⚠️ An unexpected error occurred while processing this command."
+
+    try:
         if interaction.response.is_done():
             await interaction.followup.send(msg, ephemeral=True)
         else:
             await interaction.response.send_message(msg, ephemeral=True)
+    except discord.HTTPException as e:
+        logger.debug(f"AppCommand error reply failed (interaction expired or already acknowledged): {e}")
 
 
 # ── Watchdog ─────────────────────────────────────────────────────────────────

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,8 @@ asyncio_default_fixture_loop_scope = function
 # debugging a specific test.
 log_cli = false
 log_level = WARNING
+markers =
+    real_create_task: opt out of global asyncio.create_task suppression (for tests that exercise internal task-based concurrency like fetch_md_details)
 filterwarnings =
     ignore::DeprecationWarning:discord.*
     ignore::DeprecationWarning:aiohttp.*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,20 +35,33 @@ os.environ.setdefault("GUILD_ID", "111222333")
 os.environ.setdefault("CACHE_DIR", _TEST_CACHE)
 os.environ.setdefault("LOG_FILE", os.path.join(_TEST_CACHE, "spc_bot_test.log"))
 os.environ.setdefault("FAILOVER_TOKEN", "test-failover-token-not-real")
+# Force Upstash credentials to empty so load_dotenv() (called by config.py)
+# cannot override them with real values from .env. Without this, every call
+# to get_cached_md_text / get_product_cache makes a live Upstash network
+# request, burning free-tier quota and hanging the event loop on teardown.
+os.environ.setdefault("UPSTASH_REDIS_REST_URL", "")
+os.environ.setdefault("UPSTASH_REDIS_REST_TOKEN", "")
 
 
 # ── Autouse fixtures ─────────────────────────────────────────────────────────
 
 @pytest.fixture(autouse=True)
-def global_suppress_create_task():
+def global_suppress_create_task(request):
     """Silence `asyncio.create_task` globally for all tests.
 
     Background tasks (like `_upgrade_md_message` or `_handle_watch`
     dispatches) are "fire and forget" in production but can hang
     or leak resources in tests if they run unawaited in the background.
+
+    Mark a test with @pytest.mark.real_create_task to opt out — required
+    for tests that call functions which use asyncio.create_task internally
+    as part of their core logic (e.g. fetch_md_details racing SPC vs IEM).
     """
-    with patch("asyncio.create_task", return_value=MagicMock()):
+    if request.node.get_closest_marker("real_create_task"):
         yield
+    else:
+        with patch("asyncio.create_task", return_value=MagicMock()):
+            yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -235,6 +235,53 @@ async def test_primary_demotes_when_other_holder_wins(monkeypatch):
     FailoverCog._demote.assert_awaited_once()
 
 
+async def test_primary_reclaims_expired_lease_with_nx(monkeypatch):
+    """When read returns None (key missing), primary uses SET NX to reclaim."""
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "me"
+
+    # First GET returns None (key expired), SET NX returns "OK", no re-read needed.
+    responses = {"GET": None, "SET": "OK"}
+    mock = _stub_upstash(responses)
+    monkeypatch.setattr(FailoverCog, "_upstash", mock)
+    monkeypatch.setattr(FailoverCog, "_demote", AsyncMock())
+
+    await cog._primary_cycle()
+
+    # Must NOT have demoted.
+    FailoverCog._demote.assert_not_awaited()
+    # SET call must include NX flag.
+    set_calls = [c for c in mock.calls if c[0] == "SET"]
+    assert set_calls, "expected a SET call"
+    assert "NX" in set_calls[0], "SET must use NX when read returned None"
+
+
+async def test_primary_demotes_when_nx_write_blocked_by_standby(monkeypatch):
+    """When read returns None but NX write fails (standby holds key), primary demotes."""
+    cog = FailoverCog(_make_bot(is_primary=True))
+    cog._identity = "me"
+
+    call_count = {"n": 0}
+
+    async def _resp(*args):
+        cmd = args[0] if args else ""
+        if cmd == "GET":
+            call_count["n"] += 1
+            # First read (holder check): None — key looks missing.
+            # Second read (post-NX re-check): standby is now visible.
+            return None if call_count["n"] == 1 else "S:standby:abc"
+        if cmd == "SET":
+            return None  # NX write blocked — key exists
+        return None
+
+    monkeypatch.setattr(FailoverCog, "_upstash", AsyncMock(side_effect=_resp))
+    monkeypatch.setattr(FailoverCog, "_demote", AsyncMock())
+
+    await cog._primary_cycle()
+
+    FailoverCog._demote.assert_awaited_once()
+
+
 # ── Promotion / demotion ────────────────────────────────────────────────────
 
 async def test_promote_sets_flag_invalidates_cache_loads_cogs(monkeypatch):

--- a/tests/test_hodograph.py
+++ b/tests/test_hodograph.py
@@ -57,11 +57,9 @@ class TestGenerateHodograph:
         async def raise_timeout(*args, **kwargs):
             raise asyncio.TimeoutError()
 
-        with patch("cogs.hodograph.asyncio.get_running_loop") as mock_loop:
-            mock_loop.return_value.run_in_executor = MagicMock()
-            with patch("cogs.hodograph.asyncio.wait_for", side_effect=raise_timeout), \
-                 patch("cogs.hodograph.os.makedirs"):
-                await generate_hodograph(interaction, "KTLX")
+        with patch("lib.vad_plotter.vad.vad_plotter", side_effect=raise_timeout), \
+             patch("cogs.hodograph.os.makedirs"):
+            await generate_hodograph(interaction, "KTLX")
 
         interaction.followup.send.assert_called_once()
         call_kwargs = interaction.followup.send.call_args
@@ -78,11 +76,9 @@ class TestGenerateHodograph:
         async def raise_exception(*args, **kwargs):
             raise Exception("Process failed")
 
-        with patch("cogs.hodograph.asyncio.get_running_loop") as mock_loop:
-            mock_loop.return_value.run_in_executor = MagicMock()
-            with patch("cogs.hodograph.asyncio.wait_for", side_effect=raise_exception), \
-                 patch("cogs.hodograph.os.makedirs"):
-                await generate_hodograph(interaction, "KTLX")
+        with patch("lib.vad_plotter.vad.vad_plotter", side_effect=raise_exception), \
+             patch("cogs.hodograph.os.makedirs"):
+            await generate_hodograph(interaction, "KTLX")
 
         interaction.followup.send.assert_called_once()
         call_kwargs = interaction.followup.send.call_args
@@ -95,12 +91,13 @@ class TestGenerateHodograph:
         interaction = MagicMock()
         interaction.followup = AsyncMock()
 
-        with patch("cogs.hodograph.asyncio.get_running_loop") as mock_loop:
-            mock_loop.return_value.run_in_executor = MagicMock()
-            with patch("cogs.hodograph.asyncio.wait_for", return_value=None), \
-                 patch("cogs.hodograph.os.makedirs"), \
-                 patch("cogs.hodograph.os.path.exists", return_value=False):
-                await generate_hodograph(interaction, "KTLX")
+        async def noop(*args, **kwargs):
+            return None
+
+        with patch("lib.vad_plotter.vad.vad_plotter", side_effect=noop), \
+             patch("cogs.hodograph.os.makedirs"), \
+             patch("cogs.hodograph.os.path.exists", return_value=False):
+            await generate_hodograph(interaction, "KTLX")
 
         interaction.followup.send.assert_called_once()
         call_kwargs = interaction.followup.send.call_args

--- a/tests/test_iem_races.py
+++ b/tests/test_iem_races.py
@@ -58,6 +58,7 @@ class TestFetchWatchDetailsRace:
 
 # ── fetch_md_details race ────────────────────────────────────────────────────
 
+@pytest.mark.real_create_task
 class TestFetchMdDetailsRace:
 
     @pytest.mark.asyncio
@@ -65,9 +66,11 @@ class TestFetchMdDetailsRace:
         """fetch_md_details returns image URL from SPC when available."""
         fake_html = '<img src="mcd0398.png">'
         with patch("cogs.mesoscale.http_get_text", new_callable=AsyncMock) as mt, \
-             patch("cogs.mesoscale.fetch_md_details_iem", new_callable=AsyncMock) as mi:
+             patch("cogs.mesoscale.fetch_md_details_iem", new_callable=AsyncMock) as mi, \
+             patch("cogs.mesoscale.get_cached_md_text", new_callable=AsyncMock) as mc:
             mt.return_value = fake_html
             mi.return_value = (None, None, None)
+            mc.return_value = None
             from cogs.mesoscale import fetch_md_details
             image_url, summary, from_cache, raw_text = await fetch_md_details("0398")
         assert "mcd0398" in image_url
@@ -76,27 +79,18 @@ class TestFetchMdDetailsRace:
     @pytest.mark.asyncio
     async def test_iem_image_used_when_spc_fails(self):
         """When SPC fails and no cache, IEM image URL is returned."""
-        with patch("cogs.mesoscale.http_get_text", new_callable=AsyncMock) as mt, \
-             patch("cogs.mesoscale.fetch_md_details_iem", new_callable=AsyncMock) as mi, \
+        # Use real asyncio primitives but mock the fetchers to control timing.
+        async def slow_spc(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return None
+
+        async def fast_iem(*args, **kwargs):
+            return ("http://iem.example/mcd0398.png", "IEM summary", "IEM raw")
+
+        with patch("cogs.mesoscale.http_get_text", side_effect=slow_spc), \
+             patch("cogs.mesoscale.fetch_md_details_iem", side_effect=fast_iem), \
              patch("cogs.mesoscale.os.path.exists", return_value=False), \
-             patch("cogs.mesoscale.asyncio.create_task") as mct, \
-             patch("cogs.mesoscale.asyncio.wait", new_callable=AsyncMock) as mw:
-
-            mt.return_value = None
-            mi.return_value = ("http://iem.example/mcd0398.png", "IEM summary", "IEM raw")
-
-            # Use real Futures for task mocks
-            loop = asyncio.get_running_loop()
-            spc_task = loop.create_future()
-            iem_task = loop.create_future()
-            mct.side_effect = [spc_task, iem_task]
-
-            # IEM wins immediately
-            iem_task.set_result(mi.return_value)
-            mw.return_value = ({iem_task}, {spc_task})
-
-            # SPC eventually returns None
-            spc_task.set_result(None)
+             patch("cogs.mesoscale.get_cached_md_text", return_value=None):
 
             from cogs.mesoscale import fetch_md_details
             image_url, summary, from_cache, raw_text = await fetch_md_details("0398")
@@ -109,7 +103,8 @@ class TestFetchMdDetailsRace:
         """When SPC fails and IEM returns nothing, cached file is used."""
         with patch("cogs.mesoscale.http_get_text", new_callable=AsyncMock) as mt, \
              patch("cogs.mesoscale.fetch_md_details_iem", new_callable=AsyncMock) as mi, \
-             patch("cogs.mesoscale.os.path.exists", return_value=True):
+             patch("cogs.mesoscale.os.path.exists", return_value=True), \
+             patch("cogs.mesoscale.get_cached_md_text", return_value=None):
             mt.return_value = None
             mi.return_value = (None, None, None)
             from cogs.mesoscale import fetch_md_details

--- a/tests/test_iembot.py
+++ b/tests/test_iembot.py
@@ -4,7 +4,7 @@ Tests for cogs/iembot.py — seqnum persistence, feed filtering, and text parsin
 
 import json
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from cogs.iembot import (
     IEMBotCog,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,6 @@ attributes, and broken call signatures that unit tests miss.
 """
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
-import pytest
 from utils.state import BotState
 
 

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -147,8 +147,8 @@ async def should_use_cache_for_manual(urls: List[str]) -> bool:
         return False
     now = datetime.now()
     ages = [now - datetime.fromtimestamp(m) for m in mtimes]
-    if ages and min(ages) > timedelta(days=3):
-        logger.info("[CACHE] Cached files are older than 3 days; refreshing")
+    if ages and min(ages) > timedelta(hours=3):
+        logger.info("[CACHE] Cached files are older than 3 hours; refreshing")
         return False
     logger.debug(f"[CACHE] Using cached files for Day {day} (min age: {min(ages)})")
     return True


### PR DESCRIPTION
## Root causes found and fixed

### 1. Standby pre-acknowledging slash commands (`main.py`)
Both primary and standby connect to Discord's gateway with the same token. Discord dispatches `INTERACTION_CREATE` to all connected sessions. When the standby received a command it had no cog for, `on_app_command_error` fell through to the generic branch and called `interaction.response.send_message()` — **pre-acknowledging the interaction on Discord's side**. The primary's subsequent `defer()` then failed with `40060: Interaction has already been acknowledged`, and the error handler's own `send_message` failed again, producing the `Task exception was never retrieved` noise. Fix: drop `CommandNotFound` silently (standby gets these on every invocation). Also wrap all error-reply paths in `try/except HTTPException` to absorb the `10062: Unknown interaction` (expired token) cascade.

### 2. Split-brain lease reclaim during reconnect (`cogs/failover.py`)
`_primary_cycle` used a plain `GET` → blind `SET EX` pattern. `_upstash()` returns `None` on both "key missing" and "Upstash error" — the caller can't tell them apart. When 3cape's Upstash connectivity was lost for ~11 min (the lease expired), UR707SC correctly promoted and wrote its identity. When 3cape's connectivity partially returned (writes succeed before reads stabilise), `_read_lease_holder()` returned `None`, the `if holder and ...` guard was falsy, and 3cape did a blind `SET` — overwriting UR707SC's legitimate lease. That caused a ~30 s dual-primary window, duplicate posts, and the spurious MD cancellations. Fix: when the read returns `None`, use `SET NX EX` (set-if-not-exists) to reclaim only if the key is genuinely absent. If the NX write is blocked (returns `None`), re-read and demote if another node holds the key.

### 3. Stale `!spc1` / manual cache serving yesterday's outlook (`utils/cache.py`)
`should_use_cache_for_manual` returned cached files as "fresh" if they were less than 3 days old. The `is_near_spc_update` window guard only blocks caching ±60 min around each SPC update time; between windows a file from the previous day's 1300z issuance is happily served. The longest inter-update gap is ~5 hours, so 3 hours is a safe upper bound. Fix: reduce max age from `timedelta(days=3)` → `timedelta(hours=3)`.

### 4. Hodograph async conversion (`lib/vad_plotter`, `cogs/hodograph.py`)
`vad_plotter` and its dependencies (`download_vad`, `find_file_times`, `get_asos_surface_wind`) were blocking the event loop with `requests` / `urlopen`. Converted all to `async`/`await` using the shared `http_get_bytes`/`http_get_text` utilities. `plot_hodograph` (CPU/matplotlib) stays sync and is offloaded to `loop.run_in_executor`. Two runtime bugs caught in review: missing module-level `asyncio` import in `vad.py` (would `NameError` on every Discord invocation), and a naive-vs-aware datetime comparison in `find_file_times` (would `TypeError` when fetching VAD listings by time).

### 5. CI unblocked — test suite green again (was broken since PR #175)
PR #175 promoted `suppress_create_task` to global autouse. That broke `TestFetchMdDetailsRace`: `fetch_md_details` internally calls `asyncio.create_task` for its SPC/IEM race, and `asyncio.wait` hung forever on the returned `MagicMock` objects. Also: live Upstash credentials leaked from `.env` via `config.py`'s `load_dotenv()`, causing `get_cached_md_text` to make real network calls in tests (billing free-tier quota). Fixes: conftest blocks Upstash env vars with `setdefault("")` before `load_dotenv` runs; new `@pytest.mark.real_create_task` marker opts specific tests out of the global suppression; `TestGenerateHodograph` updated to patch `vad_plotter` directly (old tests patched `get_running_loop`/`run_in_executor` which no longer exist after the async conversion).

## Test results
- 292/292 pass, 24 seconds
- Lint clean (ruff)

## Checklist
- [x] Split-brain NX reclaim tests
- [x] `TestFetchMdDetailsRace` no longer hangs
- [x] `TestGenerateHodograph` updated for async `vad_plotter`
- [x] No live network calls in test suite
- [x] Full suite: 292 passed, 0 failed, 0 hung