### PR TITLE
release: v5.15.1 - Public IP Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. Format
 loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 version numbers follow [SemVer](https://semver.org/).
 
+## [5.15.1] — 2026-05-04
+
+### Changed
+- **Status Display.** Show public IP instead of private LAN IP for operational clarity.
+
 ## [5.15.0] — 2026-05-04
 
 ### Added

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 # Single source of truth for the release displayed in /help.
 # Bump this in the same commit as the git tag.
-__version__ = "5.15.0"
+__version__ = "5.15.1"
 
 load_dotenv()
 


### PR DESCRIPTION
Patch release with minor change to status display.

**Changes:**
- Show public IP instead of private LAN IP in /status for better operational clarity