### PR TITLE
fix(ci): copy both requirements files for ci image build

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -30,7 +30,7 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 
 # Pre-install all dependencies (build wheels and install)
-COPY requirements-dev.txt .
+COPY requirements.txt requirements-dev.txt .
 RUN pip install --upgrade pip setuptools wheel && \
     pip install -r requirements-dev.txt
 


### PR DESCRIPTION
Fixes pip install failure in Dockerfile.ci

The ci-image build was failing because requirements-dev.txt includes '-r requirements.txt' but we weren't copying requirements.txt into the image.

Now copying both files so pip can resolve the dependency.