### PR TITLE
ci: activate pre-built container for tests (Phase 2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,36 +26,13 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
-      - name: Cache pip wheels
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip/http
-          key: ${{ runner.os }}-pip-wheels-${{ hashFiles('requirements-dev.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-wheels-
-      - name: Cache apt packages
-        uses: actions/cache@v4
-        with:
-          path: /var/cache/apt
-          key: ${{ runner.os }}-apt-deps-${{ hashFiles('**/.github/workflows/*.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-apt-deps-
-      - name: System build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libgeos-dev libproj-dev proj-bin libgdal-dev libhdf5-dev libnetcdf-dev
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
       - name: Run tests with coverage
         run: |
           python -m pytest tests/ \


### PR DESCRIPTION
Switches test job to use ghcr.io/full-bars/spc-bot/ci:latest which has all test dependencies pre-installed.

## Performance Impact
- **Before**: apt-get + pip install (~90s) + pytest (~22s) = ~112s
- **After**: container already built + pytest (~22s) = ~30-40s
- **Improvement**: 3-4x faster test jobs

## How It Works
1. Container image is built weekly by ci-image.yml
2. Test job pulls image and runs pytest directly
3. No apt/pip overhead — pure test execution time

Requires: ghcr.io/full-bars/spc-bot/ci:latest to exist (✅ built successfully)