### PR TITLE
feat: Tornado Dashboard and EF rating distinctions

### DIFF
--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -361,6 +361,9 @@ class ReportsCog(commands.Cog):
                 await add_posted_survey(guid)
                 await prune_posted_surveys()
                 logger.info(f"[REPORTS] Posted Autoplot 253 for {guid} ({label})")
+                
+                from utils.events_db import link_dat_guid_to_tornado
+                await link_dat_guid_to_tornado(event_date, guid, label)
 
         except Exception as e:
             logger.warning(f"[REPORTS] Survey check failed for {event_date}: {e}")

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -19,7 +19,7 @@ import json as _json
 import logging
 import re
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
 import discord
@@ -515,61 +515,135 @@ def _extract_narrative(raw: str) -> Optional[str]:
     return text or None
 
 
-class SignificantEventsPaginatorView(discord.ui.View):
+class TornadoDashboardView(discord.ui.View):
     def __init__(self, events: list, title: str):
         super().__init__(timeout=300)
         self.events = events
         self.title = title
-        self.page = 0
-        self.per_page = 10
-        self.max_page = (len(events) - 1) // self.per_page
-        self._update_buttons()
+        
+        # Group by date (UTC)
+        self.grouped = {}
+        for e in events:
+            dt = datetime.fromtimestamp(e['timestamp'], timezone.utc)
+            date_str = dt.strftime("%Y-%m-%d")
+            if date_str not in self.grouped:
+                self.grouped[date_str] = []
+            self.grouped[date_str].append(e)
+            
+        self.dates = sorted(list(self.grouped.keys()), reverse=True)
+        
+        # Build select options
+        options = [
+            discord.SelectOption(label="Summary Dashboard", value="summary", default=True)
+        ]
+        for d in self.dates[:24]: # max 25 options total
+            options.append(discord.SelectOption(label=f"Events for {d}", value=d))
+            
+        self.select = discord.ui.Select(options=options, custom_id="date_select")
+        self.select.callback = self.on_select
+        self.add_item(self.select)
+        
+        # Add Tornado Archive link button
+        if events:
+            min_ts = min(e['timestamp'] for e in events)
+            max_ts = max(e['timestamp'] for e in events)
+            min_dt = datetime.fromtimestamp(min_ts, timezone.utc).strftime("%Y-%m-%dT00:00Z")
+            # For end, add 1 day to max_ts to ensure we cover the interval
+            max_dt = (datetime.fromtimestamp(max_ts, timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%dT00:00Z")
+            url = f"https://tornadoarchive.com/home/tornado-archive-data-explorer/#interval={min_dt};{max_dt}&map=-97.1249;45.5585;4.01&domain=North%20America&filters=partition|PartitionFilter|f_scale|(E)FU,(E)F0,(E)F1,(E)F2,(E)F3,(E)F4,(E)F5"
+            self.add_item(discord.ui.Button(label="Tornado Archive", url=url, style=discord.ButtonStyle.link))
 
-    def _update_buttons(self):
-        self.prev_btn.disabled = self.page == 0
-        self.next_btn.disabled = self.page >= self.max_page
+    async def on_select(self, interaction: discord.Interaction):
+        val = self.select.values[0]
+        for opt in self.select.options:
+            opt.default = (opt.value == val)
+            
+        if val == "summary":
+            embed = self.build_summary_embed()
+        else:
+            embed = self.build_daily_embed(val)
+            
+        await interaction.response.edit_message(embed=embed, view=self)
+        
+    def _get_ef_emoji(self, mag: str) -> str:
+        mag = (mag or "").upper()
+        if "EF5" in mag: return "🟣"
+        if "EF4" in mag: return "🔴"
+        if "EF3" in mag: return "🟠"
+        if "EF2" in mag: return "🟡"
+        if "EF1" in mag: return "🟢"
+        if "EF0" in mag: return "🔵"
+        return "⚪"
 
-    def build_embed(self) -> discord.Embed:
-        start = self.page * self.per_page
-        end = start + self.per_page
-        page_events = self.events[start:end]
-
+    def build_summary_embed(self) -> discord.Embed:
         embed = discord.Embed(
             title=self.title,
-            color=discord.Color.red() if "Tornado" in self.title else discord.Color.dark_red(),
+            color=discord.Color.red(),
             timestamp=datetime.now(timezone.utc)
         )
         
-        for e in page_events:
-            rel_time = f"<t:{int(e['timestamp'])}:R>"
+        for date_str in self.dates[:15]: # Display summary for up to 15 days to fit embed limits
+            day_events = self.grouped[date_str]
+            counts = {"EF5": 0, "EF4": 0, "EF3": 0, "EF2": 0, "EF1": 0, "EF0": 0, "EFU": 0}
+            for e in day_events:
+                mag = (e.get("magnitude") or "").upper()
+                matched = False
+                for scale in ["EF5", "EF4", "EF3", "EF2", "EF1", "EF0"]:
+                    if scale in mag:
+                        counts[scale] += 1
+                        matched = True
+                        break
+                if not matched:
+                    counts["EFU"] += 1
             
-            mag = e.get("magnitude", "")
-            # Cleaner rating display: "EF2" or "Confirmed"
-            rating_str = f" ({mag})" if mag and mag != "Confirmed" else ""
+            parts = []
+            if counts["EF5"]: parts.append(f"🟣 {counts['EF5']} EF5")
+            if counts["EF4"]: parts.append(f"🔴 {counts['EF4']} EF4")
+            if counts["EF3"]: parts.append(f"🟠 {counts['EF3']} EF3")
+            if counts["EF2"]: parts.append(f"🟡 {counts['EF2']} EF2")
+            if counts["EF1"]: parts.append(f"🟢 {counts['EF1']} EF1")
+            if counts["EF0"]: parts.append(f"🔵 {counts['EF0']} EF0")
+            if counts["EFU"]: parts.append(f"⚪ {counts['EFU']} Unrated")
             
-            val = (
-                f"**Location:** {e['location']}\n"
-                f"**Office:** {e['source']} | **Time:** {rel_time}"
-            )
-            if e.get("vtec_id"):
-                val += f"\n**VTEC:** `{e['vtec_id']}`"
+            val = ", ".join(parts) if parts else "No ratings available"
+            embed.add_field(name=f"📅 {date_str} ({len(day_events)} Tornadoes)", value=val, inline=False)
             
-            embed.add_field(name=f"🌪️ Tornado{rating_str}", value=val, inline=False)
-
-        embed.set_footer(text=f"Page {self.page + 1} of {self.max_page + 1} | Showing {start + 1}-{min(end, len(self.events))} of {len(self.events)} events.")
+        embed.set_footer(text="Select a date from the dropdown to view specific events.")
         return embed
-
-    @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
-    async def prev_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
-        self.page = max(0, self.page - 1)
-        self._update_buttons()
-        await interaction.response.edit_message(embed=self.build_embed(), view=self)
-
-    @discord.ui.button(label="Next ▶", style=discord.ButtonStyle.secondary)
-    async def next_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
-        self.page = min(self.max_page, self.page + 1)
-        self._update_buttons()
-        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+        
+    def build_daily_embed(self, date_str: str) -> discord.Embed:
+        day_events = self.grouped[date_str]
+        # Sort chronologically for daily view
+        day_events = sorted(day_events, key=lambda x: x["timestamp"])
+        
+        embed = discord.Embed(
+            title=f"🌪️ Tornadoes on {date_str}",
+            color=discord.Color.red(),
+            timestamp=datetime.now(timezone.utc)
+        )
+        
+        for e in day_events[:25]: # Discord max fields is 25
+            rel_time = f"<t:{int(e['timestamp'])}:R>"
+            dt_time = datetime.fromtimestamp(e['timestamp'], timezone.utc).strftime("%H:%MZ")
+            
+            mag = e.get("magnitude", "Confirmed")
+            emoji = self._get_ef_emoji(mag)
+            
+            val = f"**Time:** {dt_time} ({rel_time})\n**Office:** {e['source']}"
+            if e.get("vtec_id"):
+                val += f" | **VTEC:** `{e['vtec_id']}`"
+            
+            if e.get("dat_guid"):
+                val += f"\n[View DAT Track](https://apps.dat.noaa.gov/stormdamage/damageviewer/?datglobalid={e['dat_guid']})"
+            
+            embed.add_field(name=f"{emoji} {e['location']} ({mag})", value=val, inline=False)
+            
+        if len(day_events) > 25:
+            embed.set_footer(text=f"Showing first 25 of {len(day_events)} events for this date.")
+        else:
+            embed.set_footer(text=f"Showing all {len(day_events)} events for this date.")
+            
+        return embed
 
 
 class WarningsCog(commands.Cog):
@@ -806,10 +880,10 @@ class WarningsCog(commands.Cog):
         # Sort by timestamp DESC just in case
         events.sort(key=lambda x: x["timestamp"], reverse=True)
         
-        view = SignificantEventsPaginatorView(events, f"🌪️ Confirmed Tornadoes (Last {range}h)")
-        embed = view.build_embed()
+        view = TornadoDashboardView(events, f"🌪️ Confirmed Tornadoes (Last {range}h)")
+        embed = view.build_summary_embed()
         
-        await interaction.followup.send(embed=embed, view=view if view.max_page > 0 else None)
+        await interaction.followup.send(embed=embed, view=view)
 
     @app_commands.command(name="sigtor", description="List significant (EF2+) tornadoes from recent surveys")
     @app_commands.describe(range="Time range to look back (hours)")
@@ -849,10 +923,10 @@ class WarningsCog(commands.Cog):
         # Sort by timestamp DESC
         sig_events.sort(key=lambda x: x["timestamp"], reverse=True)
         
-        view = SignificantEventsPaginatorView(sig_events, f"🚨 Significant Tornadoes (Last {range}h)")
-        embed = view.build_embed()
+        view = TornadoDashboardView(sig_events, f"🚨 Significant Tornadoes (Last {range}h)")
+        embed = view.build_summary_embed()
         
-        await interaction.followup.send(embed=embed, view=view if view.max_page > 0 else None)
+        await interaction.followup.send(embed=embed, view=view)
 
     # phenom+sig → human-readable event name, for cancellation posts
     _PHENOM_EVENT = {

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -16,6 +16,7 @@ import os
 import re
 import shutil
 import time
+from datetime import datetime, timezone
 from typing import Optional
 
 import aiosqlite
@@ -63,11 +64,18 @@ async def _create_tables(db: aiosqlite.Connection) -> None:
             coords      TEXT,
             timestamp   REAL NOT NULL,
             source      TEXT NOT NULL,
-            raw_text    TEXT
+            raw_text    TEXT,
+            dat_guid    TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_sig_events_type_ts
             ON significant_events (event_type, timestamp DESC);
     """)
+
+    # Migration
+    try:
+        await db.execute("ALTER TABLE significant_events ADD COLUMN dat_guid TEXT")
+    except Exception:
+        pass
 
 
 # ── Writes ───────────────────────────────────────────────────────────────────
@@ -82,26 +90,65 @@ async def add_significant_event(
     timestamp: float = 0.0,
     source: str = "",
     raw_text: str = "",
+    dat_guid: str = "",
 ) -> None:
     db = await get_events_db()
     try:
         await db.execute(
             """INSERT INTO significant_events
                (event_id, event_type, location, magnitude, vtec_id, coords,
-                timestamp, source, raw_text)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                timestamp, source, raw_text, dat_guid)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(event_id) DO UPDATE SET
                  magnitude = excluded.magnitude,
                  location  = excluded.location,
                  coords    = excluded.coords,
-                 raw_text  = excluded.raw_text""",
+                 raw_text  = excluded.raw_text,
+                 dat_guid  = CASE WHEN excluded.dat_guid != '' THEN excluded.dat_guid ELSE significant_events.dat_guid END""",
             (event_id, event_type, location, magnitude, vtec_id, coords,
-             timestamp or time.time(), source, raw_text),
+             timestamp or time.time(), source, raw_text, dat_guid),
         )
         await db.commit()
     except Exception as e:
         logger.warning(f"[EVENTS-DB] add_significant_event({event_id}) failed: {e}")
 
+async def link_dat_guid_to_tornado(date_str: str, guid: str, label: str) -> None:
+    """Attempt to link a DAT guid to a tornado based on the label."""
+    db = await get_events_db()
+    try:
+        # Date str is YYYY-MM-DD
+        dt = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        start_ts = dt.timestamp()
+        end_ts = start_ts + 86400
+        
+        async with db.execute(
+            """SELECT event_id, location FROM significant_events
+               WHERE event_type = 'Tornado'
+                 AND timestamp >= ? AND timestamp < ?""",
+            (start_ts - 43200, end_ts + 43200) # Give 12h buffer
+        ) as cur:
+            rows = await cur.fetchall()
+            
+        if not rows:
+            return
+
+        query_words = set(re.findall(r"\w+", label.upper()))
+        best_id, best_score = None, -1
+        for row in rows:
+            overlap = len(query_words & set(re.findall(r"\w+", row["location"].upper())))
+            if overlap > best_score and overlap > 0:
+                best_score, best_id = overlap, row["event_id"]
+                
+        if best_id:
+            await db.execute(
+                "UPDATE significant_events SET dat_guid = ? WHERE event_id = ?",
+                (guid, best_id)
+            )
+            await db.commit()
+            logger.info(f"[EVENTS-DB] Linked DAT {guid} to event {best_id}")
+
+    except Exception as e:
+        logger.warning(f"[EVENTS-DB] link_dat_guid_to_tornado failed: {e}")
 
 # ── Reads ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
This PR introduces a major upgrade to how the bot displays historical tornado data:
- Replaces the flat paginated list with a new TornadoDashboardView that acts as a chronological, 'calendar-style' summary dashboard.
- Makes EF ratings highly distinct using color-coded emojis (EF5, EF4, EF3, EF2, EF1, EF0).
- Integrates a global button linking directly to the Tornado Archive Data Explorer, pre-filtered for the query's time interval.
- Adds a dat_guid column to the significant_events database.
- The ReportsCog now automatically attempts to link new official NWS Damage Assessment Toolkit (DAT) tracks to their respective database events.
- Includes a direct [View DAT Track] hyperlink in the detailed daily view for any matched tornadoes.