### PR TITLE
fix(logging): surface silent exception swallows in reports and events_db

### DIFF
--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -130,7 +130,7 @@ class ReportsCog(commands.Cog):
                 try:
                     lsr_ts = datetime.strptime(product_id[:12], "%Y%m%d%H%M").replace(tzinfo=timezone.utc).timestamp()
                 except Exception:
-                    pass
+                    logger.debug("LSR timestamp parse failed for product_id %r, falling back to now()", product_id)
             
             # Dedup check for Tornadoes (Discord side)
             if "TORNADO" in event_type.upper():
@@ -264,7 +264,7 @@ class ReportsCog(commands.Cog):
                 pns_ts = dt.replace(tzinfo=timezone.utc).timestamp()
                 pns_time_str = dt.strftime("%b %d, %I:%M %p")
             except Exception:
-                pass
+                logger.debug("PNS timestamp parse failed for product_id %r", product_id)
 
         desc = (
             f"{office} issues [Damage Survey PNS]({pns_url}) (Max: {rating_str}){tor_count_msg} at {pns_time_str}\n"

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -82,12 +82,12 @@ async def _create_tables(db: aiosqlite.Connection) -> None:
     try:
         await db.execute("ALTER TABLE significant_events ADD COLUMN dat_guid TEXT")
     except Exception:
-        pass
+        logger.debug("Migration already applied: dat_guid column exists")
 
     try:
         await db.execute("ALTER TABLE significant_events ADD COLUMN lead_time REAL")
     except Exception:
-        pass
+        logger.debug("Migration already applied: lead_time column exists")
 
 
 # ── Writes ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `cogs/reports.py`: LSR and PNS timestamp parse failures on malformed `product_id` strings now log at `DEBUG` level instead of silently discarding the error
- `utils/events_db.py`: Already-applied migration steps (`ALTER TABLE ADD COLUMN`) now log at `DEBUG` level so repeated startups aren't completely silent about skipped steps

## Test plan
- [ ] 343 existing tests pass (verified pre-push)
- [ ] No behavior change — fallback values are identical; only observability improves
- [ ] Confirm `DEBUG`-level logs appear when feeding a malformed `product_id` in a local run