### PR TITLE
fix(warnings): prevent double-posting by normalizing product_id timestamps

### DIFF
--- a/cogs/nwws.py
+++ b/cogs/nwws.py
@@ -155,6 +155,10 @@ class NWWSClient(ClientXMPP):
             # Use the stable 'issue' timestamp from NWWS metadata so retransmits
             # don't get a new ID based on the current bot clock.
             ts_str = payload['issue'] or time.strftime("%Y%m%d%H%M", time.gmtime())
+            # Normalize ISO8601 format to compact format for dedup consistency
+            if "T" in ts_str and "Z" in ts_str:
+                # Convert "2026-05-03T06:50:00Z" → "202605030650"
+                ts_str = ts_str.replace("-", "").replace("T", "").replace(":", "").split("Z")[0][:12]
             product_id = f"{ts_str}-{office}-{ttaaii}-{afos_pil}"
 
             # Track NWWS wire latency (rough estimate to minute precision)


### PR DESCRIPTION
## Problem
Special Weather Statements (SPS) and other multi-source warnings were being posted twice.

### Root Cause
- NWWS provides issue timestamps in ISO8601 format: `2026-05-03T06:50:00Z`
- IEMBot uses compact format: `202605030650`
- Same warning resulted in two different product_ids
- Deduplication failed because product_ids didn't match

### Solution
Normalize ISO8601 timestamps to compact format (YYYYMMDDHHMM) when constructing product_id in the NWWS path. This ensures both NWWS and IEMBot paths recognize and deduplicate the same warnings.

## Test Plan
- Verify SPS warnings no longer double-post when both NWWS and IEMBot trigger
- Check logs for "Posted" entries—should see one per warning, not two
- Confirm other multi-source products (TOR, SVR, FFW) aren't affected