### PR TITLE
refactor: Outlook Scraper Optimization

### DIFF
--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -10,7 +10,6 @@ from config import AUTO_CACHE_FILE, SPC_CHANNEL_ID, SPC_URLS, SPC_URLS_FALLBACK
 from utils.backoff import TaskBackoff
 from utils.state_store import set_posted_urls
 from utils.cache import (
-    check_all_urls_exist_parallel,
     check_partial_updates_parallel,
     save_downloaded_images,
 )
@@ -31,9 +30,6 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
     fallback_urls = SPC_URLS_FALLBACK.get(day, [])
     if urls == fallback_urls and state.last_posted_urls.get(day_key) == urls:
         logger.info(f"[Day {day}] Fallback URLs unchanged from last post — skipping")
-        return
-
-    if not await check_all_urls_exist_parallel(urls):
         return
 
     updated_count, total_count, downloaded_data = (
@@ -207,8 +203,6 @@ class OutlooksCog(commands.Cog):
             logger.warning("SPC channel not found for auto_post_spc48")
             return
         urls = SPC_URLS["48"]
-        if not await check_all_urls_exist_parallel(urls):
-            return
         updated_count, total_count, downloaded_data = (
             await check_partial_updates_parallel(urls, self.bot.state.auto_cache)
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,9 +143,9 @@ class TestSpcUrls:
             b"</script></html>"
         )
         with patch(
-            "utils.spc_urls.http_get_bytes",
+            "utils.spc_urls.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(fake_html, 200),
+            return_value=(fake_html, 200, None),
         ):
             urls = await get_spc_urls(1)
 
@@ -165,9 +165,9 @@ class TestSpcUrls:
             b"</script></html>"
         )
         with patch(
-            "utils.spc_urls.http_get_bytes",
+            "utils.spc_urls.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(fake_html, 200),
+            return_value=(fake_html, 200, None),
         ):
             urls = await get_spc_urls(3)
 
@@ -179,9 +179,9 @@ class TestSpcUrls:
         from utils.spc_urls import get_spc_urls
 
         with patch(
-            "utils.spc_urls.http_get_bytes",
+            "utils.spc_urls.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(None, 500),
+            return_value=(None, 500, None),
         ):
             urls = await get_spc_urls(1)
 
@@ -192,9 +192,9 @@ class TestSpcUrls:
 
         fake_html = b"<html><body>No tabs here</body></html>"
         with patch(
-            "utils.spc_urls.http_get_bytes",
+            "utils.spc_urls.http_get_bytes_conditional",
             new_callable=AsyncMock,
-            return_value=(fake_html, 200),
+            return_value=(fake_html, 200, None),
         ):
             urls = await get_spc_urls(1)
 

--- a/utils/spc_urls.py
+++ b/utils/spc_urls.py
@@ -1,29 +1,41 @@
 # utils/spc_urls.py
 import logging
 import re
-from typing import List
+from typing import List, Dict, Tuple, Optional
 
 from config import (
     SPC_OUTLOOK_BASE,
 )
-from utils.http import http_get_bytes
+from utils.http import http_get_bytes_conditional
 
 logger = logging.getLogger("spc_bot")
 
+# Cache to store (etag, last_modified, urls) per day to avoid redundant parsing
+_OUTLOOK_CACHE: Dict[int, Tuple[Optional[str], Optional[str], List[str]]] = {}
 
 async def get_spc_urls(day: int) -> List[str]:
     """
     Scrape the SPC outlook HTML page to resolve the current issuance-time PNG URLs
     introduced with the CIG format on March 3, 2026.
 
+    Uses conditional HTTP requests to avoid re-downloading/parsing unchanged pages.
     Returns empty list if scraping fails — caller will skip posting rather than
     using stale fallback GIFs which may be days old.
     """
     fallback: List[str] = []
     page_url = f"{SPC_OUTLOOK_BASE}/day{day}otlk.html"
+    
+    cached_etag, cached_lm, cached_urls = _OUTLOOK_CACHE.get(day, (None, None, []))
 
     try:
-        content, status = await http_get_bytes(page_url)
+        content, status, new_headers = await http_get_bytes_conditional(
+            page_url, etag=cached_etag, last_modified=cached_lm
+        )
+        
+        if status == 304:
+            logger.debug(f"[DYN_URL] day{day} page unchanged (304 Not Modified)")
+            return cached_urls
+            
         if not content or status != 200:
             logger.warning(
                 f"[DYN_URL] Failed to fetch day{day} page (status={status})"
@@ -64,6 +76,8 @@ async def get_spc_urls(day: int) -> List[str]:
                 return fallback
 
             logger.debug(f"[DYN_URL] Resolved day{day} URLs: {urls}")
+            if new_headers:
+                _OUTLOOK_CACHE[day] = (new_headers.get("etag"), new_headers.get("last_modified"), urls)
             return urls
 
         elif day == 3:
@@ -81,6 +95,8 @@ async def get_spc_urls(day: int) -> List[str]:
                 f"{base}day3{prob_match.group(1)}.png",
             ]
             logger.debug(f"[DYN_URL] Resolved day3 URLs: {urls}")
+            if new_headers:
+                _OUTLOOK_CACHE[day] = (new_headers.get("etag"), new_headers.get("last_modified"), urls)
             return urls
 
     except Exception as e:


### PR DESCRIPTION
This PR addresses HTML scraper inefficiency in the Outlooks pipeline (v5.9 roadmap):

- **Conditional Requests:** Updated `get_spc_urls` to cache and reuse `ETag` and `Last-Modified` headers. The bot now relies on HTTP 304 Not Modified responses rather than fully re-downloading and parsing the SPC HTML indices every 30 seconds.
- **Removed Redundant HEAD Requests:** Removed `check_all_urls_exist_parallel` from the outlook polling loops. The partial updates system correctly handles 404s natively, making the separate HEAD sweep redundant.