### PR TITLE
docs(wiki): add beta warning and fix S3 bucket name

### DIFF
--- a/wiki/pages/Home.md
+++ b/wiki/pages/Home.md
@@ -2,6 +2,9 @@
 
 **SPCBot** (v5.13.0) is a high-performance, severe weather monitoring Discord bot. Built for enthusiasts and researchers, it delivers near-zero latency alerts, real-time analytics, and automated scientific plots.
 
+> [!WARNING]
+> **Warning and lifecycle tracking features are in Beta.** These features are under active development and should be considered experimental. Always rely on official NWS sources for life-safety decisions.
+
 ## 🚀 Key Features
 
 - **Gold-Standard Alerting:** NWWS-OI (XMPP) integration for sub-second latency on NWS products.

--- a/wiki/pages/Radar-Downloader.md
+++ b/wiki/pages/Radar-Downloader.md
@@ -16,7 +16,7 @@ The `/download` command allows users to retrieve raw radar data for post-event a
 
 ## ☁️ S3 Integration
 
-- **Backend:** Pulls directly from the `noaa-nexrad-level2` bucket on AWS S3.
+- **Backend:** Pulls directly from the `unidata-nexrad-level2` bucket on AWS S3.
 - **Metadata Search:** The bot performs real-time S3 prefix listing to find the exact filenames and timestamps required, ensuring accuracy even across UTC day boundaries.
 - **Efficiency:** Downloads are streamed directly to a temporary buffer and then zipped, minimizing disk I/O.
 


### PR DESCRIPTION
## Summary
- Add beta development notice to Home.md for warning/lifecycle tracking features
- Update Radar-Downloader.md S3 bucket reference from `noaa-nexrad-level2` to `unidata-nexrad-level2`

## Test plan
- [ ] Wiki renders correctly on GitHub
- [ ] Links and formatting are preserved