### PR TITLE
feat: implement stateless resumption for polling cogs

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -1,5 +1,6 @@
 # cogs/mesoscale.py
 import asyncio
+import json as _json
 import html as _html
 import logging
 import os
@@ -18,17 +19,18 @@ from utils.cache import (
 )
 from utils.change_detection import get_cache_path_for_url
 from utils.http import http_get_bytes, http_get_text, http_head_meta
-from utils.state_store import add_posted_md, prune_posted_mds
+from utils.state_store import add_posted_md, get_state, prune_posted_mds, set_state
 
 logger = logging.getLogger("spc_bot")
 
-_md_index_head: Dict[str, str] = {}
-_md_index_unreachable: bool = False
+_md_index_head: Optional[Dict[str, str]] = None
+_md_index_unreachable: Optional[bool] = None
 
 _MD_NUMBER_RE = re.compile(r"MESOSCALE DISCUSSION\s+(\d+)", re.IGNORECASE)
 _MD_HREF_RE = re.compile(r'href="(?:/products/md/)?md(\d+)\.html"', re.IGNORECASE)
 _ACUS_SPLIT_RE = re.compile(r"(?m)^ACUS11 KWNS\s+\d{6}")
 _CONCERNING_RE = re.compile(r"(CONCERNING[^\n<]{10,120})", re.IGNORECASE)
+
 
 async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[str]], bool]:
     """
@@ -39,50 +41,56 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[st
     Returns:
         (md_numbers, is_fallback)
     """
-    global _md_index_head
+    global _md_index_head, _md_index_unreachable
     logger.debug(f"[MD] Fetching MD numbers (fresh={fresh})")
+
+    # 1. Load persistent state on first run
+    if _md_index_head is None:
+        raw_head = await get_state("md_index_head")
+        _md_index_head = _json.loads(raw_head) if raw_head else {}
+    
+    if _md_index_unreachable is None:
+        raw_unreach = await get_state("md_index_unreachable")
+        _md_index_unreachable = (raw_unreach == "true") if raw_unreach else False
 
     if not fresh:
         meta = await http_head_meta(SPC_MD_INDEX_URL)
         if meta is not None and _md_index_head:
-            # Require ALL non-empty validators to match. OR was too loose —
-            # if content_length happened to line up while the page actually
-            # changed, we'd silently drop the new MD.
+            # Require ALL non-empty validators to match.
             checks = []
             for key in ("etag", "last_modified", "content_length"):
                 if meta.get(key):
                     checks.append(meta[key] == _md_index_head.get(key))
             if checks and all(checks):
                 logger.debug("[MD] Index unchanged (HEAD match)")
-                return None, False  # None → caller skips cycle entirely (no cancellations, no new-MD scan)
+                return None, False
         if meta:
             _md_index_head.update(meta)
+            await set_state("md_index_head", _json.dumps(_md_index_head))
     else:
         # Clear the cached HEAD info if fresh is requested
         _md_index_head = {}
+        await set_state("md_index_head", "{}")
 
     logger.debug(f"[MD] Requesting SPC index: {SPC_MD_INDEX_URL}")
     html = await http_get_text(SPC_MD_INDEX_URL)
 
-    global _md_index_unreachable
     # If SPC is unreachable, try to scrape from IEM
     if not html:
         logger.warning("[MD] SPC index HTML empty/failed, falling back to IEM")
         if not _md_index_unreachable:
             logger.warning("[MD] SPC index unreachable — falling back to IEM for active MD list")
             _md_index_unreachable = True
+            await set_state("md_index_unreachable", "true")
         try:
             # Fetch the raw text of SWOMCD products from the last 24 hours
-            # Format: YYYY-MM-DD HH:MM
             sts = (datetime.now(timezone.utc) - timedelta(hours=24)).strftime("%Y-%m-%d %H:%M")
             url = f"https://mesonet.agron.iastate.edu/cgi-bin/afos/retrieve.py?pil=SWOMCD&limit=10&sdate={sts}"
             
             text = await http_get_text(url, retries=2, timeout=15)
             if text:
-                # Find all discussion numbers in the concatenated text block.
-                # Since we filtered by sdate, everything in the response is recent.
                 md_nums = set()
-                matches = re.findall(r"MESOSCALE DISCUSSION\s+(\d+)", text, re.IGNORECASE)
+                matches = _MD_NUMBER_RE.findall(text)
                 for m in matches:
                     md_nums.add(m.zfill(4))
                 
@@ -93,16 +101,14 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[st
         except Exception as e:
             logger.exception(f"[MD] IEM fallback for index failed: {e}")
         
-        # If both failed, return None to signal a fetch failure rather than an empty index
         return None, True
 
     if _md_index_unreachable:
         logger.info("[MD] SPC index reachable again")
         _md_index_unreachable = False
+        await set_state("md_index_unreachable", "false")
 
-    numbers = re.findall(
-        r'href="(?:/products/md/)?md(\d+)\.html"', html, re.IGNORECASE
-    )
+    numbers = _MD_HREF_RE.findall(html)
     seen = set()
     result = []
     for n in numbers:

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -25,7 +25,14 @@ from utils.cache import (
 )
 from utils.change_detection import get_cache_path_for_url, is_placeholder_image
 from utils.http import http_get_bytes, http_get_bytes_conditional, http_get_text
-from utils.state_store import add_posted_watch, prune_posted_watches
+from utils.state_store import (
+    add_posted_watch,
+    get_state,
+    get_validators,
+    prune_posted_watches,
+    set_state,
+    set_validators,
+)
 
 logger = logging.getLogger("spc_bot")
 
@@ -38,12 +45,8 @@ _VTEC_RE = re.compile(
 _WW_HREF_RE = re.compile(r'href="[^"]*ww(\d+)\.html"', re.IGNORECASE)
 _TORNADO_WATCH_RE = re.compile(r"Tornado Watch", re.IGNORECASE)
 
-# Conditional-GET state for the NWS active-alerts feed. Validators let us
-# 304 most 2-minute polls; _last_parsed holds the parsed dict to return
-# on 304 so callers see no behavioral difference vs. a fresh fetch.
-_nws_validators: Dict[str, str] = {}
+# Conditional-GET state for the NWS active-alerts feed.
 _nws_last_parsed: Optional[Dict[str, dict]] = None
-
 
 
 async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
@@ -53,25 +56,49 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
     Deduplicates by watch number from the VTEC string.
     """
     global _nws_last_parsed
-    # Keep retries×timeout well under the 2-minute auto_post_watches
-    # cycle so a bad NWS API window doesn't stall successive ticks.
+
+    # 1. Load persistent state on first run
+    state_validators = await get_validators(NWS_ALERTS_URL) or {}
+    if _nws_last_parsed is None:
+        raw_last = await get_state("watch_last_parsed")
+        if raw_last:
+            try:
+                _nws_last_parsed = _json.loads(raw_last)
+                # Re-hydrate ISO strings back to datetime objects
+                for w in _nws_last_parsed.values():
+                    if w.get("expires"):
+                        w["expires"] = datetime.fromisoformat(w["expires"])
+                logger.info(f"[WATCH] Resumed {len(_nws_last_parsed)} watches from state store")
+            except Exception as e:
+                logger.warning(f"[WATCH] Failed to load last_parsed state: {e}")
+                _nws_last_parsed = {}
+        else:
+            _nws_last_parsed = {}
+
+    # 2. Conditional GET
     content, status, validators = await http_get_bytes_conditional(
         NWS_ALERTS_URL,
-        etag=_nws_validators.get("etag") or None,
-        last_modified=_nws_validators.get("last_modified") or None,
+        etag=state_validators.get("etag"),
+        last_modified=state_validators.get("last_modified"),
         retries=2,
         timeout=15,
     )
-    if status == 304 and _nws_last_parsed is not None:
+    
+    if status == 304:
         return _nws_last_parsed
+        
     if not content or status != 200:
-        logger.warning(
-            f"[WATCH] NWS API returned status {status} — will retry next cycle"
-        )
+        logger.warning(f"[WATCH] NWS API returned status {status} — will retry next cycle")
         return None
+
+    # 3. Update validators
     if validators and (validators.get("etag") or validators.get("last_modified")):
-        _nws_validators["etag"] = validators.get("etag", "")
-        _nws_validators["last_modified"] = validators.get("last_modified", "")
+        await set_validators(
+            NWS_ALERTS_URL, 
+            validators.get("etag", ""), 
+            validators.get("last_modified", "")
+        )
+        
     try:
         data = _json.loads(content)
     except Exception as e:
@@ -99,16 +126,26 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
                     )
                 except (ValueError, TypeError) as e:
                     logger.debug(f"[WATCH] Could not parse expires {expires_str!r}: {e}")
-            logger.debug(
-                f"[WATCH] NWS API: #{watch_num} ({wtype}) expires {expires_dt}"
-            )
+            
             affected_zones = props.get("affectedZones", [])
             result[watch_num] = {
                 "type": wtype,
                 "expires": expires_dt,
                 "affected_zones": affected_zones,
             }
+            
+    # 4. Save to persistent state
     _nws_last_parsed = result
+    
+    # Serialize for storage (converting datetimes to strings)
+    persist_data = {}
+    for num, info in result.items():
+        copy = dict(info)
+        if copy.get("expires"):
+            copy["expires"] = copy["expires"].isoformat()
+        persist_data[num] = copy
+        
+    await set_state("watch_last_parsed", _json.dumps(persist_data))
     return result
 
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from utils.http import CircuitOpenError
 from utils.state_store import (
     check_integrity, close_db, get_db,
     get_all_hashes, get_posted_urls, get_posted_mds, get_posted_watches,
-    get_posted_reports,
+    get_posted_reports, get_all_posted_warnings,
     get_state,
 )
 from utils.cache import hydrate_validators_from_store
@@ -97,10 +97,20 @@ async def setup_hook():
         get_posted_urls("day2"),
         get_posted_urls("day3"),
         get_state("iembot_last_seqnum"),
+        get_state("iembot_botstalk_last_seqnum"),
+        get_all_posted_warnings(),
         return_exceptions=True
     )
     
-    db_auto, db_manual, db_mds, db_watches, db_reports, csu_raw, d1_urls, d2_urls, d3_urls, last_seq = results
+    db_auto, db_manual, db_mds, db_watches, db_reports, csu_raw, d1_urls, d2_urls, d3_urls, last_seq, last_botstalk, db_warnings = results
+
+    if isinstance(last_botstalk, str):
+        bot.state.iembot_botstalk_last_seqnum = int(last_botstalk)
+        logger.info(f"[DB] Restored last botstalk seqnum {last_botstalk}")
+
+    if isinstance(db_warnings, dict):
+        bot.state.posted_warnings.update(db_warnings)
+        logger.info(f"[DB] Restored {len(db_warnings)} posted warnings into cache")
 
     if isinstance(last_seq, str):
         bot.state.iembot_last_seqnum = int(last_seq)


### PR DESCRIPTION
Ensures that NWS watch state and SPC MD index metadata (ETags) are preserved across process restarts and failover events. Prevents redundant alerts and optimizes bandwidth.