### PR TITLE
fix: MD fallback, SigWX cleanup, and LSR explanation

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -59,15 +59,16 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> List[str]:
     html = await http_get_text(SPC_MD_INDEX_URL)
 
     global _md_index_unreachable
-    # If SPC is unreachable, try to scrape from IEM's nwstext API
+    # If SPC is unreachable, try to scrape from IEM
     if not html:
         logger.warning("[MD] SPC index HTML empty/failed, falling back to IEM")
         if not _md_index_unreachable:
             logger.warning("[MD] SPC index unreachable — falling back to IEM for active MD list")
             _md_index_unreachable = True
         try:
+            # Use the CGI retrieve service which returns a structure matching our expected parsing
             content, status = await http_get_bytes(
-                "https://mesonet.agron.iastate.edu/api/1/nwstext.json?product=MCD&limit=40",
+                "https://mesonet.agron.iastate.edu/cgi-bin/afos/retrieve.py?pil=SWOMCD&limit=40&fmt=json",
                 retries=2, timeout=15
             )
             if content and status == 200:
@@ -81,9 +82,13 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> List[str]:
                 # Only return MDs from today/recent hours if possible, 
                 # but for simplicity we'll just return the unique ones in the feed.
                 return sorted(list(md_nums), reverse=True)
+            else:
+                logger.warning(f"[MD] IEM fallback failed with status {status}")
         except Exception as e:
             logger.exception(f"[MD] IEM fallback for index failed: {e}")
-        return []
+        
+        # If both failed, return None to signal a fetch failure rather than an empty index
+        return None
 
     if _md_index_unreachable:
         logger.info("[MD] SPC index reachable again")
@@ -616,6 +621,10 @@ class MesoscaleCog(commands.Cog):
                 return
 
             md_numbers = await fetch_latest_md_numbers()
+            if md_numbers is None:
+                # Both SPC and IEM failed - skip this cycle to avoid false cancellations
+                return
+            
             current_mds = set(md_numbers)
             # -1 sentinel disables lag-protection when the index is empty
             # (nothing to compare against, so all active MDs can be cancelled).

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -169,42 +169,6 @@ class ReportsCog(commands.Cog):
                     source=office,
                     raw_text=remarks,
                 )
-            elif "HAIL" in event_upper:
-                m_mag = re.search(r"[ME]([\d.]+)", r)
-                if m_mag:
-                    try:
-                        size = float(m_mag.group(1))
-                        if size >= 3.0:
-                            await add_significant_event(
-                                event_id=f"IEM:LSR:{product_id}:hail",
-                                event_type="Hail",
-                                location=location,
-                                magnitude=f"{size:.2f} Inch",
-                                coords=coords,
-                                timestamp=lsr_ts,
-                                source=office,
-                                raw_text=remarks,
-                            )
-                    except ValueError:
-                        pass
-            elif "WND" in event_upper or "WIND" in event_upper:
-                m_mag = re.search(r"[ME]([\d.]+)", r)
-                if m_mag:
-                    try:
-                        speed = float(m_mag.group(1))
-                        if speed >= 80:
-                            await add_significant_event(
-                                event_id=f"IEM:LSR:{product_id}:wind",
-                                event_type="Wind",
-                                location=location,
-                                magnitude=f"{speed} MPH",
-                                coords=coords,
-                                timestamp=lsr_ts,
-                                source=office,
-                                raw_text=remarks,
-                            )
-                    except ValueError:
-                        pass
 
             await channel.send(embed=embed)
 
@@ -415,13 +379,8 @@ class ReportsCog(commands.Cog):
                 # Check significance
                 is_sig = False
                 typetext = props.get("typetext", "").upper()
-                mag = props.get("magf", 0)
                 
                 if typetext == "TORNADO":
-                    is_sig = True
-                elif typetext == "HAIL" and mag >= 3.0:
-                    is_sig = True
-                elif "WIND" in typetext and mag >= 80:
                     is_sig = True
                 
                 if is_sig:
@@ -446,19 +405,10 @@ class ReportsCog(commands.Cog):
                         event_type = "Tornado"
                         magnitude = "Confirmed"
                         event_id = f"IEM:LSR:{pid}"
-                    elif typetext == "HAIL":
-                        event_type = "Hail"
-                        magnitude = f"{mag:.2f} Inch"
-                        event_id = f"IEM:LSR:{pid}:hail"
-                    else:
-                        event_type = "Wind"
-                        magnitude = f"{int(mag)} MPH"
-                        event_id = f"IEM:LSR:{pid}:wind"
 
-                    # Dedup for tornadoes: if the iembot fast-path already logged
-                    # this event, update that entry with the cleaner GeoJSON
-                    # location ("City, ST") rather than skipping entirely.
-                    if event_type == "Tornado":
+                        # Dedup for tornadoes: if the iembot fast-path already logged
+                        # this event, update that entry with the cleaner GeoJSON
+                        # location ("City, ST") rather than skipping entirely.
                         from utils.state_store import find_matching_tornado  # noqa: PLC0415
                         match_id = await find_matching_tornado(office, ts, location, window_hours=1.0)
                         if match_id:
@@ -477,20 +427,20 @@ class ReportsCog(commands.Cog):
                             await add_posted_report(pid)
                             continue
 
-                    await add_significant_event(
-                        event_id=event_id,
-                        event_type=event_type,
-                        location=location,
-                        magnitude=magnitude,
-                        coords=f"{props.get('lat')}N {abs(props.get('lon'))}W",
-                        timestamp=ts,
-                        source=office,
-                        raw_text=props.get("remark"),
-                    )
-                    # Persist dedup
-                    self.bot.state.posted_reports.add(pid)
-                    await add_posted_report(pid)
-                    await prune_posted_reports()
+                        await add_significant_event(
+                            event_id=event_id,
+                            event_type=event_type,
+                            location=location,
+                            magnitude=magnitude,
+                            coords=f"{props.get('lat')}N {abs(props.get('lon'))}W",
+                            timestamp=ts,
+                            source=office,
+                            raw_text=props.get("remark"),
+                        )
+                        # Persist dedup
+                        self.bot.state.posted_reports.add(pid)
+                        await add_posted_report(pid)
+                        await prune_posted_reports()
 
         except Exception as e:
             logger.warning(f"[REPORTS] LSR poll failed: {e}")

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -90,6 +90,22 @@ class ReportsCog(commands.Cog):
             m_remarks = re.search(r"REMARKS\s*\.\.\.\s*(.*?)(?=\n\s*\n|\$\$|$)", r, re.I | re.DOTALL)
             remarks = m_remarks.group(1).replace("\n", " ").strip() if m_remarks else ""
 
+            # Specialized logic for automated stations (ASOS, AWOS, MTR)
+            source_upper = source.upper()
+            is_automated = any(x in source_upper for x in ("ASOS", "AWOS", "MTR"))
+            
+            peak_wind_summary = ""
+            if is_automated:
+                # Extract Peak Wind: PK WND 27045/2220 -> 45kt
+                m_pk = re.search(r"PK WND\s+\d{3}(\d{2,3})/?(\d{4})?", remarks, re.I)
+                if m_pk:
+                    gust_kt = m_pk.group(1).lstrip("0")
+                    time_pk = m_pk.group(2)
+                    peak_wind_summary = f"Peak wind {gust_kt}kt"
+                    if time_pk:
+                        peak_wind_summary += f" at {time_pk[:2]}:{time_pk[2:]}Z"
+                    peak_wind_summary += ". "
+
             office = product_id.split("-")[1] if "-" in product_id else "NWS"
             lsr_url = f"https://mesonet.agron.iastate.edu/p.php?pid={product_id}"
             
@@ -120,10 +136,11 @@ class ReportsCog(commands.Cog):
                 color = discord.Color.dark_blue()
 
             # Format: {location} [{County, STATE}] {source} [reports {event}](url) at {time} -- {remarks}
+            source_display = f"({source})" if is_automated else source
             area_frag = f"{location} [{county}, {state}]" if state else f"{location}"
             desc = (
-                f"{area_frag} {source} [reports {event_type}]({lsr_url}) at {time_str} -- "
-                f"{remarks if remarks else 'No additional remarks.'}\n"
+                f"{area_frag} {source_display} [reports {event_type}]({lsr_url}) at {time_str} -- "
+                f"{peak_wind_summary}{remarks if remarks else 'No additional remarks.'}\n"
                 f"[<t:{int(lsr_ts)}:R>]"
             )
 

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -684,7 +684,7 @@ class WarningsCog(commands.Cog):
             logger.warning(f"[WARN] Failed to persist {vtec_id}: {e}")
 
     async def _check_and_log_significant_event(self, event: str, raw_text: str, vtec: dict):
-        """Parse warning text for confirmed tornadoes or high-end hail/wind and log to DB."""
+        """Parse warning text for confirmed tornadoes and log to DB."""
         text_upper = (raw_text or "").upper()
         vtec_id = vtec.get("vtec_id", "Unknown")
         
@@ -724,42 +724,6 @@ class WarningsCog(commands.Cog):
                 raw_text=raw_text
             )
             logger.info(f"[WARN] Logged confirmed tornado for {vtec_id} (match: {match_id is not None})")
-
-        # 2. High-end Hail (>= 3.00 IN)
-        m_hail = re.search(r"HAIL\.\.\.?([\d\.]+)\s*IN", text_upper)
-        if m_hail:
-            try:
-                size = float(m_hail.group(1))
-                if size >= 3.0:
-                    await add_significant_event(
-                        event_id=f"NWS:WARN:HAIL:{vtec_id}",
-                        event_type="Hail",
-                        location="Affected Area",
-                        magnitude=f"{size} IN",
-                        vtec_id=vtec_id,
-                        source=vtec.get("office", "NWS"),
-                        raw_text=raw_text
-                    )
-            except ValueError:
-                pass
-
-        # 3. High-end Wind (>= 80 MPH)
-        m_wind = re.search(r"WIND\.\.\.?([\d\.]+)\s*MPH", text_upper)
-        if m_wind:
-            try:
-                speed = float(m_wind.group(1))
-                if speed >= 80.0:
-                    await add_significant_event(
-                        event_id=f"NWS:WARN:WIND:{vtec_id}",
-                        event_type="Wind",
-                        location="Affected Area",
-                        magnitude=f"{speed} MPH",
-                        vtec_id=vtec_id,
-                        source=vtec.get("office", "NWS"),
-                        raw_text=raw_text
-                    )
-            except ValueError:
-                pass
 
     @app_commands.command(name="recenttornadoes", description="List confirmed tornadoes from recent warnings and reports")
     @app_commands.describe(range="Time range to look back")


### PR DESCRIPTION
This PR addresses recent concerns:
- Fixed the 404 MD index fallback URL by switching to the IEM retrieve.py JSON endpoint.
- Updated auto_post_md to skip cycles if both SPC and IEM fail, preventing false cancellations.
- Refined Significant Weather tracking to only include confirmed Tornadoes (skipping Hail and Wind) in both Warnings and Reports cogs.
- Cleaned up LSR poll and handler to align with the new Tornado-only tracking strategy.