### PR TITLE
fix/feat: codebase audit fixes + warning format overhaul

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -711,8 +711,8 @@ class MesoscaleCog(commands.Cog):
                     await prune_posted_mds()
                     self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
                     logger.info(f"[MD] Posted MD #{md_num}")
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.exception(f"[MD] auto_post_md send failed for #{md_num}: {e}")
             self._md_backoff.success()
 
         except Exception as e:

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -492,6 +492,7 @@ class MesoscaleCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._md_backoff = TaskBackoff("auto_post_md")
+        self._cancelled_mds: set = set()  # MDs cancelled this session — never re-activate
 
     async def cog_load(self):
         self.auto_post_md.start()
@@ -657,6 +658,7 @@ class MesoscaleCog(commands.Cog):
                         embed.set_footer(text="SPC MD Monitor")
                         try:
                             await channel.send(embed=embed)
+                            self._cancelled_mds.add(md_num)
                             self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
                             logger.info(
                                 f"[MD] Posted cancellation for #{md_num}"
@@ -670,6 +672,8 @@ class MesoscaleCog(commands.Cog):
 
             # ── New MDs ────────────────────────────────────────────────────
             for md_num in md_numbers:
+                if md_num in self._cancelled_mds:
+                    continue  # SPC index flap — don't re-activate a cancelled MD
                 self.bot.state.active_mds.add(md_num)
                 if md_num in self.bot.state.posted_mds:
                     continue

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -1068,9 +1068,6 @@ class SoundingCog(commands.Cog):
         await interaction.followup.send(embed=checking_embed)
         status_msg = await interaction.original_response()
 
-        verified = await filter_stations_with_data(candidates)
-        nearest = verified[:3]
-
         # Run RAOB verification and ACARS search concurrently
         acars_task = asyncio.create_task(get_acars_profiles_near(lat, lon, max_dist_km=400))
         verified = await filter_stations_with_data(candidates)

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -76,13 +76,15 @@ def parse_vtec(text: str) -> Optional[dict]:
     m = _VTEC_RE.search(text)
     if not m:
         return None
-    action, office, phenom, sig, etn, _start, _end = m.groups()
+    action, office, phenom, sig, etn, start, end = m.groups()
     return {
         "action": action,
         "office": office,
         "phenom": phenom,
         "sig": sig,
         "etn": etn,
+        "start": start,
+        "end": end,
         "vtec_id": f"{office}.{phenom}.{sig}.{etn}",
     }
 
@@ -212,28 +214,132 @@ def iem_autoplot_url(vtec: dict) -> str:
     )
 
 
+def _vtec_url(vtec: dict) -> str:
+    """Build an IEM VTEC event page URL from a parsed vtec dict."""
+    start = vtec.get("start", "")
+    if start and len(start) >= 11:
+        # '260429T0228Z' → '2026-04-29T02:28Z'
+        try:
+            year = 2000 + int(start[:2])
+            iso = f"{year}-{start[2:4]}-{start[4:6]}T{start[7:9]}:{start[9:11]}Z"
+        except (ValueError, IndexError):
+            now = datetime.now(timezone.utc)
+            year = now.year
+            iso = now.strftime("%Y-%m-%dT%H:%MZ")
+    else:
+        now = datetime.now(timezone.utc)
+        year = now.year
+        iso = now.strftime("%Y-%m-%dT%H:%MZ")
+    action = vtec.get("action", "NEW")
+    office = vtec.get("office", "")
+    phenom = vtec.get("phenom", "")
+    sig = vtec.get("sig", "")
+    etn = int(vtec.get("etn", "0") or "0")
+    return (
+        f"https://mesonet.agron.iastate.edu/vtec/f/"
+        f"{year}-O-{action}-{office}-{phenom}-{sig}-{etn:04d}_{iso}"
+    )
+
+
+def _vtec_unix_ts(vtec: dict) -> int:
+    """Return the Unix timestamp for the VTEC start time, or now if unavailable."""
+    start = vtec.get("start", "")
+    if start and len(start) >= 11:
+        try:
+            year = 2000 + int(start[:2])
+            month = int(start[2:4])
+            day = int(start[4:6])
+            hour = int(start[7:9])
+            minute = int(start[9:11])
+            return int(datetime(year, month, day, hour, minute, tzinfo=timezone.utc).timestamp())
+        except (ValueError, IndexError):
+            pass
+    return int(time.time())
+
+
+def _area_with_state(area_desc: str, ugc_codes: List[str]) -> str:
+    """Append [STATE] abbreviations to the area string, grouping counties by state.
+
+    Uses the NWS API geocode.UGC list (e.g. ['MSC023', 'ARC001']) to determine
+    which counties belong to which state, then formats them as:
+        'Clarke, Jasper, Jones [MS]'                         (single state)
+        'Ashley, Chicot [AR] and Washington [MS]'            (two states)
+    County names come from area_desc (already comma/semicolon separated).
+    The UGC ordering matches the area_desc ordering in NWS API responses.
+    """
+    if not ugc_codes:
+        return area_desc
+
+    # Parse county names from areaDesc
+    counties = [c.strip() for c in re.split(r'[;,]\s*', area_desc) if c.strip()]
+    if not counties:
+        return area_desc
+
+    # Group UGC codes by state (first 2 chars), preserving order of first appearance
+    from collections import OrderedDict
+    state_counts: dict = OrderedDict()
+    for ugc in ugc_codes:
+        if len(ugc) >= 2:
+            state = ugc[:2].upper()
+            state_counts[state] = state_counts.get(state, 0) + 1
+
+    if not state_counts:
+        return area_desc
+
+    # Split county list by state group counts
+    parts = []
+    idx = 0
+    for state, count in state_counts.items():
+        group = counties[idx:idx + count]
+        if group:
+            parts.append(f"{', '.join(group)} [{state}]")
+        idx += count
+
+    # Any leftover counties (mismatch in UGC/areaDesc lengths) appended to last group
+    if idx < len(counties):
+        remainder = counties[idx:]
+        if parts:
+            parts[-1] = parts[-1] + f", {', '.join(remainder)}"
+        else:
+            return area_desc
+
+    if len(parts) == 1:
+        return parts[0]
+    elif len(parts) == 2:
+        return f"{parts[0]} and {parts[1]}"
+    else:
+        return ", ".join(parts[:-1]) + f" and {parts[-1]}"
+
+
 def build_concise_warning_text(
     event: str,
     vtec: dict,
     raw_text: Optional[str] = None,
     feature: Optional[dict] = None,
+    ugc_codes: Optional[List[str]] = None,
 ) -> str:
-    """Build a one-line concise warning string for Discord."""
+    """Build the warning description for Discord.
+
+    Format: {office} [{verb} {event}](vtec_url) [{tags}] for {area} [STATE] till HH:MMZ
+            {narrative}
+            [<t:unix_ts:R>]
+    """
     office = vtec["office"]
     if office.startswith("K") and len(office) == 4:
         office = office[1:]
 
-    # 1. Action Verb
+    # 1. Action verb
     action_map = {
         "NEW": "issues",
         "CON": "continues",
         "CAN": "cancels",
-        "EXP": "expired",
+        "EXP": "expires",
+        "EXT": "extends time of",
         "UPG": "upgrades",
     }
     action_verb = action_map.get(vtec["action"], "updates")
-    
-    # 2. Extract Tags (tornado, hail, wind)
+
+    # 2. Tags (tornado, hail, wind)
     tags = []
     text_to_search = raw_text or ""
     if feature:
@@ -241,14 +347,13 @@ def build_concise_warning_text(
         text_to_search += " " + (props.get("description") or "")
         params = props.get("parameters", {})
         if params.get("tornadoDetection"):
-             tags.append(f"tornado: {params['tornadoDetection'][0]}")
+            tags.append(f"tornado: {params['tornadoDetection'][0]}")
         if params.get("maxHailSize"):
-             tags.append(f"hail: {params['maxHailSize'][0]} IN")
+            tags.append(f"hail: {params['maxHailSize'][0]} IN")
         if params.get("maxWindGust"):
-             tags.append(f"wind: {params['maxWindGust'][0]}")
-    
+            tags.append(f"wind: {params['maxWindGust'][0]}")
+
     if not tags and text_to_search:
-        # Regex fallback for iembot path
         m_tor = re.search(r"TORNADO\.\.\.(.+?)(?:\n|$)", text_to_search, re.I)
         if m_tor:
             tags.append(f"tornado: {m_tor.group(1).strip()}")
@@ -261,66 +366,59 @@ def build_concise_warning_text(
 
     tag_str = f" [{', '.join(tags)}]" if tags else ""
 
-    # 3. Area Description
+    # 3. Area (with [STATE] grouping when UGC codes are available)
     area = "affected area"
     if feature:
         area = feature.get("properties", {}).get("areaDesc", area)
     elif raw_text:
-        # Greedy search for the area list between a start keyword and the narrative/bullets
         m_area = re.search(r"(?:Warning for|Statement for|IMPACT)\s+(.+?)(?=\n\s*\*|\n\s*At\s+|$)", raw_text, re.I | re.DOTALL)
         if m_area:
             raw_list = m_area.group(1)
-            # Split by dots, newlines, or " AND "
             parts = re.split(r"\n|\.\.\.|\s+AND\s+", raw_list, flags=re.I)
             counties = []
             for p in parts:
                 c = p.strip().strip(".")
                 if not c or len(c) < 3:
                     continue
-                # Skip common NWS boilerplate and time phrases
-
                 if any(x in c.upper() for x in ["THROUGH", "UNTIL", "PORTIONS", "AM", "PM", "EDT", "CDT", "MDT", "PDT", "HST", "AKDT"]):
                     continue
-                # Remove regional prefixes
                 c = re.sub(r"^(?:Northeastern|Northwestern|Southeastern|Southwestern|Northern|Southern|Eastern|Western|Central)\s+", "", c, flags=re.I)
-                # Remove region/state suffixes
                 c = re.split(r"\s+in\s+", c, flags=re.I)[0]
-                # Remove "County" or "Counties"
                 c = re.sub(r"\s+Count[iy].*$", "", c, flags=re.I)
-                # Final clean and avoid pure direction words
                 c = c.strip()
                 if c and c.upper() not in ["CENTRAL", "NORTH", "SOUTH", "EAST", "WEST"] and c not in counties:
                     counties.append(c)
             if counties:
                 area = ", ".join(counties)
 
-    # 4. Expiration Time
-    # VTEC end: 260428T0530Z
+    area_formatted = _area_with_state(area, ugc_codes or [])
+
+    # 4. Expiration time (VTEC end field: '260428T0530Z')
     expires_str = ""
     if vtec.get("end"):
         try:
-            z_time = vtec["end"].split("T")[1] # e.g. 0530Z
+            z_time = vtec["end"].split("T")[1]
             expires_str = f" till {z_time[:2]}:{z_time[2:4]}Z"
         except (IndexError, ValueError):
             pass
 
-    # 5. Narrative Bullet
+    # 5. Narrative bullet
     narrative = ""
     if text_to_search:
-        # Find the paragraph starting with "At" (optional bullet *)
-        # Refined lookahead to stop at CAPS... tags or next bullet.
         m_nat = re.search(r"(?:\*\s*)?At\s+(.+?)(?=\n\s*\*|\n\s*LAT\.\.\.LON|\n[A-Z]{4,}\b\.{3,}|$)", text_to_search, re.I | re.DOTALL)
         if m_nat:
             val = m_nat.group(1).strip()
-            # Bold the NWS tags (HAZARD, SOURCE, IMPACT, etc.)
             val = re.sub(r"([A-Z]{4,}\b\.{3,})", r"**\1**", val)
             val = re.sub(r"\s+", " ", val).strip()
-            # Clean up leading/trailing dots
             val = val.lstrip(".").strip()
-            # No bullet per user request
             narrative = f"\nAt {val}"
 
-    return f"{office} {action_verb} {event}{tag_str} for {area}{expires_str}{narrative}"
+    # 6. Hyperlinked verb + relative timestamp
+    vtec_link = _vtec_url(vtec)
+    unix_ts = _vtec_unix_ts(vtec)
+    linked_verb = f"[{action_verb} {event}]({vtec_link})"
+
+    return f"{office} {linked_verb}{tag_str} for {area_formatted}{expires_str}{narrative}\n[<t:{unix_ts}:R>]"
 
 
 def _extract_narrative(raw: str) -> Optional[str]:
@@ -730,7 +828,20 @@ class WarningsCog(commands.Cog):
         event_name = self._PHENOM_EVENT.get((phenom, sig), f"{phenom}.{sig} Warning")
         action_verb = "cancels" if reason == "Cancelled" else "expires"
         area_str = f" for {area}" if area else ""
-        description = f"**{office} {action_verb} {event_name}**{area_str}"
+
+        # Build a cancellation vtec dict with CAN/EXP action for the URL
+        cancel_vtec = dict(vtec or {})
+        cancel_vtec["action"] = "CAN" if reason == "Cancelled" else "EXP"
+        if not cancel_vtec.get("start"):
+            now = datetime.now(timezone.utc)
+            cancel_vtec["start"] = now.strftime("%y%m%dT%H%MZ")
+        vtec_link = _vtec_url(cancel_vtec)
+        unix_ts = _vtec_unix_ts(cancel_vtec)
+
+        description = (
+            f"{office} [{action_verb} {event_name}]({vtec_link}){area_str}\n"
+            f"[<t:{unix_ts}:R>]"
+        )
 
         # Fetch the IEM Autoplot image — for cancelled events IEM marks it
         # "Event No Longer Active" automatically.
@@ -892,7 +1003,11 @@ class WarningsCog(commands.Cog):
         title, color = get_warning_style(event, description, params)
         vtec_id = vtec["vtec_id"]
 
-        concise_text = build_concise_warning_text(event, vtec, feature=feature.model_dump())
+        ugc_codes = (props.geocode.UGC or []) if props.geocode else []
+        area_desc = _area_with_state(props.areaDesc or "", ugc_codes)
+        concise_text = build_concise_warning_text(
+            event, vtec, feature=feature.model_dump(), ugc_codes=ugc_codes
+        )
 
         # Log significant events (tornadoes, hail, wind) to DB
         await self._check_and_log_significant_event(event, description, vtec)
@@ -934,7 +1049,7 @@ class WarningsCog(commands.Cog):
 
         msg = await channel.send(embed=embed, files=files)
         logger.info(f"[WARN] Posted {event} {vtec_id}")
-        return msg
+        return msg, area_desc
 
     @auto_poll_warnings.after_loop
     async def after_loop(self):

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -718,21 +718,8 @@ class WarningsCog(commands.Cog):
         if not channel:
             return
 
-        # Build the one-line cancellation description.
-        # Pull area from the original embed description so we don't have to
-        # re-query NWS — the area was already formatted nicely at post time.
-        area = ""
-        try:
-            original = await channel.fetch_message(message_id)
-            if original.embeds:
-                desc = original.embeds[0].description or ""
-                m = re.search(r"\bfor\b (.+?)(?:\s+till\s+|\s*\n|$)", desc, re.IGNORECASE)
-                if m:
-                    area = m.group(1).strip()
-        except discord.NotFound:
-            pass
-        except Exception as e:
-            logger.debug(f"[WARN] Could not fetch original embed for {vtec_id}: {e}")
+        # Area was stored in posted_warnings when the warning was first posted.
+        area = info.get("area", "")
 
         phenom = (vtec or {}).get("phenom", "")
         sig = (vtec or {}).get("sig", "")
@@ -741,7 +728,7 @@ class WarningsCog(commands.Cog):
             office = office[1:]
 
         event_name = self._PHENOM_EVENT.get((phenom, sig), f"{phenom}.{sig} Warning")
-        action_verb = "cancels" if reason == "Cancelled" else "has expired —"
+        action_verb = "cancels" if reason == "Cancelled" else "expires"
         area_str = f" for {area}" if area else ""
         description = f"**{office} {action_verb} {event_name}**{area_str}"
 

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -690,10 +690,21 @@ class WarningsCog(commands.Cog):
 
         await interaction.followup.send(embed=embed)
 
+    # phenom+sig → human-readable event name, for cancellation posts
+    _PHENOM_EVENT = {
+        ("TO", "W"): "Tornado Warning",
+        ("SV", "W"): "Severe Thunderstorm Warning",
+        ("FF", "W"): "Flash Flood Warning",
+        ("FF", "A"): "Flash Flood Watch",
+        ("TO", "A"): "Tornado Watch",
+        ("SV", "A"): "Severe Thunderstorm Watch",
+        ("SPS", "S"): "Special Weather Statement",
+    }
+
     async def _handle_cancellation(
         self, vtec_id: str, reason: str = "Expired / Cancelled", vtec: dict | None = None
     ):
-        """Edit an existing warning post to mark it as inactive."""
+        """Post a new cancellation notice; leave the original warning post untouched."""
         info = self.bot.state.posted_warnings.get(vtec_id)
         if not info:
             return
@@ -707,47 +718,61 @@ class WarningsCog(commands.Cog):
         if not channel:
             return
 
+        # Build the one-line cancellation description.
+        # Pull area from the original embed description so we don't have to
+        # re-query NWS — the area was already formatted nicely at post time.
+        area = ""
         try:
-            msg = await channel.fetch_message(message_id)
-            if not msg.embeds:
-                return
-
-            embed = msg.embeds[0]
-            # Avoid double-cancellation logic
-            if "✅" in (embed.title or ""):
-                return
-
-            # Update title and color
-            embed.title = f"✅ {embed.title or ''} — {reason}"
-            embed.color = discord.Color.green()
-
-            # Add status to footer
-            footer = embed.footer.text or ""
-            embed.set_footer(text=f"{footer} | {reason}")
-
-            # Try to fetch updated IEM image for the cancellation
-            files = []
-            if vtec and ((vtec.get("etn") and vtec["etn"] != "0") or vtec.get("phenom") == "SPS"):
-                image_url = iem_autoplot_url(vtec)
-                filename = f"cancel_{vtec_id.replace('.', '_')}.png"
-                try:
-                    content, status = await http_get_bytes(image_url, retries=1, timeout=10)
-                    if content and status == 200:
-                        from io import BytesIO
-                        files.append(discord.File(BytesIO(content), filename=filename))
-                        embed.set_image(url=f"attachment://{filename}")
-                except Exception as e:
-                    logger.debug(f"[WARN] No cancellation image for {vtec_id}: {e}")
-
-            await msg.edit(embed=embed, attachments=files)
-            logger.info(f"[WARN] Marked {vtec_id} as {reason} in Discord")
-
+            original = await channel.fetch_message(message_id)
+            if original.embeds:
+                desc = original.embeds[0].description or ""
+                m = re.search(r"\bfor\b (.+?)(?:\s+till\s+|\s*\n|$)", desc, re.IGNORECASE)
+                if m:
+                    area = m.group(1).strip()
         except discord.NotFound:
-            logger.debug(
-                f"[WARN] Message for {vtec_id} not found, skipping cancel edit"
-            )
+            pass
         except Exception as e:
-            logger.warning(f"[WARN] Failed to cancel {vtec_id}: {e}")
+            logger.debug(f"[WARN] Could not fetch original embed for {vtec_id}: {e}")
+
+        phenom = (vtec or {}).get("phenom", "")
+        sig = (vtec or {}).get("sig", "")
+        office = (vtec or {}).get("office", vtec_id.split(".")[0])
+        if office.startswith("K") and len(office) == 4:
+            office = office[1:]
+
+        event_name = self._PHENOM_EVENT.get((phenom, sig), f"{phenom}.{sig} Warning")
+        action_verb = "cancels" if reason == "Cancelled" else "has expired —"
+        area_str = f" for {area}" if area else ""
+        description = f"**{office} {action_verb} {event_name}**{area_str}"
+
+        # Fetch the IEM Autoplot image — for cancelled events IEM marks it
+        # "Event No Longer Active" automatically.
+        files = []
+        if vtec and ((vtec.get("etn") and vtec["etn"] != "0") or phenom == "SPS"):
+            image_url = iem_autoplot_url(vtec)
+            filename = f"cancel_{vtec_id.replace('.', '_')}.png"
+            try:
+                content, status = await http_get_bytes(image_url, retries=1, timeout=10)
+                if content and status == 200:
+                    from io import BytesIO
+                    files.append(discord.File(BytesIO(content), filename=filename))
+            except Exception as e:
+                logger.debug(f"[WARN] No cancellation image for {vtec_id}: {e}")
+
+        embed = discord.Embed(
+            description=description,
+            color=discord.Color.dark_gray(),
+            timestamp=datetime.now(timezone.utc),
+        )
+        if files:
+            embed.set_image(url=f"attachment://{files[0].filename}")
+        embed.set_footer(text=f"VTEC {vtec_id}")
+
+        try:
+            await channel.send(embed=embed, files=files)
+            logger.info(f"[WARN] Posted cancellation for {vtec_id}")
+        except Exception as e:
+            logger.warning(f"[WARN] Failed to post cancellation for {vtec_id}: {e}")
 
     @tasks.loop(seconds=30)
     async def auto_poll_warnings(self):

--- a/models/nws.py
+++ b/models/nws.py
@@ -3,6 +3,11 @@ from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, Field
 
+class NWSAlertGeocode(BaseModel):
+    UGC: Optional[List[str]] = None
+    SAME: Optional[List[str]] = None
+
+
 class NWSAlertParameters(BaseModel):
     VTEC: Optional[List[str]] = None
     maxHailSize: Optional[List[str]] = None
@@ -22,6 +27,7 @@ class NWSAlertProperties(BaseModel):
     instruction: Optional[str] = None
     response: Optional[str] = None
     parameters: Optional[NWSAlertParameters] = None
+    geocode: Optional[NWSAlertGeocode] = None
     effective: Optional[datetime] = None
     onset: Optional[datetime] = None
     expires: Optional[datetime] = None

--- a/tests/test_mesoscale.py
+++ b/tests/test_mesoscale.py
@@ -161,3 +161,81 @@ async def test_cancellation_send_failure_re_adds_md():
         await cog.auto_post_md()
 
     assert "0100" in bot.state.active_mds
+
+
+# ── post_md_now (iembot fast-path) ───────────────────────────────────────────
+
+def _make_bot_for_post(posted_mds=None, active_mds=None):
+    bot = MagicMock()
+    bot.state.is_primary = True
+    bot.state.posted_mds = set(posted_mds or [])
+    bot.state.active_mds = set(active_mds or [])
+    bot.state.auto_cache = {}
+    bot.state.last_post_times = {}
+    bot.cogs = {}
+    bot.wait_until_ready = AsyncMock()
+    channel = AsyncMock()
+    bot.get_channel.return_value = channel
+    return bot, channel
+
+
+@pytest.mark.asyncio
+async def test_post_md_now_dedup_skips_already_posted():
+    """post_md_now returns immediately if the MD is already in posted_mds."""
+    bot, channel = _make_bot_for_post(posted_mds={"0398"})
+    cog = MesoscaleCog.__new__(MesoscaleCog)
+    cog.bot = bot
+
+    await cog.post_md_now("0398")
+
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_md_now_sends_and_marks_posted():
+    """post_md_now posts an embed and records the MD in state."""
+    bot, channel = _make_bot_for_post()
+    cog = MesoscaleCog.__new__(MesoscaleCog)
+    cog.bot = bot
+
+    with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=("http://img/mcd0398.png", "summary", False, "raw text"))), \
+         patch("cogs.mesoscale.download_single_image", AsyncMock(return_value=(None, False, None))), \
+         patch("cogs.mesoscale.extract_md_body", return_value="Discussion body"), \
+         patch("cogs.mesoscale.add_posted_md", AsyncMock()), \
+         patch("cogs.mesoscale.clean_md_text_for_discord", return_value="Discussion body"):
+        await cog.post_md_now("398")
+
+    channel.send.assert_called_once()
+    assert "0398" in bot.state.posted_mds
+    assert "0398" in bot.state.active_mds
+
+
+@pytest.mark.asyncio
+async def test_post_md_now_no_channel_returns_early():
+    """post_md_now silently returns if the channel is not found."""
+    bot, _ = _make_bot_for_post()
+    bot.get_channel.return_value = None
+    cog = MesoscaleCog.__new__(MesoscaleCog)
+    cog.bot = bot
+
+    await cog.post_md_now("0398")  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_post_md_now_send_failure_does_not_mark_posted():
+    """A Discord send failure must not mark the MD as posted — it must be retried next cycle."""
+    import discord as _discord
+
+    bot, channel = _make_bot_for_post()
+    channel.send.side_effect = _discord.HTTPException(MagicMock(status=500), "server error")
+
+    cog = MesoscaleCog.__new__(MesoscaleCog)
+    cog.bot = bot
+
+    with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=(None, None, False, None))), \
+         patch("cogs.mesoscale.download_single_image", AsyncMock(return_value=(None, False, None))), \
+         patch("cogs.mesoscale.extract_md_body", return_value=None), \
+         patch("cogs.mesoscale.clean_md_text_for_discord", return_value=None):
+        await cog.post_md_now("0398")  # must not raise
+
+    assert "0398" not in bot.state.posted_mds

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -243,26 +243,17 @@ async def test_post_warning_now_skips_non_NEW_actions(monkeypatch):
 async def test_handle_cancellation_posts_new_message(monkeypatch):
     """Cancellation must post a NEW message in channel — original post is left untouched."""
     vtec_id = "KOUN.SV.W.0042"
-    mapping = {vtec_id: {"message_id": 123, "channel_id": 456}}
+    # area is now stored in posted_warnings at post time
+    mapping = {vtec_id: {"message_id": 123, "channel_id": 456, "area": "Garfield, Noble"}}
     vtec = {"office": "KOUN", "phenom": "SV", "sig": "W", "etn": "0042", "vtec_id": vtec_id}
     cog = _make_cog(posted=mapping)
     cog.bot.state.active_warnings = {vtec_id: vtec}
 
-    # Original embed has area in description
-    mock_original = AsyncMock()
-    mock_original.embeds = [discord.Embed(
-        title="⛈️ Severe Thunderstorm Warning",
-        description="OUN issues Severe Thunderstorm Warning for Garfield, Noble till 23:00Z",
-    )]
     channel = cog.bot.get_channel.return_value
-    channel.fetch_message = AsyncMock(return_value=mock_original)
 
     monkeypatch.setattr("cogs.warnings.http_get_bytes", AsyncMock(return_value=(None, 404)))
 
     await cog._handle_cancellation(vtec_id, reason="Cancelled", vtec=vtec)
-
-    # Original message must NOT be edited
-    mock_original.edit.assert_not_called()
 
     # A NEW message must be sent
     channel.send.assert_called_once()

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -240,29 +240,37 @@ async def test_post_warning_now_skips_non_NEW_actions(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handle_cancellation_edits_message(monkeypatch):
-    """Marking a warning as cancelled should fetch the message and
-    edit the embed with a strike-through description."""
+async def test_handle_cancellation_posts_new_message(monkeypatch):
+    """Cancellation must post a NEW message in channel — original post is left untouched."""
     vtec_id = "KOUN.SV.W.0042"
     mapping = {vtec_id: {"message_id": 123, "channel_id": 456}}
+    vtec = {"office": "KOUN", "phenom": "SV", "sig": "W", "etn": "0042", "vtec_id": vtec_id}
     cog = _make_cog(posted=mapping)
-    cog.bot.state.active_warnings = {vtec_id: {"office": "OUN"}}
+    cog.bot.state.active_warnings = {vtec_id: vtec}
 
-    mock_msg = AsyncMock()
-    mock_msg.embeds = [discord.Embed(title="Storm", description="Heavy rain")]
-    cog.bot.get_channel.return_value.fetch_message = AsyncMock(return_value=mock_msg)
+    # Original embed has area in description
+    mock_original = AsyncMock()
+    mock_original.embeds = [discord.Embed(
+        title="⛈️ Severe Thunderstorm Warning",
+        description="OUN issues Severe Thunderstorm Warning for Garfield, Noble till 23:00Z",
+    )]
+    channel = cog.bot.get_channel.return_value
+    channel.fetch_message = AsyncMock(return_value=mock_original)
 
-    await cog._handle_cancellation(vtec_id, reason="Cancelled")
+    monkeypatch.setattr("cogs.warnings.http_get_bytes", AsyncMock(return_value=(None, 404)))
 
-    # Verify message was fetched and edited
-    cog.bot.get_channel.return_value.fetch_message.assert_called_with(123)
-    mock_msg.edit.assert_called_once()
-    
-    # Verify embed was modified
-    # Note: edit is called with embed=embed, attachments=files
-    edited_embed = mock_msg.edit.call_args[1]["embed"]
-    assert "Cancelled" in edited_embed.title
-    assert edited_embed.color == discord.Color.green()
+    await cog._handle_cancellation(vtec_id, reason="Cancelled", vtec=vtec)
+
+    # Original message must NOT be edited
+    mock_original.edit.assert_not_called()
+
+    # A NEW message must be sent
+    channel.send.assert_called_once()
+    sent_embed = channel.send.call_args.kwargs["embed"]
+    assert "cancels" in sent_embed.description
+    assert "Severe Thunderstorm Warning" in sent_embed.description
+    assert "Garfield" in sent_embed.description
+    assert sent_embed.color == discord.Color.dark_gray()
 
 
 @pytest.mark.asyncio

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -6,7 +6,7 @@ Run with: python -m pytest tests/ -v
 """
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -194,3 +194,95 @@ class TestFetchActiveWatchesNWS:
 
         assert result == {}
         assert result is not None
+
+
+# ── post_watch_now (iembot fast-path) ────────────────────────────────────────
+
+
+def _make_watch_bot(posted_watches=None):
+    bot = MagicMock()
+    bot.state.posted_watches = set(posted_watches or [])
+    bot.state.auto_cache = {}
+    bot.state.last_post_times = {}
+    bot.cogs = {}
+    bot.wait_until_ready = AsyncMock()
+    channel = AsyncMock()
+    bot.get_channel.return_value = channel
+    return bot, channel
+
+
+@pytest.mark.asyncio
+async def test_post_watch_now_dedup_skips_already_posted():
+    """post_watch_now returns immediately if the watch is already posted."""
+    from cogs.watches import WatchesCog
+
+    bot, channel = _make_watch_bot(posted_watches={"0102"})
+    cog = WatchesCog.__new__(WatchesCog)
+    cog.bot = bot
+
+    await cog.post_watch_now("0102", {"type": "SVR", "expires": None, "affected_zones": []})
+
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_watch_now_sends_and_marks_posted():
+    """post_watch_now posts an embed and records the watch in state."""
+    from cogs.watches import WatchesCog
+
+    bot, channel = _make_watch_bot()
+    cog = WatchesCog.__new__(WatchesCog)
+    cog.bot = bot
+
+    nws_info = {"type": "SVR", "expires": None, "affected_zones": []}
+
+    with patch("cogs.watches.fetch_watch_details", AsyncMock(return_value=("http://img.png", "summary", None))), \
+         patch("cogs.watches.download_single_image", AsyncMock(return_value=(None, False, None))), \
+         patch("cogs.watches.add_posted_watch", AsyncMock()), \
+         patch("cogs.watches.prune_posted_watches", AsyncMock()):
+        await cog.post_watch_now("0102", nws_info)
+
+    channel.send.assert_called_once()
+    assert "0102" in bot.state.posted_watches
+
+
+@pytest.mark.asyncio
+async def test_post_watch_now_no_channel_returns_early():
+    """post_watch_now silently returns if the channel is not found."""
+    from cogs.watches import WatchesCog
+
+    bot, _ = _make_watch_bot()
+    bot.get_channel.return_value = None
+    cog = WatchesCog.__new__(WatchesCog)
+    cog.bot = bot
+
+    await cog.post_watch_now("0102", {"type": "SVR", "expires": None, "affected_zones": []})
+
+
+@pytest.mark.asyncio
+async def test_post_watch_now_dispatches_to_sounding_cog():
+    """When affected_zones is non-empty, post_soundings_for_watch is scheduled."""
+    from cogs.watches import WatchesCog
+
+    bot, channel = _make_watch_bot()
+    mock_sounding = MagicMock()
+    mock_sounding.post_soundings_for_watch = AsyncMock()
+    bot.cogs["SoundingCog"] = mock_sounding
+
+    nws_info = {
+        "type": "TORNADO",
+        "expires": None,
+        "affected_zones": ["https://api.weather.gov/zones/county/IAC001"],
+    }
+
+    cog = WatchesCog.__new__(WatchesCog)
+    cog.bot = bot
+
+    with patch("cogs.watches.fetch_watch_details", AsyncMock(return_value=(None, None, None))), \
+         patch("cogs.watches.download_single_image", AsyncMock(return_value=(None, False, None))), \
+         patch("cogs.watches.add_posted_watch", AsyncMock()), \
+         patch("cogs.watches.prune_posted_watches", AsyncMock()):
+        await cog.post_watch_now("0102", nws_info)
+
+    # post_soundings_for_watch is called to build the coroutine arg for create_task
+    mock_sounding.post_soundings_for_watch.assert_called_once_with("0102", nws_info, channel)

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -767,7 +767,11 @@ async def get_posted_urls(day_key: str) -> List[str]:
         return list(val)
     try:
         result = await _upstash_cmd("GET", _k_posted_urls(day_key))
-        urls = json.loads(result) if result else []
+        try:
+            urls = json.loads(result) if result else []
+        except json.JSONDecodeError:
+            logger.warning(f"[STATE] get_posted_urls({day_key}): malformed Upstash response, falling back to SQLite")
+            urls = await sqlite_backend.get_posted_urls(day_key)
         _cache_set(cache_key, urls)
         return list(urls)
     except _UpstashUnavailable as e:


### PR DESCRIPTION
## Bug Fixes

**`cogs/mesoscale.py` — silent send failure on auto MD post**
The `channel.send` / `add_posted_md` block in `auto_post_md` was wrapped in `except Exception: pass`, swallowing all errors silently. A Discord outage or Upstash write failure would go unlogged and the MD could be reposted next cycle. Replaced with `logger.exception(...)`.

**`cogs/sounding.py` — double station availability lookup**
The `/sounding` command called `filter_stations_with_data(candidates)` twice — once blocking before the ACARS task, and again concurrently with it. The first result was immediately discarded. Removed the dead blocking call, halving the station-availability API round-trip per invocation.

**`utils/state_store.py` — unguarded `JSONDecodeError` in `get_posted_urls`**
`json.loads(result)` inside `except _UpstashUnavailable` only — a malformed Upstash response would raise `JSONDecodeError` uncaught. Added explicit `except json.JSONDecodeError` fallback to SQLite.

**`cogs/mesoscale.py` — MD cancellation spam**
SPC index flapping caused the New MDs loop to silently re-add an expired MD to `active_mds` on each reappearance, triggering a fresh cancellation post every 20 minutes. Added `_cancelled_mds` set — after a successful cancellation, the MD is never re-activated by the index in the same session.

## Warning Format Overhaul

**Cancellations as separate posts**
`_handle_cancellation` previously edited the original warning post in-place (green title, ✅, new image). Now posts a new message in channel and leaves the original untouched.

**Hyperlinked action verb**
Warning description format changed to:
```
{office} [issues Tornado Warning](IEM_VTEC_url) [tags] for {area} [STATE] till HH:MMZ
At narrative...
[<t:unix_ts:R>]
```
Action verb is a clickable link to the IEM VTEC event page. Cancellations follow the same pattern.

**State abbreviation grouping**
Counties grouped by state using `geocode.UGC` codes from the NWS API. Multi-state warnings format as `Ashley, Chicot [AR] and Washington [MS]`. Added `NWSAlertGeocode` model to capture UGC.

**Relative timestamp**
`[<t:unix_ts:R>]` on the second line renders as "2 minutes ago" in Discord, derived from the VTEC start time (now stored in `parse_vtec` instead of discarded).

**`extends time of` action verb for EXT VTEC action**

## Tests
- `post_md_now` and `post_watch_now` coverage: dedup guard, successful post, no-channel early return, send-failure state invariant, sounding dispatch
- Cancellation test updated for new separate-post behavior

## Results
305/305 pass, lint clean.