### PR TITLE
feat: Tornado Analytics Overhaul and Dashboard Redesign

### DIFF
--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -2,5 +2,5 @@ ALL_EXTENSIONS = [
     "cogs.iembot", "cogs.reports", "cogs.scp", "cogs.outlooks", "cogs.mesoscale", "cogs.watches",
     "cogs.warnings",
     "cogs.status", "cogs.radar", "cogs.csu_mlp", "cogs.ncar",
-    "cogs.sounding", "cogs.hodograph", "cogs.maintenance",
+    "cogs.sounding", "cogs.hodograph", "cogs.maintenance", "cogs.analytics",
 ]

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -1,0 +1,247 @@
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+logger = logging.getLogger("spc_bot")
+
+class AnalyticsCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @app_commands.command(name="topstats", description="Show leading states or WFOs for tornado counts (IEM Autoplot 92/141)")
+    @app_commands.describe(
+        by="Rank by State or NWS Office (WFO)",
+        year="Year to query (default: current year)",
+        source="Source of data (Warnings vs Reports)"
+    )
+    @app_commands.choices(by=[
+        app_commands.Choice(name="State", value="state"),
+        app_commands.Choice(name="WFO", value="wfo"),
+    ])
+    @app_commands.choices(source=[
+        app_commands.Choice(name="Warnings (VTEC)", value="92"),
+        app_commands.Choice(name="Reports (LSR)", value="141"),
+    ])
+    async def top_stats(
+        self, 
+        interaction: discord.Interaction, 
+        by: str = "state", 
+        year: Optional[int] = None,
+        source: str = "92"
+    ):
+        await interaction.response.defer()
+        
+        current_year = datetime.now(timezone.utc).year
+        year = year or current_year
+        
+        # Build URL for IEM Autoplot
+        # #92: v:TO.W (Tornado Warning), s: (state/wfo), year
+        # #141: v:TO (Tornado LSR), s: (state/wfo), year
+        v_param = "TO.W" if source == "92" else "TO"
+        unit_param = "state" if by == "state" else "wfo"
+        
+        url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/{source}/v:{v_param}::{unit_param}:all::year:{year}.png"
+        
+        embed = discord.Embed(
+            title=f"📊 Top Tornado {'Warnings' if source == '92' else 'Reports'} by {by.upper()} ({year})",
+            color=discord.Color.blue(),
+            timestamp=datetime.now(timezone.utc)
+        )
+        embed.set_image(url=url)
+        embed.set_footer(text=f"Data provided by IEM Autoplot #{source}")
+        
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(name="dayssince", description="Show the streak since the last Tornado Warning (IEM Autoplot 235)")
+    @app_commands.describe(
+        wfo="4-letter WFO code (e.g. KOUN, leave blank for national map)",
+        state="2-letter State code (e.g. OK, used if WFO is blank)"
+    )
+    async def days_since(
+        self, 
+        interaction: discord.Interaction, 
+        wfo: Optional[str] = None,
+        state: Optional[str] = None
+    ):
+        await interaction.response.defer()
+        
+        param = "national"
+        if wfo:
+            wfo = wfo.upper()
+            if wfo.startswith("K") and len(wfo) == 4:
+                wfo = wfo[1:]
+            param = f"wfo:{wfo}"
+        elif state:
+            param = f"state:{state.upper()}"
+            
+        url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/235/v:TO.W::{param}.png"
+        
+        embed = discord.Embed(
+            title="⏳ Days Since Last Tornado Warning",
+            color=discord.Color.green(),
+            timestamp=datetime.now(timezone.utc)
+        )
+        embed.set_image(url=url)
+        embed.set_footer(text="Data provided by IEM Autoplot #235")
+        
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(name="dailyrecap", description="Visual summary of all tornado warning polygons for a day (IEM Autoplot 203)")
+    @app_commands.describe(date="Date in YYYY-MM-DD format (default: yesterday)")
+    async def daily_recap(self, interaction: discord.Interaction, date: Optional[str] = None):
+        await interaction.response.defer()
+        
+        if not date:
+            yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+            date = yesterday.strftime("%Y-%m-%d")
+            
+        url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/203/date:{date}::v:TO.W.png"
+        
+        embed = discord.Embed(
+            title=f"🗺️ Tornado Warning Recap: {date}",
+            color=discord.Color.red(),
+            timestamp=datetime.now(timezone.utc)
+        )
+        embed.set_image(url=url)
+        embed.set_footer(text="Data provided by IEM Autoplot #203")
+        
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(name="tornadoheatmap", description="Generate a density map of tornado reports (IEM Autoplot 108)")
+    @app_commands.describe(
+        days="Number of days to look back",
+        state="2-letter State code (optional)"
+    )
+    async def tornado_heatmap(self, interaction: discord.Interaction, days: int = 30, state: Optional[str] = None):
+        await interaction.response.defer()
+        
+        now = datetime.now(timezone.utc)
+        sts = (now - timedelta(days=days)).strftime("%Y-%m-%d%%200000")
+        ets = now.strftime("%Y-%m-%d%%202359")
+        
+        state_param = f"::state:{state.upper()}" if state else ""
+        url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/108/v:TO::sts:{sts}::ets:{ets}{state_param}.png"
+        
+        embed = discord.Embed(
+            title=f"🔥 Tornado Report Heatmap (Last {days} Days)",
+            color=discord.Color.orange(),
+            timestamp=datetime.now(timezone.utc)
+        )
+        embed.set_image(url=url)
+        embed.set_footer(text="Data provided by IEM Autoplot #108")
+        
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(name="riskmap", description="Visualize historical SPC Day 1 outlook risk frequency (IEM Autoplot 232)")
+    @app_commands.describe(
+        threshold="Risk threshold (SLGT, MDT, HIGH)",
+        state="2-letter State code (optional)",
+        years="Number of years to look back (default: 10)"
+    )
+    @app_commands.choices(threshold=[
+        app_commands.Choice(name="Slight Risk", value="SLGT"),
+        app_commands.Choice(name="Enhanced Risk", value="ENH"),
+        app_commands.Choice(name="Moderate Risk", value="MDT"),
+        app_commands.Choice(name="High Risk", value="HIGH"),
+    ])
+    async def risk_map(
+        self, 
+        interaction: discord.Interaction, 
+        threshold: str = "SLGT", 
+        state: Optional[str] = None,
+        years: int = 10
+    ):
+        await interaction.response.defer()
+        
+        now = datetime.now(timezone.utc)
+        sts = (now - timedelta(days=365 * years)).strftime("%Y-%m-%d")
+        ets = now.strftime("%Y-%m-%d")
+        
+        state_param = f"::state:{state.upper()}" if state else ""
+        url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/232/t:threshold::threshold:{threshold}::sts:{sts}::ets:{ets}{state_param}.png"
+        
+        embed = discord.Embed(
+            title=f"📈 Historical {threshold} Risk Frequency (Last {years} Years)",
+            color=discord.Color.dark_green(),
+            timestamp=datetime.now(timezone.utc)
+        )
+        embed.set_image(url=url)
+        embed.set_footer(text="Data provided by IEM Autoplot #232")
+        
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(name="verify", description="Storm-based warning verification metrics via IEM Cow")
+    @app_commands.describe(
+        wfo="3-letter WFO code (e.g. OUN, BMX)",
+        days="Number of days to look back (default: 30)",
+        phenomena="VTEC phenomena (TO for Tornado, SV for Severe Thunderstorm)"
+    )
+    @app_commands.choices(phenomena=[
+        app_commands.Choice(name="Tornado (TO)", value="TO"),
+        app_commands.Choice(name="Severe Thunderstorm (SV)", value="SV"),
+        app_commands.Choice(name="Flash Flood (FF)", value="FF"),
+    ])
+    async def verify(
+        self, 
+        interaction: discord.Interaction, 
+        wfo: str, 
+        days: int = 30,
+        phenomena: str = "TO"
+    ):
+        await interaction.response.defer()
+        
+        wfo = wfo.upper()
+        if wfo.startswith("K") and len(wfo) == 4:
+            wfo = wfo[1:]
+            
+        now = datetime.now(timezone.utc)
+        sts = (now - timedelta(days=days)).strftime("%Y-%m-%dT00:00Z")
+        ets = now.strftime("%Y-%m-%dT23:59Z")
+        
+        # IEM Cow API
+        url = (
+            f"https://mesonet.agron.iastate.edu/api/1/cow.json"
+            f"?wfo={wfo}&begints={sts}&endts={ets}&phenomena={phenomena}&lsrtype={phenomena}"
+        )
+        
+        from utils.http import http_get_json
+        data = await http_get_json(url)
+        if not data or "stats" not in data:
+            await interaction.followup.send(f"Could not fetch verification data for {wfo}.")
+            return
+            
+        stats = data["stats"]
+        
+        embed = discord.Embed(
+            title=f"🐄 IEM Cow Verification: {wfo} ({phenomena})",
+            description=f"Verification metrics for the last {days} days.",
+            color=discord.Color.blue(),
+            timestamp=datetime.now(timezone.utc)
+        )
+        
+        # POD (Probability of Detection)
+        pod = stats.get("POD[1]", 0.0)
+        # FAR (False Alarm Ratio)
+        far = stats.get("FAR[1]", 0.0)
+        # Lead Time
+        avg_lt = stats.get("avg_leadtime[min]")
+        
+        embed.add_field(name="POD (Detection)", value=f"{pod:.2f}", inline=True)
+        embed.add_field(name="FAR (False Alarm)", value=f"{far:.2f}", inline=True)
+        embed.add_field(name="CSI (Success Index)", value=f"{stats.get('CSI[1]', 0.0):.2f}", inline=True)
+        
+        if avg_lt is not None:
+            embed.add_field(name="Avg Lead Time", value=f"{avg_lt:.1f} min", inline=True)
+            
+        embed.add_field(name="Warnings", value=f"{stats.get('events_total', 0)}", inline=True)
+        embed.add_field(name="Verified", value=f"{stats.get('events_verified', 0)}", inline=True)
+        
+        embed.set_footer(text=f"IEM Cow | Interval: {sts} to {ets}")
+        await interaction.followup.send(embed=embed)
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(AnalyticsCog(bot))

--- a/cogs/maintenance.py
+++ b/cogs/maintenance.py
@@ -64,6 +64,10 @@ class MaintenanceCog(commands.Cog):
                 logger.info(f"[MAINTENANCE] Cleanup complete. Removed {deleted_count} files ({mb_freed:.2f} MB freed)")
             else:
                 logger.info("[MAINTENANCE] Cleanup complete. No files needed deletion.")
+
+            # Prune significant_events older than 365 days
+            from utils.events_db import prune_old_significant_events
+            await prune_old_significant_events(days=365)
                 
         except Exception as e:
             logger.exception(f"[MAINTENANCE] Error during cache cleanup: {e}")

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -119,10 +119,26 @@ class ReportsCog(commands.Cog):
             
             # Dedup check for Tornadoes (Discord side)
             if "TORNADO" in event_type.upper():
-                from utils.state_store import find_matching_tornado
-                match_id = await find_matching_tornado(office, lsr_ts, location, window_hours=1.0)
-                if match_id:
-                    logger.info(f"[REPORTS] Skipping Discord post for Tornado LSR {product_id}, matches {match_id}")
+                from utils.state_store import find_matching_tornado, get_posted_warning_timestamp
+                match = await find_matching_tornado(office, lsr_ts, location, window_hours=1.0)
+                if match:
+                    event_id, vtec_id = match
+                    logger.info(f"[REPORTS] Skipping Discord post for Tornado LSR {product_id}, matches {event_id}")
+                    
+                    # Calculate Lead Time if we have a vtec_id
+                    if vtec_id:
+                        warn_ts = await get_posted_warning_timestamp(vtec_id)
+                        if warn_ts:
+                            lead_time = (lsr_ts - warn_ts) / 60.0
+                            logger.info(f"[REPORTS] Calculated lead time for {event_id}: {lead_time:.1f} min")
+                            from utils.events_db import add_significant_event
+                            # Update existing event with lead time
+                            await add_significant_event(
+                                event_id=event_id,
+                                event_type="Tornado",
+                                location=location,
+                                lead_time=lead_time
+                            )
                     continue
 
             color = discord.Color.blue()
@@ -270,22 +286,22 @@ class ReportsCog(commands.Cog):
             coords = f"{m_latlon.group(1)}N {abs(float(m_latlon.group(2)))}W"
 
         from utils.state_store import find_matching_tornado
-        match_id = await find_matching_tornado(office, event_ts, event_name)
+        match = await find_matching_tornado(office, event_ts, event_name)
         
         # Only log to significant events if it's a Tornado survey
         # (check event_name and rating)
         is_tornado = "TORNADO" in event_name.upper() or rating.startswith("EF")
         
         if is_tornado:
-            if match_id:
-                logger.info(f"[REPORTS] Found matching tornado {match_id} for survey, updating rating to {rating}")
+            if match:
+                event_id, vtec_id = match
+                logger.info(f"[REPORTS] Found matching tornado {event_id} for survey, updating rating to {rating}")
                 # Update existing row by using the same event_id
                 await add_significant_event(
-                    event_id=match_id,
+                    event_id=event_id,
                     event_type="Tornado",
                     location=event_name,
                     magnitude=rating,
-                    vtec_id=None, # Keep existing? add_significant_event in db.py doesn't update vtec_id on conflict yet
                     coords=coords,
                     timestamp=event_ts,
                     source=office,

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -515,13 +515,55 @@ def _extract_narrative(raw: str) -> Optional[str]:
     return text or None
 
 
+class TornadoPhotoView(discord.ui.View):
+    def __init__(self, urls: list, parent_view: discord.ui.View, location: str):
+        super().__init__(timeout=300)
+        self.urls = urls
+        self.parent_view = parent_view
+        self.location = location
+        self.index = 0
+        self._update_buttons()
+
+    def _update_buttons(self):
+        self.prev_btn.disabled = self.index <= 0
+        self.next_btn.disabled = self.index >= len(self.urls) - 1
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"📸 Damage Photos: {self.location}",
+            color=discord.Color.teal(),
+            timestamp=datetime.now(timezone.utc)
+        )
+        embed.set_image(url=self.urls[self.index])
+        embed.set_footer(text=f"Photo {self.index + 1} of {len(self.urls)}")
+        return embed
+
+    @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
+    async def prev_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.index = max(0, self.index - 1)
+        self._update_buttons()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    @discord.ui.button(label="Next ▶", style=discord.ButtonStyle.secondary)
+    async def next_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.index = min(len(self.urls) - 1, self.index + 1)
+        self._update_buttons()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    @discord.ui.button(label="🔙 Back to Card", style=discord.ButtonStyle.primary)
+    async def back_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.edit_message(embed=self.parent_view.build_card_embed(), view=self.parent_view)
+
+
 class TornadoDashboardView(discord.ui.View):
-    def __init__(self, events: list, title: str):
+    def __init__(self, events: list, title: str, mode: str = "card"):
         super().__init__(timeout=300)
         self.events = events
         self.title = title
+        self.mode = mode # "summary" or "card"
+        self.index = 0   # Index for card mode
         
-        # Group by date (UTC)
+        # Group by date (UTC) for summary mode
         self.grouped = {}
         for e in events:
             dt = datetime.fromtimestamp(e['timestamp'], timezone.utc)
@@ -531,50 +573,110 @@ class TornadoDashboardView(discord.ui.View):
             self.grouped[date_str].append(e)
             
         self.dates = sorted(list(self.grouped.keys()), reverse=True)
+        self._update_items()
+
+    def _update_items(self):
+        self.clear_items()
         
-        # Build select options
-        options = [
-            discord.SelectOption(label="Summary Dashboard", value="summary", default=True)
-        ]
-        # Only show dates that have actual tornado events
-        for d in self.dates[:24]: # Discord max options is 25
-            options.append(discord.SelectOption(label=f"Events for {d}", value=d))
+        if self.mode == "summary":
+            # Build select options for summary
+            options = [discord.SelectOption(label="Summary Dashboard", value="summary", default=True)]
+            for d in self.dates[:24]:
+                options.append(discord.SelectOption(label=f"Events for {d}", value=d))
             
-        self.select = discord.ui.Select(options=options, custom_id="date_select")
-        self.select.callback = self.on_select
-        self.add_item(self.select)
-        
-        # Add Tornado Archive link button
-        if events:
-            min_ts = min(e['timestamp'] for e in events)
-            max_ts = max(e['timestamp'] for e in events)
-            # UTC formatting for TornadoArchive
-            min_dt = datetime.fromtimestamp(min_ts, timezone.utc).strftime("%Y-%m-%dT00:00Z")
-            max_dt = (datetime.fromtimestamp(max_ts, timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%dT00:00Z")
+            select = discord.ui.Select(options=options, custom_id="date_select")
+            select.callback = self.on_select
+            self.add_item(select)
+        else:
+            # Card mode navigation
+            self.add_item(self.first_btn)
+            self.add_item(self.prev_btn)
+            self.add_item(self.next_btn)
+            self.add_item(self.last_btn)
+            self.add_item(self.summary_btn)
             
-            # The URL needs to be correctly formatted for the fragment-based state
-            # TornadoArchive uses a specific hash structure
-            import urllib.parse
-            fragment = (
-                f"interval={min_dt};{max_dt}&map=-97.1249;45.5585;4.01&domain=North%20America"
-                f"&filters=partition|PartitionFilter|f_scale|(E)FU,(E)F0,(E)F1,(E)F2,(E)F3,(E)F4,(E)F5"
-            )
-            safe_fragment = urllib.parse.quote(fragment, safe="=&;/-|(),")
-            url = f"https://tornadoarchive.com/home/tornado-archive-data-explorer/#{safe_fragment}"
+            # Add Photos button if event has a dat_guid
+            e = self.events[self.index]
+            if e.get("dat_guid"):
+                self.add_item(self.photos_btn)
+            
+            self.first_btn.disabled = self.index <= 0
+            self.prev_btn.disabled = self.index <= 0
+            self.next_btn.disabled = self.index >= len(self.events) - 1
+            self.last_btn.disabled = self.index >= len(self.events) - 1
+
+        # Global Archive Button
+        if self.events:
+            min_ts = min(e['timestamp'] for e in self.events)
+            max_ts = max(e['timestamp'] for e in self.events)
+            min_dt = datetime.fromtimestamp(min_ts, timezone.utc).strftime("%Y-%m-%d")
+            max_dt = (datetime.fromtimestamp(max_ts, timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%d")
+            
+            # Stable URL format using query parameters
+            url = f"https://tornadoarchive.com/explorer/?start={min_dt}&end={max_dt}&domain=north_america"
             self.add_item(discord.ui.Button(label="Tornado Archive", url=url, style=discord.ButtonStyle.link))
 
     async def on_select(self, interaction: discord.Interaction):
-        val = self.select.values[0]
-        for opt in self.select.options:
-            opt.default = (opt.value == val)
-            
+        val = interaction.data["values"][0]
         if val == "summary":
-            embed = self.build_summary_embed()
+            await interaction.response.edit_message(embed=self.build_summary_embed(), view=self)
         else:
-            embed = self.build_daily_embed(val)
-            
-        await interaction.response.edit_message(embed=embed, view=self)
-        
+            # Switch to card mode at the first event of that day
+            day_events = self.grouped[val]
+            first_event = sorted(day_events, key=lambda x: x["timestamp"], reverse=True)[0]
+            self.index = self.events.index(first_event)
+            self.mode = "card"
+            self._update_items()
+            await interaction.response.edit_message(embed=self.build_card_embed(), view=self)
+
+    @discord.ui.button(label="⏮️ First", style=discord.ButtonStyle.secondary)
+    async def first_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.index = 0
+        self._update_items()
+        await interaction.response.edit_message(embed=self.build_card_embed(), view=self)
+
+    @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
+    async def prev_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.index = max(0, self.index - 1)
+        self._update_items()
+        await interaction.response.edit_message(embed=self.build_card_embed(), view=self)
+
+    @discord.ui.button(label="Next ▶", style=discord.ButtonStyle.secondary)
+    async def next_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.index = min(len(self.events) - 1, self.index + 1)
+        self._update_items()
+        await interaction.response.edit_message(embed=self.build_card_embed(), view=self)
+
+    @discord.ui.button(label="Last ⏭️", style=discord.ButtonStyle.secondary)
+    async def last_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.index = len(self.events) - 1
+        self._update_items()
+        await interaction.response.edit_message(embed=self.build_card_embed(), view=self)
+
+    @discord.ui.button(label="📋 Summary", style=discord.ButtonStyle.primary)
+    async def summary_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.mode = "summary"
+        self._update_items()
+        await interaction.response.edit_message(embed=self.build_summary_embed(), view=self)
+
+    @discord.ui.button(label="📸 Photos", style=discord.ButtonStyle.success)
+    async def photos_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
+        e = self.events[self.index]
+        guid = e.get("dat_guid")
+        if not guid:
+            await interaction.response.send_message("No DAT info available for this event.", ephemeral=True)
+            return
+
+        await interaction.response.defer()
+        from utils.events_db import fetch_dat_photos
+        urls = await fetch_dat_photos(guid)
+        if not urls:
+            await interaction.followup.send("No damage photos found in the DAT for this event.", ephemeral=True)
+            return
+
+        photo_view = TornadoPhotoView(urls, self, e["location"])
+        await interaction.edit_original_response(embed=photo_view.build_embed(), view=photo_view)
+
     def _get_ef_emoji(self, mag: str) -> str:
         mag = (mag or "").upper()
         if "EF5" in mag: return "🟣"
@@ -587,14 +689,11 @@ class TornadoDashboardView(discord.ui.View):
 
     def build_summary_embed(self) -> discord.Embed:
         embed = discord.Embed(
-            title=self.title,
+            title=f"{self.title} (Summary)",
             color=discord.Color.red(),
             timestamp=datetime.now(timezone.utc)
         )
         
-        # Display summary for up to 30 days. If more, they can use the select menu.
-        # Field limits: 25 fields max. We'll group multiple days per field if needed,
-        # or just show the last 25 active days.
         for date_str in self.dates[:25]: 
             day_events = self.grouped[date_str]
             counts = {"EF5": 0, "EF4": 0, "EF3": 0, "EF2": 0, "EF1": 0, "EF0": 0, "EFU": 0}
@@ -622,42 +721,47 @@ class TornadoDashboardView(discord.ui.View):
             embed.add_field(name=f"📅 {date_str} ({len(day_events)})", value=val, inline=True)
             
         embed.set_footer(
-            text=f"Showing last {min(25, len(self.dates))} active days. Select a date from the dropdown for chronological details."
+            text=f"Showing last {min(25, len(self.dates))} active days. Use dropdown to pick a day."
         )
         return embed
         
-    def build_daily_embed(self, date_str: str) -> discord.Embed:
-        day_events = self.grouped[date_str]
-        # Sort chronologically for daily view
-        day_events = sorted(day_events, key=lambda x: x["timestamp"])
+    def build_card_embed(self) -> discord.Embed:
+        e = self.events[self.index]
+        dt = datetime.fromtimestamp(e['timestamp'], timezone.utc)
+        date_str = dt.strftime("%Y-%m-%d %H:%MZ")
+        rel_time = f"<t:{int(e['timestamp'])}:R>"
+        
+        mag = e.get("magnitude", "Confirmed")
+        emoji = self._get_ef_emoji(mag)
         
         embed = discord.Embed(
-            title=f"🌪️ Tornadoes on {date_str}",
+            title=f"{emoji} Tornado: {e['location']}",
             color=discord.Color.red(),
             timestamp=datetime.now(timezone.utc)
         )
         
-        for e in day_events[:25]: # Discord max fields is 25
-            rel_time = f"<t:{int(e['timestamp'])}:R>"
-            dt_time = datetime.fromtimestamp(e['timestamp'], timezone.utc).strftime("%H:%MZ")
+        embed.add_field(name="Rating", value=mag, inline=True)
+        embed.add_field(name="Time", value=f"{date_str}\n({rel_time})", inline=True)
+        embed.add_field(name="Office", value=e['source'], inline=True)
+        
+        if e.get("lead_time") is not None:
+             embed.add_field(name="Lead Time", value=f"{e['lead_time']:.1f} min", inline=True)
+        
+        if e.get("vtec_id"):
+            url = f"https://mesonet.agron.iastate.edu/vtec/f/{dt.year}-O-NEW-{e['source']}-TO-W-{e['vtec_id'].split('.')[-1]}_{dt.strftime('%Y-%m-%dT%H:%MZ')}"
+            embed.add_field(name="VTEC ID", value=f"[{e['vtec_id']}]({url})", inline=True)
+
+        if e.get("dat_guid"):
+            dat_url = f"https://apps.dat.noaa.gov/stormdamage/damageviewer/?datglobalid={e['dat_guid']}"
+            embed.add_field(name="NWS DAT", value=f"[View Track]({dat_url})", inline=True)
+
+        if e.get("raw_text"):
+             text = e["raw_text"]
+             if len(text) > 500:
+                  text = text[:497] + "..."
+             embed.add_field(name="Remarks", value=f"```\n{text}\n```", inline=False)
             
-            mag = e.get("magnitude", "Confirmed")
-            emoji = self._get_ef_emoji(mag)
-            
-            val = f"**Time:** {dt_time} ({rel_time})\n**Office:** {e['source']}"
-            if e.get("vtec_id"):
-                val += f" | **VTEC:** `{e['vtec_id']}`"
-            
-            if e.get("dat_guid"):
-                val += f"\n[View DAT Track](https://apps.dat.noaa.gov/stormdamage/damageviewer/?datglobalid={e['dat_guid']})"
-            
-            embed.add_field(name=f"{emoji} {e['location']} ({mag})", value=val, inline=False)
-            
-        if len(day_events) > 25:
-            embed.set_footer(text=f"Showing first 25 of {len(day_events)} events for this date.")
-        else:
-            embed.set_footer(text=f"Showing all {len(day_events)} events for this date.")
-            
+        embed.set_footer(text=f"Event {self.index + 1} of {len(self.events)} | {e['coords']}")
         return embed
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -207,9 +207,11 @@ async def test_find_matching_tornado(isolated_events_db):
         event_id="LSR:1", event_type="Tornado", location="3 SE FLORENCE",
         source="HUN", timestamp=now
     )
-    match_id = await events_db.find_matching_tornado(
+    match = await events_db.find_matching_tornado(
         source="HUN", timestamp=now + 600, location_query="LAUDERDALE COUNTY TORNADO"
     )
+    assert match is not None
+    match_id, vtec_id = match
     assert match_id == "LSR:1"
 
     no_match = await events_db.find_matching_tornado(

--- a/utils/db.py
+++ b/utils/db.py
@@ -452,6 +452,21 @@ async def get_all_posted_warnings() -> dict:
         return {}
 
 
+async def get_posted_warning_timestamp(vtec_id: str) -> Optional[float]:
+    """Get the posted_at timestamp for a specific VTEC ID."""
+    try:
+        db = await get_db()
+        async with db.execute(
+            "SELECT posted_at FROM posted_warnings WHERE vtec_id = ?",
+            (vtec_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+            return row["posted_at"] if row else None
+    except Exception as e:
+        logger.warning(f"[DB] get_posted_warning_timestamp failed: {e}")
+        return None
+
+
 async def add_posted_warning(
     vtec_id: str, message_id: int, channel_id: int, posted_at: float = 0.0, area: str = ""
 ):

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -17,7 +17,7 @@ import re
 import shutil
 import time
 from datetime import datetime, timezone
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import aiosqlite
 
@@ -65,7 +65,8 @@ async def _create_tables(db: aiosqlite.Connection) -> None:
             timestamp   REAL NOT NULL,
             source      TEXT NOT NULL,
             raw_text    TEXT,
-            dat_guid    TEXT
+            dat_guid    TEXT,
+            lead_time   REAL
         );
         CREATE INDEX IF NOT EXISTS idx_sig_events_type_ts
             ON significant_events (event_type, timestamp DESC);
@@ -74,6 +75,11 @@ async def _create_tables(db: aiosqlite.Connection) -> None:
     # Migration
     try:
         await db.execute("ALTER TABLE significant_events ADD COLUMN dat_guid TEXT")
+    except Exception:
+        pass
+
+    try:
+        await db.execute("ALTER TABLE significant_events ADD COLUMN lead_time REAL")
     except Exception:
         pass
 
@@ -91,22 +97,24 @@ async def add_significant_event(
     source: str = "",
     raw_text: str = "",
     dat_guid: str = "",
+    lead_time: float = None,
 ) -> None:
     db = await get_events_db()
     try:
         await db.execute(
             """INSERT INTO significant_events
                (event_id, event_type, location, magnitude, vtec_id, coords,
-                timestamp, source, raw_text, dat_guid)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                timestamp, source, raw_text, dat_guid, lead_time)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(event_id) DO UPDATE SET
                  magnitude = excluded.magnitude,
                  location  = excluded.location,
                  coords    = excluded.coords,
                  raw_text  = excluded.raw_text,
-                 dat_guid  = CASE WHEN excluded.dat_guid != '' THEN excluded.dat_guid ELSE significant_events.dat_guid END""",
+                 dat_guid  = CASE WHEN excluded.dat_guid != '' THEN excluded.dat_guid ELSE significant_events.dat_guid END,
+                 lead_time = CASE WHEN excluded.lead_time IS NOT NULL THEN excluded.lead_time ELSE significant_events.lead_time END""",
             (event_id, event_type, location, magnitude, vtec_id, coords,
-             timestamp or time.time(), source, raw_text, dat_guid),
+             timestamp or time.time(), source, raw_text, dat_guid, lead_time),
         )
         await db.commit()
     except Exception as e:
@@ -150,6 +158,49 @@ async def link_dat_guid_to_tornado(date_str: str, guid: str, label: str) -> None
     except Exception as e:
         logger.warning(f"[EVENTS-DB] link_dat_guid_to_tornado failed: {e}")
 
+async def fetch_dat_photos(guid: str) -> List[str]:
+    """Retrieve damage photo URLs for a given DAT event_id (guid)."""
+    from utils.http import http_get_json
+    
+    # 1. Query Layer 0 (Points) to find ObjectIDs for this event
+    query_url = (
+        "https://services.dat.noaa.gov/arcgis/rest/services/nws_damageassessmenttoolkit/DamageViewer/FeatureServer/0/query"
+        f"?where=event_id='{guid}'&outFields=objectid&f=json"
+    )
+    
+    data = await http_get_json(query_url)
+    if not data or "features" not in data:
+        return []
+        
+    object_ids = [f["attributes"]["objectid"] for f in data["features"]]
+    if not object_ids:
+        return []
+        
+    # 2. Query Attachments for those ObjectIDs
+    # We can use the /queryAttachments endpoint for bulk lookup
+    ids_str = ",".join(str(i) for i in object_ids[:20]) # Limit to 20 points
+    attach_url = (
+        "https://services.dat.noaa.gov/arcgis/rest/services/nws_damageassessmenttoolkit/DamageViewer/FeatureServer/0/queryAttachments"
+        f"?objectIds={ids_str}&f=json"
+    )
+    
+    attach_data = await http_get_json(attach_url)
+    if not attach_data or "attachmentGroups" not in attach_data:
+        return []
+        
+    urls = []
+    for group in attach_data["attachmentGroups"]:
+        parent_id = group["parentObjectId"]
+        for info in group["attachmentInfos"]:
+            if info.get("contentType", "").startswith("image/"):
+                attach_id = info["id"]
+                urls.append(
+                    f"https://services.dat.noaa.gov/arcgis/rest/services/nws_damageassessmenttoolkit/DamageViewer/FeatureServer/0/{parent_id}/attachments/{attach_id}"
+                )
+    
+    return urls
+
+
 # ── Reads ────────────────────────────────────────────────────────────────────
 
 async def get_recent_significant_events(
@@ -173,19 +224,17 @@ async def get_recent_significant_events(
     except Exception as e:
         logger.warning(f"[EVENTS-DB] get_recent_significant_events failed: {e}")
         return []
-
-
 async def find_matching_tornado(
     source: str,
     timestamp: float,
     location_query: str,
     window_hours: float = 12.0,
-) -> Optional[str]:
+) -> Optional[Tuple[str, Optional[str]]]:
     db = await get_events_db()
     try:
         window = window_hours * 3600
         async with db.execute(
-            """SELECT event_id, location FROM significant_events
+            """SELECT event_id, vtec_id, location FROM significant_events
                WHERE event_type = 'Tornado'
                  AND source = ?
                  AND timestamp BETWEEN ? AND ?""",
@@ -194,18 +243,41 @@ async def find_matching_tornado(
             rows = await cur.fetchall()
         if not rows:
             return None
-        if len(rows) == 1:
-            return rows[0]["event_id"]
+
+        # Location-based matching if multiple
         query_words = set(re.findall(r"\w+", location_query.upper()))
-        best_id, best_score = None, -1
+        best_row, best_score = None, -1
         for row in rows:
             overlap = len(query_words & set(re.findall(r"\w+", row["location"].upper())))
             if overlap > best_score:
-                best_score, best_id = overlap, row["event_id"]
-        return best_id
+                best_score, best_row = overlap, row
+
+        if best_row:
+            return best_row["event_id"], best_row["vtec_id"]
+        return None
+
     except Exception as e:
         logger.warning(f"[EVENTS-DB] find_matching_tornado failed: {e}")
         return None
+
+
+async def prune_old_significant_events(days: int = 365) -> int:
+    """Remove events older than N days to keep the database size manageable."""
+    db = await get_events_db()
+    try:
+        cutoff = time.time() - (days * 86400)
+        async with db.execute(
+            "DELETE FROM significant_events WHERE timestamp < ?",
+            (cutoff,)
+        ) as cur:
+            count = cur.rowcount
+        await db.commit()
+        if count > 0:
+            logger.info(f"[EVENTS-DB] Pruned {count} events older than {days} days")
+        return count
+    except Exception as e:
+        logger.warning(f"[EVENTS-DB] Pruning failed: {e}")
+        return 0
 
 
 # ── syncthing snapshot ───────────────────────────────────────────────────────

--- a/utils/http.py
+++ b/utils/http.py
@@ -255,3 +255,33 @@ async def http_head_meta(url: str, timeout: int = 20) -> Optional[Dict[str, str]
         circuit_breaker.record_failure(host)
         logger.warning(f"HEAD meta failed for {url}: {type(e).__name__}: {e}")
         return None
+
+
+async def http_get_json(url: str, retries: int = 1, timeout: int = 15) -> Optional[dict]:
+    """Fetch JSON from a URL with retries and circuit breaker."""
+    parsed = urlparse(url)
+    host = parsed.netloc
+    if circuit_breaker.is_open(host):
+        return None
+
+    try:
+        session = await ensure_session()
+        for attempt in range(retries + 1):
+            async with session.get(
+                url, timeout=aiohttp.ClientTimeout(total=timeout)
+            ) as r:
+                if r.status == 200:
+                    circuit_breaker.record_success(host)
+                    return await r.json()
+                if r.status == 429 or r.status >= 500:
+                    if attempt < retries:
+                        await asyncio.sleep(2**attempt)
+                        continue
+                logger.warning(f"JSON fetch failed for {url}: {r.status}")
+                circuit_breaker.record_failure(host)
+                return None
+    except Exception as e:
+        circuit_breaker.record_failure(host)
+        logger.warning(f"JSON fetch error for {url}: {type(e).__name__}: {e}")
+        return None
+    return None

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -669,7 +669,7 @@ async def find_matching_tornado(
     timestamp: float,
     location_query: str,
     window_hours: float = 12.0,
-) -> Optional[str]:
+) -> Optional[Tuple[str, Optional[str]]]:
     from utils.events_db import find_matching_tornado as _find  # noqa: PLC0415
     return await _find(source, timestamp, location_query, window_hours)
 


### PR DESCRIPTION
This PR completes the Meteorological Analytics and Dashboard redesign:
- Redesigned Tornado Dashboard: Switches to a 'Single Card' UI with First / Last and Prev / Next navigation.
- Damage Photo Carousel: Integrated a Photos button that opens a scrollable carousel of official NWS DAT damage photos for matched tornadoes.
- Lead Time Tracking: Automatically calculates and displays warning-to-report lead time (in minutes).
- New Analytics Cog:
    - /topstats: Rank states/WFOs by tornado warning or report counts.
    - /dayssince: Track warning-free streaks.
    - /dailyrecap: Visual recap maps of warning polygons.
    - /tornadoheatmap: Density maps of tornado reports.
    - /riskmap: Historical frequency of SPC risk categories.
    - /verify: Detailed storm-based verification metrics (POD, FAR, Lead Time) via IEM Cow.
- Maintenance: Implemented a rolling 365-day retention policy for the historical tornado database.