### PR TITLE
feat(watchdog): dual-endpoint probe with operator alerts on degradation

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,6 +30,7 @@ CONFIG = {
     # Test channel for warnings during dev. Override via env once we're
     # ready to point this at production.
     "warnings_channel_id": int(os.getenv("WARNINGS_CHANNEL_ID") or "1336294580743704607"),
+    "dev_channel_id": int(os.getenv("DEV_CHANNEL_ID") or "1336294580743704607"),
     "manual_cache_file": os.getenv("MANUAL_CACHE_FILE", "posted_records.json"),
     "auto_cache_file": os.getenv("AUTO_CACHE_FILE", "auto_posted_records.json"),
     "guild_id": _require_int("GUILD_ID"),
@@ -46,6 +47,7 @@ SPC_CHANNEL_ID = CONFIG["spc_channel_id"]
 HEALTH_CHANNEL_ID = CONFIG["health_channel_id"]
 SOUNDING_CHANNEL_ID = CONFIG["sounding_channel_id"]
 WARNINGS_CHANNEL_ID = CONFIG["warnings_channel_id"]
+DEV_CHANNEL_ID = CONFIG["dev_channel_id"]
 MANUAL_CACHE_FILE = os.path.join(CONFIG["cache_file_dir"], CONFIG["manual_cache_file"])
 AUTO_CACHE_FILE = os.path.join(CONFIG["cache_file_dir"], CONFIG["auto_cache_file"])
 GUILD_ID = CONFIG["guild_id"]

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import discord
 import discord.app_commands
 from discord.ext import commands, tasks
 
-from config import CACHE_DIR, CONFIG, HEALTH_CHANNEL_ID, TOKEN, __version__
+from config import CACHE_DIR, CONFIG, DEV_CHANNEL_ID, HEALTH_CHANNEL_ID, TOKEN, __version__
 import utils.http
 from utils.http import CircuitOpenError
 from utils.state_store import (
@@ -295,21 +295,26 @@ async def watchdog_task():
     if not bot.state.is_primary:
         return
 
-    # Probe an endpoint we actually depend on. NWS API works as a liveness
-    # check and tells us something about SPC/NWS reachability — the things
-    # that would silently break posts. HEAD keeps the check cheap.
-    probe_healthy = False
-    probe_url = "https://api.weather.gov/"
-    if utils.http.http_session is not None and not utils.http.http_session.closed:
+    # Probe two independent endpoints. We only count a failure if BOTH fail —
+    # a single-endpoint outage (e.g. NWS maintenance) shouldn't trigger a
+    # session teardown or operator alert.
+    _PROBE_PRIMARY = "https://api.weather.gov/"
+    _PROBE_SECONDARY = "https://mesonet.agron.iastate.edu/"
+
+    async def _head_ok(url: str) -> bool:
+        if utils.http.http_session is None or utils.http.http_session.closed:
+            return False
         try:
             async with utils.http.http_session.head(
-                probe_url,
-                timeout=aiohttp.ClientTimeout(total=20),
-                allow_redirects=True,
+                url, timeout=aiohttp.ClientTimeout(total=20), allow_redirects=True
             ) as r:
-                probe_healthy = r.status < 500
+                return r.status < 500
         except Exception as e:
-            logger.warning(f"[WATCHDOG] Session probe to {probe_url} failed: {e!r}")
+            logger.warning(f"[WATCHDOG] Session probe to {url} failed: {e!r}")
+            return False
+
+    primary_ok = await _head_ok(_PROBE_PRIMARY)
+    probe_healthy = primary_ok or await _head_ok(_PROBE_SECONDARY)
 
     if probe_healthy:
         if _session_probe_failures > 0:
@@ -322,6 +327,19 @@ async def watchdog_task():
                 f"[WATCHDOG] Session probe failed {_session_probe_failures} consecutive times — "
                 "tearing down and recreating"
             )
+            try:
+                ch = bot.get_channel(DEV_CHANNEL_ID) or await bot.fetch_channel(DEV_CHANNEL_ID)
+                await ch.send(embed=discord.Embed(
+                    title="⚠️ Watchdog: session reset",
+                    description=(
+                        f"Both `{_PROBE_PRIMARY}` and `{_PROBE_SECONDARY}` failed "
+                        f"{_session_probe_failures} consecutive cycles. "
+                        "Tearing down and recreating the aiohttp session."
+                    ),
+                    color=discord.Color.red(),
+                ))
+            except Exception as alert_err:
+                logger.warning(f"[WATCHDOG] Could not send session-reset alert: {alert_err}")
             await utils.http.close_session()
             await utils.http.ensure_session()
             _session_probe_failures = 0
@@ -330,6 +348,19 @@ async def watchdog_task():
                 f"[WATCHDOG] Session probe failed ({_session_probe_failures}/3) — "
                 "waiting for next cycle"
             )
+            if _session_probe_failures == 2:
+                try:
+                    ch = bot.get_channel(DEV_CHANNEL_ID) or await bot.fetch_channel(DEV_CHANNEL_ID)
+                    await ch.send(embed=discord.Embed(
+                        title="⚠️ Watchdog: probe degraded (2/3)",
+                        description=(
+                            f"Both `{_PROBE_PRIMARY}` and `{_PROBE_SECONDARY}` unreachable "
+                            "for 2 consecutive cycles. Session reset on next failure."
+                        ),
+                        color=discord.Color.orange(),
+                    ))
+                except Exception as alert_err:
+                    logger.warning(f"[WATCHDOG] Could not send degradation alert: {alert_err}")
 
     # Grace period for startup race: tasks need a few ticks to schedule
     # their first iteration after wait_until_ready() unblocks.


### PR DESCRIPTION
## Summary
- **Dual-endpoint probe**: watchdog now checks both `api.weather.gov` and `mesonet.agron.iastate.edu` each cycle; a failure only counts if both are unreachable, preventing a single-endpoint NWS outage from triggering a session reset
- **2/3 degradation alert**: orange embed posted to the dev channel when both probes fail for 2 consecutive cycles, giving operators advance warning before the session teardown fires
- **3/3 reset alert**: red embed posted confirming the session teardown when the threshold is reached
- **`DEV_CHANNEL_ID`** added to `config.py` (env var `DEV_CHANNEL_ID`, defaults to `1336294580743704607`)

## Motivation
The v5.9.1 logs showed `api.weather.gov` hitting 2/3 probe failures in the same window that SPC HTML went empty — likely a correlated NWS infra hiccup, not a local session problem. The old probe would have reset a healthy session. The new probe requires both upstreams to be dark before acting.

## Test plan
- [ ] 343 existing tests pass (verified pre-push)
- [ ] Simulate primary probe failure in dev: secondary passes → no counter increment
- [ ] Simulate both probes failing 2 cycles: orange embed appears in dev channel
- [ ] Simulate 3 cycles: red embed + session recreated