### PR TITLE
feat: Warning Updates and MD Shield Final Fix

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -648,14 +648,19 @@ class MesoscaleCog(commands.Cog):
                 self._missing_confirmation.pop(num, None)
 
             if diff:
-                # Shield 1: If more than 3 disappear at once, it's likely an index sync error
-                if len(diff) > 3:
+                # Update missing confirmations for all vanished MDs
+                for md_num in diff:
+                    self._missing_confirmation[md_num] = self._missing_confirmation.get(md_num, 0) + 1
+
+                # Shield 1: If more than 3 disappear at once, it's likely an index sync error.
+                # Suppress the entire cycle UNLESS they have been missing for 2+ consecutive checks.
+                max_misses = max(self._missing_confirmation.get(md_num, 0) for md_num in diff)
+                if len(diff) > 3 and max_misses < 2:
                     logger.warning(f"[MD] Mass disappearance detected ({len(diff)} MDs) — suppressing as index lag")
                     return
 
                 for md_num in list(diff):
                     # Shield 2: Require 2 consecutive misses before posting cancellation
-                    self._missing_confirmation[md_num] = self._missing_confirmation.get(md_num, 0) + 1
                     if self._missing_confirmation[md_num] < 2:
                         logger.info(f"[MD] MD #{md_num} missing (count {self._missing_confirmation[md_num]}) — awaiting confirmation")
                         continue

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -139,6 +139,8 @@ _WARNING_STYLE = {
     "Tornado Warning":             ("🌪️", discord.Color.red()),
     "Severe Thunderstorm Warning": ("⛈️", discord.Color.gold()),
     "Flash Flood Warning":         ("🌊", discord.Color.dark_blue()),
+    "Severe Weather Statement":    ("⛈️", discord.Color.gold()),
+    "Flash Flood Statement":       ("🌊", discord.Color.dark_blue()),
     "Special Weather Statement":   ("☁️", discord.Color.blue()),
 }
 
@@ -884,21 +886,36 @@ class WarningsCog(commands.Cog):
                 self.bot.state.active_warnings.pop(vtec_id, None)
             return
 
-        if action != "NEW":
+        # ── Pipeline fast-path for updates (CON, EXT, EXA) ─────────────────────
+        is_update = action in ("CON", "EXT", "EXA")
+        
+        # We only treat it as an update if we have actually posted the issuance.
+        # Otherwise (e.g. startup discovery), it proceeds as an issuance.
+        if is_update and vtec_id not in self.bot.state.posted_warnings:
+            is_update = False
+
+        if not is_update and action != "NEW":
             return
 
-        if vtec_id in self.bot.state.posted_warnings:
+        if not is_update and vtec_id in self.bot.state.posted_warnings:
             return
+
         # Claim the dedup key BEFORE the (possibly slow) Discord send so
         # a concurrent NWS API poll can't double-post.
-        self.bot.state.posted_warnings[vtec_id] = {} # placeholder
+        if not is_update:
+            self.bot.state.posted_warnings[vtec_id] = {} # placeholder
+        
         self.bot.state.active_warnings[vtec_id] = vtec
 
         # Log significant events (tornadoes, hail, wind) to DB
         await self._check_and_log_significant_event(event, raw_text, vtec)
 
         emoji, display_event, color, footer_id = get_warning_style(event, raw_text)
-        concise_text = build_concise_warning_text(display_event, vtec, raw_text=raw_text)
+        
+        prev_area = self.bot.state.posted_warnings.get(vtec_id, {}).get("area", "")
+        concise_text = build_concise_warning_text(
+            display_event, vtec, raw_text=raw_text, is_update=is_update, prev_area=prev_area
+        )
 
         embed = discord.Embed(
             title=f"{emoji} {display_event}",
@@ -923,15 +940,9 @@ class WarningsCog(commands.Cog):
 
         try:
             msg = await channel.send(embed=embed, files=files)
-            logger.info(f"[WARN] Posted (iembot) {event} {vtec_id}")
-            # Update the in-memory mapping with the message info
-            area_desc = ""
-            if "properties" in vtec: # iembot path doesn't usually have this
-                 pass # extracted logic needed?
-            # Actually, area_desc was returned by _post_warning in NWS API path.
-            # iembot path is NEW only for now.
+            logger.info(f"[WARN] Posted (iembot) {event} {vtec_id} ({'Update' if is_update else 'Issuance'})")
             
-            # Simple area extraction for iembot path persistence
+            # Simple area extraction for persistence
             area_m = re.search(r"for (.+?) till", concise_text)
             area_desc = area_m.group(1) if area_m else "affected area"
 
@@ -942,7 +953,7 @@ class WarningsCog(commands.Cog):
             }
         except discord.HTTPException as e:
             # Roll back the dedup claim on a hard send failure
-            if vtec_id in self.bot.state.posted_warnings:
+            if not is_update and vtec_id in self.bot.state.posted_warnings:
                 del self.bot.state.posted_warnings[vtec_id]
             logger.exception(
                 f"[WARN] iembot send failed for {vtec_id}: {e}"

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -220,15 +220,17 @@ async def test_post_warning_now_dedups_against_posted_set(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_post_warning_now_skips_non_NEW_actions(monkeypatch):
-    """SVS / CON / CAN updates arrive via the same iembot stream but
-    aren't initial issuances — PR B only handles NEW. Updates land in
-    PR D."""
-    cog = _make_cog()
+async def test_post_warning_now_posts_CON_updates(monkeypatch):
+    """SVS / CON / EXT updates arrive via the same iembot stream and
+    should be posted as updates if the original issuance was seen."""
+    vtec_id = "KOUN.SV.W.0042"
+    mapping = {vtec_id: {"message_id": 123, "channel_id": 456, "area": "Noble"}}
+    cog = _make_cog(posted=mapping)
 
     import cogs.warnings as warnings_mod
     monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
     monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
+    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
 
     con_text = SAMPLE_RAW.replace(
         "/O.NEW.KOUN.SV.W.0042.", "/O.CON.KOUN.SV.W.0042."
@@ -238,8 +240,11 @@ async def test_post_warning_now_skips_non_NEW_actions(monkeypatch):
         con_text,
         "Severe Thunderstorm Warning",
     )
-    cog.bot.get_channel.return_value.send.assert_not_called()
-    assert "KOUN.SV.W.0042" not in cog.bot.state.posted_warnings
+    
+    channel = cog.bot.get_channel.return_value
+    channel.send.assert_called_once()
+    embed = channel.send.call_args.kwargs["embed"]
+    assert "updates Severe Thunderstorm Warning" in embed.description
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR implements the v5.8 Update Pipeline and resolves the MD Mass-Cancellation Shield bug:
- Warning Updates: Enabled posting of CON, EXT, and EXA actions as concise Update embeds. Added support for SVS (Severe Weather Statement) and FFS (Flash Flood Statement).
- Concise Update Logic: Integrated area difference parsing ('cancels X, continues Y') for iembot-triggered updates.
- MD Shield Fix: Corrected the logic in MesoscaleCog to ensure mass disappearances (>3) are only suppressed for a single cycle, allowing legitimate mass expirations to proceed.
- Improved Visibility: All SPS products are now posted without filtering to maintain debugging visibility.
- Testing: Updated test_warnings.py and test_mesoscale.py to cover the new update pipeline and shield behavior.