### PR TITLE
fix: MD and Sounding fallback errors

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -130,24 +130,23 @@ async def fetch_md_details_iem(md_number: str) -> Tuple[Optional[str], Optional[
     summary = None
     raw_text = None
     try:
-        content, status = await http_get_bytes(
-            "https://mesonet.agron.iastate.edu/api/1/nwstext.json?product=MCD&limit=50",
-            retries=2, timeout=15
-        )
-        if content and status == 200:
-            data = json.loads(content)
-            for entry in data.get("data", []):
-                text = entry.get("data", "")
+        url = "https://mesonet.agron.iastate.edu/cgi-bin/afos/retrieve.py?pil=SWOMCD&limit=10"
+        text = await http_get_text(url, retries=2, timeout=15)
+        if text:
+            # The text block contains multiple MCDs; find the one we want
+            # Split by the WMO header (ACUS11 KWNS) which precedes each MD
+            products = re.split(r"(?m)^ACUS11 KWNS\s+\d{6}", text)
+            for p in products:
                 if (
-                    f"MESOSCALE DISCUSSION {num_int}" in text.upper()
-                    or f"MESOSCALE DISCUSSION {padded}" in text
+                    f"MESOSCALE DISCUSSION {num_int}" in p.upper()
+                    or f"MESOSCALE DISCUSSION {padded}" in p
                 ):
-                    raw_text = text
-                    concerning = re.search(r"(CONCERNING[^\n<]{10,120})", text, re.IGNORECASE)
+                    raw_text = p
+                    concerning = re.search(r"(CONCERNING[^\n<]{10,120})", p, re.IGNORECASE)
                     if concerning:
                         summary = concerning.group(1).strip()
                     else:
-                        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+                        lines = [ln.strip() for ln in p.splitlines() if ln.strip()]
                         summary = " ".join(lines[:3])[:200]
                     break
     except Exception as e:

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -1,7 +1,6 @@
 # cogs/mesoscale.py
 import asyncio
 import html as _html
-import json
 import logging
 import os
 import re

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -517,6 +517,10 @@ async def fetch_iem_sounding(station_id: str, year: str, month: str,
     Fetch a sounding from IEM and convert to SounderPy clean_data format.
     Falls back to SounderPy (Wyoming) if IEM fails.
     """
+    # Skip 5-digit WMO IDs as IEM's json/raob.py has a 4-char limit
+    if station_id.isdigit() and len(station_id) > 4:
+        return None
+
     ts = f"{year}-{month}-{day}T{hour}:00:00Z"
     url = f"{IEM_RAOB_URL}?station={station_id}&ts={ts}"
     try:
@@ -566,6 +570,11 @@ async def get_available_sounding_times_iem(
             return cached_result
 
     async def check_hour(dt: datetime) -> Optional[tuple]:
+        # Skip 5-digit WMO IDs as IEM's json/raob.py has a 4-char limit
+        # and auto-prepends 'K' to numeric IDs, triggering 422 errors.
+        if station_id.isdigit() and len(station_id) > 4:
+            return None
+
         ts = dt.strftime("%Y-%m-%dT%H:00:00Z")
         url = f"{IEM_RAOB_URL}?station={station_id}&ts={ts}"
         try:


### PR DESCRIPTION
This PR fixes the remaining JSON and 422 errors in the data fallbacks:

- **MD Detail Fallback:** Switched from the broken `nwstext.json` endpoint to the reliable `retrieve.py` service for fetching MCD text when SPC is down.
- **Sounding Availability:** Skip IEM checks for 5-digit WMO IDs. These IDs are currently incompatible with IEM's JSON RAOB service and were triggering thousands of `422 Unprocessable Content` warnings in the logs.
- **Improved Reliability:** Updated parsing logic to handle the multi-MCD text blocks returned by the IEM retrieve service.