### PR TITLE
fix(warnings): handle null damage-threat params from NWS API

### DIFF
--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -160,13 +160,13 @@ def get_warning_style(event: str, text: str, params: dict = None) -> Tuple[str, 
 
     # Param-based detection (NWS API specific)
     if params:
-        t_threat = params.get("tornadoDamageThreat", [])
+        t_threat = params.get("tornadoDamageThreat") or []
         if "CATASTROPHIC" in t_threat:
             return "🚨🚨 TORNADO EMERGENCY", discord.Color.from_rgb(139, 0, 0)
         if "CONSIDERABLE" in t_threat:
             return "⚠️ PDS Tornado Warning", discord.Color.red()
-            
-        s_threat = params.get("thunderstormDamageThreat", [])
+
+        s_threat = params.get("thunderstormDamageThreat") or []
         if "DESTRUCTIVE" in s_threat:
              return "🚨 DESTRUCTIVE Severe Tstorm Warning", discord.Color.purple()
         if "CONSIDERABLE" in s_threat:

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -9,6 +9,7 @@ import pytest
 from cogs.warnings import (
     WarningsCog,
     _extract_narrative,
+    get_warning_style,
     parse_vtec,
     parse_warning_polygon,
 )
@@ -294,3 +295,44 @@ async def test_post_warning_now_claims_key_before_send(monkeypatch):
         "Severe Thunderstorm Warning",
     )
     assert observed == [True], "vtec_id must be claimed before send"
+
+
+# ── get_warning_style ─────────────────────────────────────────────────────────
+
+class TestGetWarningStyle:
+    """NWS API sometimes returns explicit null for damage-threat params.
+    Regression: .get("tornadoDamageThreat", []) returns None (not []) when
+    the key is present with value null, causing 'in None' TypeError."""
+
+    def test_null_tornado_damage_threat_does_not_raise(self):
+        title, _ = get_warning_style(
+            "Tornado Warning", "", params={"tornadoDamageThreat": None}
+        )
+        assert "Tornado Warning" in title
+
+    def test_null_thunderstorm_damage_threat_does_not_raise(self):
+        title, _ = get_warning_style(
+            "Severe Thunderstorm Warning", "", params={"thunderstormDamageThreat": None}
+        )
+        assert "Severe Thunderstorm Warning" in title
+
+    def test_both_null_does_not_raise(self):
+        title, _ = get_warning_style(
+            "Tornado Warning", "",
+            params={"tornadoDamageThreat": None, "thunderstormDamageThreat": None},
+        )
+        assert title  # just shouldn't raise
+
+    def test_catastrophic_tornado_threat_detected(self):
+        title, _ = get_warning_style(
+            "Tornado Warning", "",
+            params={"tornadoDamageThreat": "CATASTROPHIC"},
+        )
+        assert "TORNADO EMERGENCY" in title
+
+    def test_destructive_thunderstorm_threat_detected(self):
+        title, _ = get_warning_style(
+            "Severe Thunderstorm Warning", "",
+            params={"thunderstormDamageThreat": "DESTRUCTIVE"},
+        )
+        assert "DESTRUCTIVE" in title


### PR DESCRIPTION
## Root cause

NWS API occasionally returns explicit `null` for `tornadoDamageThreat` / `thunderstormDamageThreat` when no threat level is set. `dict.get(key, [])` returns `None` (not the default `[]`) when the key is present with value `null` — so `"CATASTROPHIC" in None` raised `TypeError` and dropped the entire warnings tick.

Happened 3× in production on 2026-04-29 at 12:40, 13:40, and 18:00. The backoff retry recovered each time, but one warning poll cycle was skipped per occurrence.

## Fix

```python
# before
t_threat = params.get("tornadoDamageThreat", [])
s_threat = params.get("thunderstormDamageThreat", [])

# after
t_threat = params.get("tornadoDamageThreat") or []
s_threat = params.get("thunderstormDamageThreat") or []
```

## Tests

5 new cases in `TestGetWarningStyle`: null tornado threat, null thunderstorm threat, both null, CATASTROPHIC detection, DESTRUCTIVE detection.

## Checklist
- [x] 297/297 tests pass
- [x] Lint clean