### PR TITLE
refactor: Sounding API Optimization

### DIFF
--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -680,7 +680,8 @@ class SoundingCog(commands.Cog):
         # ── Phase 1: gather IEM availability for all stations concurrently ──
         async def _check_avail(station):
             sid = station.get("icao") or station.get("wmo")
-            avail = await get_available_sounding_times_iem(sid, hours_back=24, skip_cache=True)
+            # Use skip_cache=False to utilize any data cached by prewarm_soundings_for_md
+            avail = await get_available_sounding_times_iem(sid, hours_back=24, skip_cache=False)
             if not avail:
                 return None
             y, mo, d, h = avail[0]

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -36,6 +36,7 @@ finally:
 
 from utils.state_store import get_state, set_state  # noqa: E402  # follows sounderpy import
 from utils.geo import haversine
+from utils.http import http_get_json
 
 # ProcessPoolExecutor for parallel sounding plots. Each worker process gets
 # its own matplotlib instance so plots run concurrently without lock contention.
@@ -517,17 +518,11 @@ async def fetch_iem_sounding(station_id: str, year: str, month: str,
     Falls back to SounderPy (Wyoming) if IEM fails.
     """
     ts = f"{year}-{month}-{day}T{hour}:00:00Z"
+    url = f"{IEM_RAOB_URL}?station={station_id}&ts={ts}"
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                IEM_RAOB_URL,
-                params={"station": station_id, "ts": ts},
-                headers={"User-Agent": USER_AGENT},
-                timeout=aiohttp.ClientTimeout(total=15),
-            ) as resp:
-                if resp.status != 200:
-                    return None
-                data = await resp.json()
+        data = await http_get_json(url, retries=1, timeout=15)
+        if not data:
+            return None
 
         profiles = data.get("profiles", [])
         if not profiles or not profiles[0].get("profile"):
@@ -572,17 +567,11 @@ async def get_available_sounding_times_iem(
 
     async def check_hour(dt: datetime) -> Optional[tuple]:
         ts = dt.strftime("%Y-%m-%dT%H:00:00Z")
+        url = f"{IEM_RAOB_URL}?station={station_id}&ts={ts}"
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    IEM_RAOB_URL,
-                    params={"station": station_id, "ts": ts},
-                    headers={"User-Agent": USER_AGENT},
-                    timeout=aiohttp.ClientTimeout(total=8),
-                ) as resp:
-                    if resp.status != 200:
-                        return None
-                    data = await resp.json()
+            data = await http_get_json(url, retries=1, timeout=8)
+            if not data:
+                return None
             profiles = data.get("profiles", [])
             if profiles and profiles[0].get("profile"):
                 return (


### PR DESCRIPTION
This PR addresses critical inefficiencies in the Sounding pipeline (v5.9 roadmap):
- API Abuse Fixed: Rewrote get_available_sounding_times_iem to use the centralized HTTP session pool. Previously, it spawned 25 separate aiohttp sessions per station check, causing massive connection spikes during high-risk sweeps.
- Pre-warming Restored: Fixed a bug where post_soundings_for_watch ignored pre-warmed sounding data by forcing a cache bypass. It now correctly leverages the data pre-fetched by the mesoscale discussion monitor.