### PR TITLE
fix(md): eliminate IEM-fallback active_mds poisoning and HEAD-match false-empty

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -51,7 +51,7 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[st
                     checks.append(meta[key] == _md_index_head.get(key))
             if checks and all(checks):
                 logger.debug("[MD] Index unchanged (HEAD match)")
-                return [], False
+                return None, False  # None → caller skips cycle entirely (no cancellations, no new-MD scan)
         if meta:
             _md_index_head.update(meta)
     else:
@@ -696,7 +696,12 @@ class MesoscaleCog(commands.Cog):
             for md_num in md_numbers:
                 if md_num in self._cancelled_mds:
                     continue  # SPC index flap — don't re-activate a cancelled MD
-                self.bot.state.active_mds.add(md_num)
+                # Only mark as active from the authoritative SPC index. IEM fallback
+                # returns historical MDs (up to 24h old) that may already be cancelled;
+                # adding them here poisons active_mds and triggers false cancellations
+                # the moment SPC comes back up.
+                if not is_fallback:
+                    self.bot.state.active_mds.add(md_num)
                 if md_num in self.bot.state.posted_mds:
                     continue
 
@@ -734,6 +739,9 @@ class MesoscaleCog(commands.Cog):
                         t = asyncio.create_task(self._upgrade_md_message(md_num, msg, full_text))
                         self._pending_tasks.add(t)
                         t.add_done_callback(self._pending_tasks.discard)
+                    # Track in active_mds after a successful post regardless of source —
+                    # we genuinely just announced this MD and need to cancel it later.
+                    self.bot.state.active_mds.add(md_num)
                     self.bot.state.posted_mds.add(md_num)
                     await add_posted_md(str(md_num))
                     await prune_posted_mds()

--- a/tests/test_mesoscale.py
+++ b/tests/test_mesoscale.py
@@ -327,7 +327,12 @@ async def test_fetch_md_numbers_deduplicates_repeated_numbers():
 
 @pytest.mark.asyncio
 async def test_fetch_md_numbers_spc_path_uses_head_cache():
-    """Unchanged SPC index (HEAD match) returns empty list without full fetch."""
+    """Unchanged SPC index (HEAD match) returns None without full fetch.
+
+    None is the skip-cycle sentinel — the caller treats it the same as both
+    sources failing, so no cancellations and no new-MD scans fire on a
+    no-change cycle.
+    """
     import cogs.mesoscale as md_mod
 
     # Seed a cached HEAD so the comparison can match
@@ -341,7 +346,7 @@ async def test_fetch_md_numbers_spc_path_uses_head_cache():
     })), patch("cogs.mesoscale.http_get_text") as mock_get:
         result, is_fallback = await fetch_latest_md_numbers(fresh=False)
 
-    assert result == []
+    assert result is None
     assert is_fallback is False
     mock_get.assert_not_called()
 


### PR DESCRIPTION
## Root cause

Two bugs caused repeated cancellation spam for already-cancelled MDs every time SPC's index had an outage. Three previous fix attempts (v5.6.5, v5.7.9, v5.8.1) all targeted the cancellation side but left the root causes intact.

## Bug 1 — HEAD early-return treated as empty index

`fetch_latest_md_numbers` returned `([], False)` when HEAD validators matched (no-change shortcut). The caller saw `md_numbers=[]` with `is_fallback=False` and diffed `active_mds` against an empty set — cancelling every tracked MD even though SPC was just unchanged, not empty.

**Fix:** Return `(None, False)` on HEAD match. The caller already treats `None` as a skip-cycle sentinel (same path as both-sources-fail), so no cancellations and no new-MD scan fire.

## Bug 2 — IEM fallback poisoned `active_mds`

The New MDs loop called `active_mds.add()` unconditionally, including when `is_fallback=True`. IEM returns historical MDs from the last 24 h, so already-cancelled MDs re-entered `active_mds`. When SPC recovered (`is_fallback=False`), the cancellation diff fired for all of them.

**Fix:** Guard `active_mds.add()` with `if not is_fallback`. After a successful new-MD post, always add to `active_mds` regardless of source — we genuinely announced that MD and need to cancel it later if it expires.

## Test changes

- `test_fetch_md_numbers_spc_path_uses_head_cache`: updated assertion from `result == []` to `result is None`, updated docstring to explain the skip-cycle semantics.