### PR TITLE
fix: prevent false warning cancellation spam

### DIFF
--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -1213,7 +1213,8 @@ class WarningsCog(commands.Cog):
             # Store the vtec dict so disappeared path can use it for graphics
             current_vtec_data[issuance_id] = vtec_dict
 
-            if vtec_dict["action"] == "NEW":
+            # If it's in the poll at all, it hasn't disappeared.
+            if vtec_dict["action"] in ("NEW", "CON", "EXT", "UPG"):
                 current_vtec_ids.add(issuance_id)
 
             if issuance_id in self.bot.state.posted_warnings:


### PR DESCRIPTION
This PR fixes a logic bug in the NWS poll loop:
- Previously, only 'NEW' products were added to the 'current' set.
- If a warning was in a 'CON' (Continued) or 'EXT' (Extended) state, it wasn't counted as current, causing the bot to think it had disappeared and post a duplicate cancellation notice every 30 seconds.
- Added 'NEW', 'CON', 'EXT', and 'UPG' to the current set to ensure stable state tracking.