### PR TITLE
fix: NWWS failover optimization and channel routing

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -417,6 +417,11 @@ class FailoverCog(commands.Cog):
             except Exception as e:
                 logger.exception(f"[FAILOVER] Failed to load {ext}: {e}")
 
+        # Trigger immediate NWWS connection if available
+        nwws = self.bot.get_cog("NWWSCog")
+        if nwws:
+            asyncio.create_task(nwws.trigger_connection())
+
         try:
             synced = await self.bot.tree.sync()
             logger.info(f"[FAILOVER] Synced {len(synced)} slash commands")

--- a/cogs/nwws.py
+++ b/cogs/nwws.py
@@ -178,6 +178,15 @@ class NWWSCog(commands.Cog):
         if self.xmpp_client:
             self.xmpp_client.disconnect()
 
+    async def trigger_connection(self):
+        """Immediately attempt to connect to NWWS-OI (called by FailoverCog)."""
+        if not self._should_be_connected:
+            self._should_be_connected = True
+            if not self.monitor_connection.is_running():
+                self.monitor_connection.start()
+        
+        await self.monitor_connection()
+
     @tasks.loop(seconds=30)
     async def monitor_connection(self):
         """Maintain persistent connection to NWWS-OI."""


### PR DESCRIPTION
Implements an immediate NWWS connection trigger upon node promotion to Primary, eliminating the 30-second gap. This branch also includes the .env fix for WARNINGS_CHANNEL_ID to resolve the routing bug.