### PR TITLE
feat(status): add real-time latency metrics

### DIFF
--- a/cogs/iembot.py
+++ b/cogs/iembot.py
@@ -164,6 +164,19 @@ class IEMBotCog(commands.Cog):
                 product_id = msg.get("product_id", "")
                 if not product_id:
                     continue
+                
+                # Track IEMBot wire latency
+                try:
+                    from datetime import datetime as dt_class, timezone as tz_class
+                    ts_str = product_id.split("-")[0]
+                    issue_dt = dt_class.strptime(ts_str, "%Y%m%d%H%M").replace(tzinfo=tz_class.utc)
+                    latency = (dt_class.now(tz_class.utc) - issue_dt).total_seconds()
+                    if self.bot.state.iembot_latency == 0:
+                        self.bot.state.iembot_latency = latency
+                    else:
+                        self.bot.state.iembot_latency = (self.bot.state.iembot_latency * 0.9) + (latency * 0.1)
+                except Exception:
+                    pass
 
                 if "WWUS20-SEL" in product_id or "WWUS40-SEL" in product_id:
                     t = asyncio.create_task(self._handle_watch(product_id))
@@ -322,6 +335,19 @@ class IEMBotCog(commands.Cog):
                 product_id = msg.get("product_id", "")
                 if not product_id:
                     continue
+                
+                # Track IEMBot wire latency
+                try:
+                    from datetime import datetime as dt_class, timezone as tz_class
+                    ts_str = product_id.split("-")[0]
+                    issue_dt = dt_class.strptime(ts_str, "%Y%m%d%H%M").replace(tzinfo=tz_class.utc)
+                    latency = (dt_class.now(tz_class.utc) - issue_dt).total_seconds()
+                    if self.bot.state.iembot_latency == 0:
+                        self.bot.state.iembot_latency = latency
+                    else:
+                        self.bot.state.iembot_latency = (self.bot.state.iembot_latency * 0.9) + (latency * 0.1)
+                except Exception:
+                    pass
 
                 pil_match = self._ISSUANCE_PIL_RE.search(product_id)
                 if pil_match:

--- a/cogs/nwws.py
+++ b/cogs/nwws.py
@@ -139,6 +139,19 @@ class NWWSClient(ClientXMPP):
             ts_str = payload['issue'] or time.strftime("%Y%m%d%H%M", time.gmtime())
             product_id = f"{ts_str}-{office}-{ttaaii}-{afos_pil}"
 
+            # Track NWWS wire latency (rough estimate to minute precision)
+            try:
+                from datetime import datetime as dt_class, timezone as tz_class
+                issue_dt = dt_class.strptime(ts_str[:12], "%Y%m%d%H%M").replace(tzinfo=tz_class.utc)
+                latency = (dt_class.now(tz_class.utc) - issue_dt).total_seconds()
+                # Update rolling average or just last seen
+                if self.bot.state.nwws_latency == 0:
+                    self.bot.state.nwws_latency = latency
+                else:
+                    self.bot.state.nwws_latency = (self.bot.state.nwws_latency * 0.9) + (latency * 0.1)
+            except Exception:
+                pass
+
             # 2. Routing Logic
             
             # WATCHES (SEL products)

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -252,6 +252,21 @@ class StatusView(discord.ui.View):
         )
         embed.add_field(name="📡 Connectivity", value=conn_val, inline=True)
 
+        # Latency Metrics
+        nwws_lat = self.bot.state.nwws_latency
+        iem_lat = self.bot.state.iembot_latency
+        http_lat = self.bot.state.http_latency
+        discord_rtt = self.bot.latency * 1000  # Convert to ms
+
+        latency_val = (
+            f"**Discord RTT:** `{discord_rtt:.1f}ms`\n"
+            f"**NWWS Wire:** `{nwws_lat:.1f}s`" if nwws_lat > 0 else f"**NWWS Wire:** `---`"
+        )
+        latency_val += f"\n**IEMBot Wire:** `{iem_lat:.1f}s`" if iem_lat > 0 else f"\n**IEMBot Wire:** `---`"
+        latency_val += f"\n**HTTP Avg:** `{http_lat * 1000:.1f}ms`" if http_lat > 0 else f"\n**HTTP Avg:** `---`"
+        
+        embed.add_field(name="⏱️ Latency", value=latency_val, inline=True)
+
         # Environment
         risk_label = get_current_risk_display()
         active_high_risk = peek_active_labels()

--- a/main.py
+++ b/main.py
@@ -58,6 +58,15 @@ bot = commands.Bot(command_prefix="!", intents=intents)
 bot.state = BotState()
 bot.log_handler = log_handler
 
+# Initialize HTTP latency tracking
+def _update_http_latency(l: float):
+    if bot.state.http_latency == 0:
+        bot.state.http_latency = l
+    else:
+        bot.state.http_latency = (bot.state.http_latency * 0.9) + (l * 0.1)
+
+utils.http.set_latency_callback(_update_http_latency)
+
 IS_PRIMARY = os.getenv("IS_PRIMARY", "true").lower() == "true"
 bot.state.is_primary = IS_PRIMARY
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -22,6 +22,13 @@ def _make_cog():
     bot.state = MagicMock()
     bot.state.is_primary = True
     bot.state.bot_start_time = None
+    bot.state.nwws_latency = 0.0
+    bot.state.iembot_latency = 0.0
+    bot.state.http_latency = 0.0
+    bot.state.active_mds = []
+    bot.state.active_watches = {}
+    bot.state.last_post_times = {}
+    bot.latency = 0.05  # 50ms
     cog = StatusCog(bot)
     return cog
 

--- a/utils/http.py
+++ b/utils/http.py
@@ -19,6 +19,12 @@ TIMEOUT_SLOW = 30       # Larger content, general GET
 _CB_FAILURE_THRESHOLD = 5
 _CB_RECOVERY_TIMEOUT = 60.0
 
+_latency_callback = None
+
+def set_latency_callback(cb):
+    global _latency_callback
+    _latency_callback = cb
+
 http_session: Optional[aiohttp.ClientSession] = None
 _session_lock = asyncio.Lock()
 
@@ -160,11 +166,16 @@ async def http_get_bytes_conditional(
 
     async def _do_request():
         session = await ensure_session()
+        start = time.perf_counter()
         async with session.get(
             url,
             timeout=aiohttp.ClientTimeout(total=timeout),
             headers=headers or None,
         ) as response:
+            latency = time.perf_counter() - start
+            if _latency_callback:
+                _latency_callback(latency)
+            
             if response.status in (429, 503, 502, 504):
                 # Tenacity handles the backoff/retry; we just signal the failure
                 raise aiohttp.ClientResponseError(

--- a/utils/state.py
+++ b/utils/state.py
@@ -137,6 +137,11 @@ class BotState:
         self.iembot_botstalk_last_seqnum: int = 0
         self.bot_start_time: Optional[datetime] = None
 
+        # Latency tracking (seconds)
+        self.nwws_latency: float = 0.0
+        self.iembot_latency: float = 0.0
+        self.http_latency: float = 0.0
+
         self.hashes = HashStore()
         self.posting = PostingLog()
         self.timing = TimingTracker()


### PR DESCRIPTION
This PR adds live latency tracking to the bot's status dashboard:

- **Discord RTT**: Real-time heartbeat latency between the bot and the Discord Gateway.
- **NWWS-OI Wire Latency**: Estimated 'on the wire' time for NWS products received via XMPP (calculated against product issue timestamps).
- **IEMBot Wire Latency**: Estimated 'on the wire' time for products received via the iembot JSON feed.
- **HTTP Avg Latency**: A rolling average of response times for all outgoing HTTP requests made by the bot.

These metrics provide better visibility into the bot's alerting performance and connection health.