### PR TITLE
test: upgrade to Python 3.13 for performance

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: pip
           cache-dependency-path: requirements-dev.txt
       - name: System build deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: pip
           cache-dependency-path: requirements-dev.txt
       - run: pip install ruff
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: pip
           cache-dependency-path: requirements-dev.txt
       - name: System build deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM python:3.12-slim-bookworm AS builder
+FROM python:3.13-slim-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -32,7 +32,7 @@ COPY requirements.txt .
 RUN pip wheel --no-cache-dir --wheel-dir /build/wheels -r requirements.txt
 
 # Runtime stage
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -584,6 +584,7 @@ class MesoscaleCog(commands.Cog):
         channel = self.bot.get_channel(SPC_CHANNEL_ID)
         if not channel:
             return
+        self.bot.state.posted_mds.add(md_num)
         logger.info(f"[MD] iembot-triggered post for #{md_num}")
         image_url, summary, from_cache, raw_text = await fetch_md_details(md_num)
         if raw_text:
@@ -605,7 +606,6 @@ class MesoscaleCog(commands.Cog):
         try:
             msg = await channel.send(embeds=[img_embed, text_embed], files=files)
             self.bot.state.active_mds.add(md_num)
-            self.bot.state.posted_mds.add(md_num)
             await add_posted_md(str(md_num))
             self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
             if not cache_path or not full_text:

--- a/tests/test_mesoscale.py
+++ b/tests/test_mesoscale.py
@@ -244,8 +244,8 @@ async def test_post_md_now_no_channel_returns_early():
 
 
 @pytest.mark.asyncio
-async def test_post_md_now_send_failure_does_not_mark_posted():
-    """If send fails, MD is not added to posted sets."""
+async def test_post_md_now_marks_posted_before_send():
+    """MD is marked as posted immediately to prevent concurrent duplicate posts."""
     bot, channel = _make_bot_for_post()
     channel.send.side_effect = Exception("failed")
     cog = MesoscaleCog.__new__(MesoscaleCog)
@@ -254,7 +254,7 @@ async def test_post_md_now_send_failure_does_not_mark_posted():
     with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=("img", "sum", True, "/path"))):
         await cog.post_md_now("0398")  # must not raise
 
-    assert "0398" not in bot.state.posted_mds
+    assert "0398" in bot.state.posted_mds
 
 
 # ── fetch_latest_md_numbers — IEM fallback parse path ────────────────────────


### PR DESCRIPTION
## Summary
Test Python 3.13 upgrade to verify performance gains and compatibility with geospatial dependencies.

- Updates Dockerfile to use `python:3.13-slim-bookworm` (builder and runtime)
- Updates CI workflows to test with Python 3.13
- Also fixes concurrent duplicate MCD posts from iembot (#635 posted twice)

## Testing
All local tests passed (363 tests). Awaiting GitHub CI validation for any geospatial lib incompatibilities.

## Notes
If CI passes, this is safe to merge without additional changes. If there are failures, they'll likely surface as numpy/scipy/Cartopy version constraint issues.