### PR TITLE
fix: primary-source verification for MD cancellations

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -27,11 +27,14 @@ _md_index_head: Dict[str, str] = {}
 _md_index_unreachable: bool = False
 
 
-async def fetch_latest_md_numbers(fresh: bool = False) -> List[str]:
+async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[str]], bool]:
     """
     Scrape the SPC MD index page and return a list of current MD number strings.
     Uses a HEAD check first — if the index page hasn't changed since last poll,
     skips the full HTML fetch entirely. Falls back to IEM if SPC is unreachable.
+
+    Returns:
+        (md_numbers, is_fallback)
     """
     global _md_index_head
     logger.debug(f"[MD] Fetching MD numbers (fresh={fresh})")
@@ -48,7 +51,7 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> List[str]:
                     checks.append(meta[key] == _md_index_head.get(key))
             if checks and all(checks):
                 logger.debug("[MD] Index unchanged (HEAD match)")
-                return []
+                return [], False
         if meta:
             _md_index_head.update(meta)
     else:
@@ -81,14 +84,14 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> List[str]:
                     md_nums.add(m.zfill(4))
                 
                 logger.info(f"[MD] IEM fallback returned {len(md_nums)} MDs from last 24h")
-                return sorted(list(md_nums), reverse=True)
+                return sorted(list(md_nums), reverse=True), True
             else:
                 logger.warning("[MD] IEM fallback returned empty text")
         except Exception as e:
             logger.exception(f"[MD] IEM fallback for index failed: {e}")
         
         # If both failed, return None to signal a fetch failure rather than an empty index
-        return None
+        return None, True
 
     if _md_index_unreachable:
         logger.info("[MD] SPC index reachable again")
@@ -105,7 +108,7 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> List[str]:
             result.append(n.zfill(4))
     
     logger.debug(f"[MD] Scraped {len(result)} MD numbers from SPC index")
-    return result
+    return result, False
 
 
 
@@ -499,7 +502,6 @@ class MesoscaleCog(commands.Cog):
         self._md_backoff = TaskBackoff("auto_post_md")
         self._cancelled_mds: set = set()  # MDs cancelled this session — never re-activate
         self._pending_tasks: set[asyncio.Task] = set()
-        self._missing_confirmation: Dict[str, int] = {}  # md_num -> consecutive misses
 
     async def cog_load(self):
         self.auto_post_md.start()
@@ -627,7 +629,7 @@ class MesoscaleCog(commands.Cog):
                 logger.warning("SPC channel not found for auto_post_md")
                 return
 
-            md_numbers = await fetch_latest_md_numbers()
+            md_numbers, is_fallback = await fetch_latest_md_numbers()
             if md_numbers is None:
                 # Both SPC and IEM failed - skip this cycle to avoid false cancellations
                 return
@@ -638,35 +640,14 @@ class MesoscaleCog(commands.Cog):
             current_max = max((int(m) for m in current_mds), default=-1)
 
             # ── MD cancellations ─────────────────────────────────────────────
-            # Run even when current_mds is empty — a successful empty response
-            # means no MDs are active and anything in active_mds should be
-            # cancelled.
-            diff = self.bot.state.active_mds - current_mds
-            
-            # Reset confirmation for anything still on the index
-            for num in current_mds:
-                self._missing_confirmation.pop(num, None)
-
-            if diff:
-                # Update missing confirmations for all vanished MDs
-                for md_num in diff:
-                    self._missing_confirmation[md_num] = self._missing_confirmation.get(md_num, 0) + 1
-
-                # Shield 1: If more than 3 disappear at once, it's likely an index sync error.
-                # Suppress the entire cycle UNLESS they have been missing for 2+ consecutive checks.
-                max_misses = max(self._missing_confirmation.get(md_num, 0) for md_num in diff)
-                if len(diff) > 3 and max_misses < 2:
-                    logger.warning(f"[MD] Mass disappearance detected ({len(diff)} MDs) — suppressing as index lag")
-                    return
-
+            # Run only when NOT in fallback mode. The authoritative source for 
+            # cancellations is the primary SPC index.
+            if not is_fallback:
+                diff = self.bot.state.active_mds - current_mds
                 for md_num in list(diff):
-                    # Shield 2: Require 2 consecutive misses before posting cancellation
-                    if self._missing_confirmation[md_num] < 2:
-                        logger.info(f"[MD] MD #{md_num} missing (count {self._missing_confirmation[md_num]}) — awaiting confirmation")
+                    if md_num in self._cancelled_mds:
+                        self.bot.state.active_mds.discard(md_num)
                         continue
-                    
-                    # Confirmed missing twice
-                    self._missing_confirmation.pop(md_num, None)
 
                     # Protect against index lag only when there are active MDs
                     # to compare against.
@@ -682,7 +663,6 @@ class MesoscaleCog(commands.Cog):
                             )
                             continue
 
-                    self.bot.state.active_mds.discard(md_num)
                     logger.info(
                         f"[MD] MD #{md_num} no longer on index — "
                         f"posting cancellation"
@@ -698,6 +678,7 @@ class MesoscaleCog(commands.Cog):
                     embed.set_footer(text="SPC MD Monitor")
                     try:
                         await channel.send(embed=embed)
+                        self.bot.state.active_mds.discard(md_num)
                         self._cancelled_mds.add(md_num)
                         self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
                         logger.info(
@@ -708,6 +689,8 @@ class MesoscaleCog(commands.Cog):
                             f"[MD] Failed to send cancellation "
                             f"for #{md_num}: {e}"
                         )
+            else:
+                logger.debug("[MD] In fallback mode — skipping cancellation check")
 
             # ── New MDs ────────────────────────────────────────────────────
             for md_num in md_numbers:

--- a/tests/test_mesoscale.py
+++ b/tests/test_mesoscale.py
@@ -1,18 +1,22 @@
-"""
-Tests for cogs/mesoscale.py — focused on the MD cancellation logic (#171 fix).
-"""
+"""Unit tests for cogs.mesoscale — SPC MD monitoring and IEM fallbacks."""
 
-import pytest
+import json as _json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from cogs.mesoscale import MesoscaleCog
+import discord
+import pytest
+
+from cogs.mesoscale import MesoscaleCog, fetch_latest_md_numbers
 
 
-def _make_bot(active_mds=None, posted_mds=None, is_primary=True):
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+def _make_bot(posted_mds=None, active_mds=None, is_primary=True):
     bot = MagicMock()
     bot.state.is_primary = is_primary
-    bot.state.active_mds = set(active_mds or [])
     bot.state.posted_mds = set(posted_mds or [])
+    bot.state.active_mds = set(active_mds or [])
     bot.state.last_post_times = {}
     bot.wait_until_ready = AsyncMock()
     channel = AsyncMock()
@@ -20,17 +24,16 @@ def _make_bot(active_mds=None, posted_mds=None, is_primary=True):
     return bot, channel
 
 
-# ── MD Cancellation: empty index ─────────────────────────────────────────────
+# ── MD Cancellations ──────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_cancellation_fires_when_index_empty():
     """Active MD is cancelled when the SPC index returns empty (#171 regression)."""
     bot, channel = _make_bot(active_mds={"0100"})
 
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=[])):
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=([], False))):
         cog = MesoscaleCog(bot)
-        await cog.auto_post_md() # 1st miss
-        await cog.auto_post_md() # 2nd miss (confirmed)
+        await cog.auto_post_md()
 
     channel.send.assert_called_once()
 
@@ -45,7 +48,7 @@ async def test_no_cancellation_when_md_still_active():
     """Active MD is NOT cancelled when it's still in the current index."""
     bot, channel = _make_bot(active_mds={"0100"})
 
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=["0100"])), \
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=(["0100"], False))), \
          patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=(None, None, False, None))):
         cog = MesoscaleCog(bot)
         await cog.auto_post_md()
@@ -62,10 +65,9 @@ async def test_multiple_cancellations_when_index_empty():
     """All active MDs are cancelled when the index goes empty."""
     bot, channel = _make_bot(active_mds={"0100", "0101", "0102"})
 
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=[])):
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=([], False))):
         cog = MesoscaleCog(bot)
-        await cog.auto_post_md() # 1st miss
-        await cog.auto_post_md() # 2nd miss (confirmed)
+        await cog.auto_post_md()
 
     assert channel.send.call_count == 3
 
@@ -77,11 +79,10 @@ async def test_partial_cancellation_when_some_mds_expire():
     """Only expired MDs get cancelled; active ones are spared."""
     bot, channel = _make_bot(active_mds={"0100", "0101"})
 
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=["0101"])), \
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=(["0101"], False))), \
          patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=(None, None, False, None))):
         cog = MesoscaleCog(bot)
-        await cog.auto_post_md() # 1st miss
-        await cog.auto_post_md() # 2nd miss
+        await cog.auto_post_md()
 
     cancel_calls = [
         c for c in channel.send.call_args_list
@@ -93,6 +94,20 @@ async def test_partial_cancellation_when_some_mds_expire():
     assert "0101" in bot.state.active_mds
 
 
+@pytest.mark.asyncio
+async def test_cancellation_skipped_in_fallback():
+    """Approach 2: Cancellations are skipped entirely when in fallback mode."""
+    bot, channel = _make_bot(active_mds={"0100"})
+
+    # Even though index is empty, if is_fallback=True, we don't cancel.
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=([], True))):
+        cog = MesoscaleCog(bot)
+        await cog.auto_post_md()
+
+    channel.send.assert_not_called()
+    assert "0100" in bot.state.active_mds
+
+
 # ── Lag protection ────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
@@ -101,7 +116,7 @@ async def test_lag_protection_spares_newer_md():
     bot, channel = _make_bot(active_mds={"0101"})
 
     # Index has 0100; 0101 is newer so it should be spared
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=["0100"])), \
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=(["0100"], False))), \
          patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=(None, None, False, None))):
         cog = MesoscaleCog(bot)
         await cog.auto_post_md()
@@ -118,20 +133,20 @@ async def test_lag_protection_does_not_spare_older_md():
     """An MD older than the current max is cancelled even with lag guard active."""
     bot, channel = _make_bot(active_mds={"0099"})
 
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=["0100"])), \
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=(["0100"], False))), \
          patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=(None, None, False, None))):
         cog = MesoscaleCog(bot)
-        await cog.auto_post_md() # 1st miss
-        await cog.auto_post_md() # 2nd miss
+        await cog.auto_post_md()
 
     assert "0099" not in bot.state.active_mds
+
 
 @pytest.mark.asyncio
 async def test_year_wraparound_spares_early_year_md():
     """MD 0001 is treated as newer than 9999 (year wraparound guard)."""
     bot, channel = _make_bot(active_mds={"0001"})
 
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=["9999"])), \
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=(["9999"], False))), \
          patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=(None, None, False, None))):
         cog = MesoscaleCog(bot)
         await cog.auto_post_md()
@@ -146,23 +161,22 @@ async def test_standby_does_not_post_cancellations():
     """Standby node skips the entire loop body."""
     bot, channel = _make_bot(active_mds={"0100"}, is_primary=False)
 
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=[])):
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=([], False))):
         cog = MesoscaleCog(bot)
         await cog.auto_post_md()
 
     channel.send.assert_not_called()
 
 
-# ── Discord error on cancellation send ────────────────────────────────────────
+# ── Error handling ────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_cancellation_send_failure_re_adds_md():
-    """If the Discord send fails, the MD is put back in active_mds."""
-    import discord as _discord
+    """If Discord send fails, the MD remains in active_mds for retry."""
     bot, channel = _make_bot(active_mds={"0100"})
-    channel.send.side_effect = _discord.HTTPException(MagicMock(status=500), "server error")
+    channel.send.side_effect = discord.HTTPException(MagicMock(), "failed")
 
-    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=[])):
+    with patch("cogs.mesoscale.fetch_latest_md_numbers", AsyncMock(return_value=([], False))):
         cog = MesoscaleCog(bot)
         await cog.auto_post_md()
 
@@ -187,61 +201,59 @@ def _make_bot_for_post(posted_mds=None, active_mds=None):
 
 @pytest.mark.asyncio
 async def test_post_md_now_dedup_skips_already_posted():
-    """post_md_now returns immediately if the MD is already in posted_mds."""
-    bot, channel = _make_bot_for_post(posted_mds={"0398"})
+    """post_md_now returns immediately if MD is in posted_mds."""
+    bot, channel = _make_bot_for_post(posted_mds={"0100"})
     cog = MesoscaleCog.__new__(MesoscaleCog)
     cog.bot = bot
 
-    await cog.post_md_now("0398")
+    await cog.post_md_now("0100")
 
     channel.send.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_post_md_now_sends_and_marks_posted():
-    """post_md_now posts an embed and records the MD in state."""
+    """Successful post adds MD to posted_mds and active_mds."""
     bot, channel = _make_bot_for_post()
     cog = MesoscaleCog.__new__(MesoscaleCog)
     cog.bot = bot
+    cog._pending_tasks = set()
 
-    with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=("http://img/mcd0398.png", "summary", False, "raw text"))), \
+    # Use a dummy text to trigger upgrade task creation
+    dummy_text = "SPC MD 0100"
+    
+    with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=("img", dummy_text, True, "/path"))), \
          patch("cogs.mesoscale.download_single_image", AsyncMock(return_value=(None, False, None))), \
          patch("cogs.mesoscale.extract_md_body", return_value="Discussion body"), \
          patch("cogs.mesoscale.add_posted_md", AsyncMock()), \
          patch("cogs.mesoscale.clean_md_text_for_discord", return_value="Discussion body"):
-        await cog.post_md_now("398")
+        await cog.post_md_now("100")
 
     channel.send.assert_called_once()
-    assert "0398" in bot.state.posted_mds
-    assert "0398" in bot.state.active_mds
+    assert "0100" in bot.state.posted_mds
+    assert "0100" in bot.state.active_mds
 
 
 @pytest.mark.asyncio
 async def test_post_md_now_no_channel_returns_early():
-    """post_md_now silently returns if the channel is not found."""
+    """Method returns gracefully if channel is missing."""
     bot, _ = _make_bot_for_post()
     bot.get_channel.return_value = None
     cog = MesoscaleCog.__new__(MesoscaleCog)
     cog.bot = bot
 
-    await cog.post_md_now("0398")  # should not raise
+    await cog.post_md_now("0100")  # should not raise
 
 
 @pytest.mark.asyncio
 async def test_post_md_now_send_failure_does_not_mark_posted():
-    """A Discord send failure must not mark the MD as posted — it must be retried next cycle."""
-    import discord as _discord
-
+    """If send fails, MD is not added to posted sets."""
     bot, channel = _make_bot_for_post()
-    channel.send.side_effect = _discord.HTTPException(MagicMock(status=500), "server error")
-
+    channel.send.side_effect = Exception("failed")
     cog = MesoscaleCog.__new__(MesoscaleCog)
     cog.bot = bot
 
-    with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=(None, None, False, None))), \
-         patch("cogs.mesoscale.download_single_image", AsyncMock(return_value=(None, False, None))), \
-         patch("cogs.mesoscale.extract_md_body", return_value=None), \
-         patch("cogs.mesoscale.clean_md_text_for_discord", return_value=None):
+    with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=("img", "sum", True, "/path"))):
         await cog.post_md_now("0398")  # must not raise
 
     assert "0398" not in bot.state.posted_mds
@@ -252,8 +264,6 @@ async def test_post_md_now_send_failure_does_not_mark_posted():
 @pytest.mark.asyncio
 async def test_fetch_md_numbers_parses_iem_fallback_text():
     """When SPC index is empty, IEM retrieve.py text is parsed for MD numbers."""
-    from cogs.mesoscale import fetch_latest_md_numbers
-
     iem_text = (
         "MESOSCALE DISCUSSION 0412\n"
         "Some content...\n\n"
@@ -268,43 +278,40 @@ async def test_fetch_md_numbers_parses_iem_fallback_text():
         iem_text,
     ])), \
     patch("cogs.mesoscale.http_head_meta", AsyncMock(return_value=None)):
-        result = await fetch_latest_md_numbers(fresh=True)
+        result, is_fallback = await fetch_latest_md_numbers(fresh=True)
 
     assert "0412" in result
     assert "0413" in result
+    assert is_fallback is True
 
 
 @pytest.mark.asyncio
 async def test_fetch_md_numbers_returns_none_when_both_sources_fail():
     """If SPC index and IEM fallback both fail, None is returned (not empty list)."""
-    from cogs.mesoscale import fetch_latest_md_numbers
-
     with patch("cogs.mesoscale.http_get_text", AsyncMock(return_value=None)), \
          patch("cogs.mesoscale.http_head_meta", AsyncMock(return_value=None)):
-        result = await fetch_latest_md_numbers(fresh=True)
+        result, is_fallback = await fetch_latest_md_numbers(fresh=True)
 
     assert result is None
+    assert is_fallback is True
 
 
 @pytest.mark.asyncio
 async def test_fetch_md_numbers_zero_pads_md_numbers():
     """MD numbers from IEM are zero-padded to 4 digits."""
-    from cogs.mesoscale import fetch_latest_md_numbers
-
     iem_text = "MESOSCALE DISCUSSION 42\nContent."
 
     with patch("cogs.mesoscale.http_get_text", AsyncMock(side_effect=[None, iem_text])), \
          patch("cogs.mesoscale.http_head_meta", AsyncMock(return_value=None)):
-        result = await fetch_latest_md_numbers(fresh=True)
+        result, is_fallback = await fetch_latest_md_numbers(fresh=True)
 
     assert "0042" in result
+    assert is_fallback is True
 
 
 @pytest.mark.asyncio
 async def test_fetch_md_numbers_deduplicates_repeated_numbers():
     """Duplicate MD numbers in IEM text are returned once each."""
-    from cogs.mesoscale import fetch_latest_md_numbers
-
     iem_text = (
         "MESOSCALE DISCUSSION 0100\n"
         "MESOSCALE DISCUSSION 0100\n"  # duplicate
@@ -313,16 +320,16 @@ async def test_fetch_md_numbers_deduplicates_repeated_numbers():
 
     with patch("cogs.mesoscale.http_get_text", AsyncMock(side_effect=[None, iem_text])), \
          patch("cogs.mesoscale.http_head_meta", AsyncMock(return_value=None)):
-        result = await fetch_latest_md_numbers(fresh=True)
+        result, is_fallback = await fetch_latest_md_numbers(fresh=True)
 
     assert result.count("0100") == 1
     assert "0101" in result
+    assert is_fallback is True
 
 
 @pytest.mark.asyncio
 async def test_fetch_md_numbers_spc_path_uses_head_cache():
     """Unchanged SPC index (HEAD match) returns empty list without full fetch."""
-    from cogs.mesoscale import fetch_latest_md_numbers
     import cogs.mesoscale as md_mod
 
     # Seed a cached HEAD so the comparison can match
@@ -334,9 +341,10 @@ async def test_fetch_md_numbers_spc_path_uses_head_cache():
         "last_modified": "Thu, 01 Jan 2026 00:00:00 GMT",
         "content_length": "12345",
     })), patch("cogs.mesoscale.http_get_text") as mock_get:
-        result = await fetch_latest_md_numbers(fresh=False)
+        result, is_fallback = await fetch_latest_md_numbers(fresh=False)
 
     assert result == []
+    assert is_fallback is False
     mock_get.assert_not_called()
 
     # Reset module state for other tests


### PR DESCRIPTION
This PR simplifies the Mesoscale Discussion cancellation logic to improve reliability and eliminate spam during index synchronization flaps:
- **Primary Source Requirement:** Cancellations are now only processed when the authoritative SPC index is successfully reachable.
- **Outage Resilience:** During SPC index outages, the bot falls back to the IEM archive to discover new discussions but skips expiration checks. This prevents false cancellation notices caused by synchronization lag between the two sources.
- **Code Cleanup:** Removed the multi-cycle verification shield and associated state tracking in favor of the simpler source-based rule.
- **Reliability:** Ensured that discussions are only removed from the active set if the cancellation notice is successfully posted to Discord.