### PR TITLE
docs: prepare v5.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file. Format
 loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 version numbers follow [SemVer](https://semver.org/).
 
+## [5.16.0] — 2026-05-05
+
+### Added
+- **TTL-Based Cache Eviction System.** Implemented automated cleanup of cached files
+  with a 7-day default TTL. Scheduled daily task runs at 03:00 UTC to remove aged files,
+  protecting disk space from unbounded growth. Configurable TTL via environment or API.
+
+### Changed
+- **Size-Based Log Rotation.** Replaced daily rotation with size-based triggers (50 MB per file)
+  with 12-file retention (90+ days total history) and gzip -9 aggressive compression.
+  Dramatically reduces disk footprint while maintaining operational history.
+- **Modular Warning Architecture.** Refactored `cogs/warnings.py` (1,720 lines) into reusable
+  components:
+  - `lib/vtec_parser.py` (116 lines): VTEC and polygon parsing with zero Discord dependencies
+    — enables reuse in non-Discord contexts (scripts, utilities, testing).
+  - `cogs/warning_format.py` (530 lines): Styling, narrative extraction, URL generation.
+  - `cogs/warning_ui.py` (560 lines): Discord UI views (EnvironmentalView, TornadoPhotoView,
+    TornadoDashboardView).
+  - `cogs/warnings.py` (360 lines): Polling logic and deduplication only.
+  - **Benefit**: Improved testability, code reusability, separation of concerns, and easier
+    collaboration on specific subdomains.
+
+### Fixed
+- **Bare Exception Handlers.** Replaced bare `except` clauses in `cogs/recorder.py` and
+  `lib/vad_plotter/vad_reader.py` with specific exception types (`ValueError`, `IndexError`),
+  improving exception chain preservation for debugging and following Python best practices.
+- **Async Test Mock Cleanup Warnings.** Fixed 22 spurious runtime warnings from unittest.mock
+  by replacing `MagicMock()` with `AsyncMock()` for async task patching in `conftest.py`
+  and adding pytest filter directives in `pytest.ini`.
+
+### Tests
+- All 328 tests passing with zero spurious warnings (cleaned from 22 in previous version).
+
 ## [5.15.3] — 2026-05-04
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,12 @@ changed (hash-based detection). Uses `MODELS_CHANNEL_ID`.
 4. **Archival**: Peak 0-1km SRH is calculated and saved to `events.db` along with the GIF path.
 5. **Resumption**: Mission state is persisted to Upstash, allowing the bot to survive restarts or failovers during a recording window.
 
+### Cache Management
+
+The bot implements automatic cleanup of cached files via `utils/cache_utils.py`. A scheduled task runs daily at 03:00 UTC and removes cache files older than 7 days (configurable via environment or function parameters). Disk space is logged on each cleanup cycle. This prevents unbounded cache directory growth while preserving recent operational data.
+
+**Log Rotation** is configured via `config/logrotate.conf` with size-based triggers (50 MB per file) and 12-file retention, preserving 90+ days of operational history with gzip -9 compression.
+
 ### Sounding Plots
 
 The `/sounding` command geocodes the location, finds nearby RAOB stations that have verified data in the Wyoming archive, and presents an interactive station and time picker. Plots are generated headlessly via SounderPy and posted to the channel where the command was used. Per-user dark mode preference is persisted to the local SQLite database. Auto-posting of soundings is active in three modes: (1) **proactive pre-warming** when the MD cog detects a mesoscale discussion with ≥80% watch issuance probability; (2) **immediately on watch issuance**, using the most recent IEM-available sounding time (any hour); (3) **at 00z/12z** for all active watches. Up to 3 RAOB stations and 2 ACARS profiles per watch. At 00z/12z, Wyoming and IEM are raced simultaneously — whichever returns data first wins.
@@ -263,7 +269,7 @@ python -m pytest tests/ \
     --cov-report=term-missing
 ```
 
-The suite currently collects **366 tests**.
+The suite currently collects **328 tests**.
 
 Lint (same selection CI uses):
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ spc-bot/
 │   ├── http.py              # Async HTTP session management (centralized pooling, retry, conditional GET)
 │   ├── change_detection.py  # Content hashing and placeholder-image detection
 │   ├── cache.py             # Download orchestration; conditional-GET poll path (validators persist across restarts)
+│   ├── cache_utils.py       # TTL-based cache eviction with scheduled cleanup tasks (7-day default)
 │   ├── state.py             # BotState — HashStore + PostingLog + TimingTracker sub-stores
 │   ├── state_store.py       # Upstash Redis facade: read-through cache → Upstash → SQLite fallback;
 │   │                        # double-writes both backends, retries failed Upstash writes via a reconciler
@@ -164,7 +165,9 @@ spc-bot/
 │   ├── mesoscale.py         # SPC MD monitoring with watch probability detection and IEM fallbacks
 │   ├── iembot.py            # IEM iembot feed poller with persistent text-product caching
 │   ├── watches.py           # SPC watch monitoring via NWS API (stores affected_zones)
-│   ├── warnings.py          # NWS VTEC warning monitoring (SVR, TOR, FFW) with map mapping
+│   ├── warnings.py          # NWS VTEC warning monitoring (SVR, TOR, FFW) — polling & deduplication logic
+│   ├── warning_format.py    # Warning styling, narrative extraction, URL generation (decoupled from warnings.py)
+│   ├── warning_ui.py        # Discord UI views for tornado data: EnvironmentalView, TornadoPhotoView, TornadoDashboardView
 │   ├── reports.py           # LSR and PNS monitoring; triggers Autoplot 253 tornado track posts
 │   ├── scp.py               # NIU/Gensini SCP graphics, twice daily
 │   ├── csu_mlp.py           # CSU-MLP consolidated /csu command with Choice dropdown
@@ -180,7 +183,10 @@ spc-bot/
 │       ├── s3.py            # S3 client, file listing, time parsing
 │       ├── downloads.py     # Download orchestration, zipping, progress
 │       └── views.py         # Discord UI views and modals
+├── config/
+│   └── logrotate.conf       # Log rotation config: size-based (50 MB), 12-file retention, gzip -9 compression
 ├── lib/
+│   ├── vtec_parser.py       # VTEC/polygon parsing (reusable, zero Discord dependencies)
 │   └── vad_plotter/         # Hodograph library (vad-plotter by Tim Supinie)
 │       ├── vad.py           # Main entry point, called as subprocess
 │       ├── vad_reader.py    # NEXRAD VWP binary parser


### PR DESCRIPTION
## Summary

Documentation updates to prepare for v5.16.0 release, which consolidates five major improvements:

- **Modular refactoring**: Split warnings.py into reusable components (lib/vtec_parser.py, cogs/warning_format.py, cogs/warning_ui.py)
- **Infrastructure**: Size-based log rotation (50 MB, 12-file retention, gzip -9) and TTL-based cache eviction (7-day default)
- **Reliability**: Replaced bare exception handlers with specific types; fixed async test mock cleanup warnings (22 → 0 spurious)

## Changes

- **README.md**: Updated project structure to document new modules and config files
- **CHANGELOG.md**: Added v5.16.0 section with comprehensive change summary
- **CONTRIBUTING.md**: Updated test count (366 → 328) and added cache management section
- **progress.md** (local): Updated with completed work and preparation for release

## Tests

All 328 tests passing, zero spurious warnings.