### PR TITLE
Refresh setup and operations docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,11 +15,11 @@ GUILD_ID=your_guild_id
 # MANUAL_CACHE_FILE=posted_records.json
 # AUTO_CACHE_FILE=auto_posted_records.json
 
-# Upstash Redis — shared state + leader election (required, see CONTRIBUTING.md)
-UPSTASH_REDIS_REST_URL=https://your-upstash-url.upstash.io
-UPSTASH_REDIS_REST_TOKEN=your-upstash-token
+# Upstash Redis — shared state + leader election (required for HA)
+# UPSTASH_REDIS_REST_URL=https://your-upstash-url.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=your-upstash-token
 
-# Failover
+# Failover token (required even on a single node; configure the same value on both nodes for HA)
 # Set IS_PRIMARY=true on one box, false on the other. The bot picks up
 # leader-election duty from the Upstash lease regardless; this flag only
 # controls initial cog loading so the standby starts with no cogs running.
@@ -47,3 +47,7 @@ NWWS_SERVER=nwws-oi.weather.gov
 # The bot flips the folder mode automatically on promotion/demotion.
 # SYNCTHING_API_KEY=your_local_syncthing_api_key
 # SYNCTHING_FOLDER_ID=spcbot-events
+
+# Off-server forensics backups via rclone (optional)
+# RCLONE_REMOTE=gdrive
+# RCLONE_DEST_DIR=spc-bot-forensics

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ NWWS-OI (sub-1s latency), SPC watch alerts with deduplication, NWS warnings (TOR
 ## Quick Start
 
 ### Prerequisites
-- Python 3.12+ or Docker
+- Python 3.13+ or Docker
 - Discord bot token ([Discord Developer Portal](https://discord.com/developers/applications))
-- Channel IDs for your Discord server
+- Discord channel IDs for SPC/model posts
 - (Optional) [Upstash Redis](https://upstash.com/) for high-availability failover
 
 ### Docker (Recommended)
@@ -32,6 +32,15 @@ curl -O https://raw.githubusercontent.com/full-bars/spc-bot/main/.env.example
 cp .env.example .env
 # Edit .env with your Discord token and channel IDs
 docker compose up -d
+```
+
+Minimum required `.env` for a single-node install:
+```env
+DISCORD_TOKEN=your_bot_token_here
+SPC_CHANNEL_ID=your_spc_channel_id
+MODELS_CHANNEL_ID=your_models_channel_id
+GUILD_ID=your_guild_id
+FAILOVER_TOKEN=your_non_default_shared_secret
 ```
 
 ### Systemd (Linux)
@@ -64,30 +73,13 @@ The bot automatically manages folder modes (send-only on Primary, receive-only o
 
 - **[PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)** — Full file tree, module descriptions, architecture overview, testing guide
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — Development setup, slash commands, auto-posting mechanics, persistence model, failover details, running tests
+- **[docs/testing.md](docs/testing.md)** — Focused test-running guide for local development and CI troubleshooting
 - **[GitHub Wiki](https://github.com/full-bars/spc-bot/wiki)** — Feature guides (Alerting Authority, Warning Lifecycle, Soundings, Maintenance)
 - **[CHANGELOG.md](CHANGELOG.md)** — Release history and version-by-version improvements
 
 ## Status
 
-Work in progress. Actively developed in free time. All 328 tests passing with zero spurious warnings.
-
-## Built With
-
-* [discord.py](https://github.com/Rapptz/discord.py)
-* [aiohttp](https://github.com/aio-libs/aiohttp)
-* [aioboto3](https://github.com/aio-libs/aioboto3)
-* [aiosqlite](https://github.com/omnilib/aiosqlite)
-* [sounderpy](https://github.com/kylejgillett/sounderpy)
-* [MetPy](https://github.com/Unidata/MetPy)
-* [numpy](https://numpy.org)
-* [matplotlib](https://matplotlib.org)
-* [requests](https://requests.readthedocs.io)
-* [pytz](https://github.com/stub42/pytz)
-* [vad-plotter](https://github.com/tsupinie/vad-plotter) by Tim Supinie
-
-## Status
-
-Work in progress. Actively developed in my free time, expect some bugs.
+Work in progress. Actively developed in free time; expect behavior to evolve between releases.
 
 ## Built With
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,55 @@
+# Testing Guide
+
+This guide covers the common local checks for SPCBot development.
+
+## Environment
+
+Use the project virtual environment when available:
+
+```bash
+./venv/bin/python -m pytest
+./venv/bin/python -m ruff check .
+```
+
+If the virtual environment does not exist yet:
+
+```bash
+python3 -m venv venv
+./venv/bin/python -m pip install -r requirements-dev.txt
+```
+
+The test suite sets required configuration values in `tests/conftest.py` before importing `config.py`, so local tests should not need real Discord, NWWS, or Upstash credentials.
+
+## Focused Test Runs
+
+Run tests for a specific subsystem while iterating:
+
+```bash
+./venv/bin/python -m pytest tests/test_main_lifecycle.py
+./venv/bin/python -m pytest tests/test_watches.py tests/test_mesoscale.py
+./venv/bin/python -m pytest tests/test_state_store.py tests/test_db.py
+./venv/bin/python -m pytest tests/test_hodograph.py tests/test_sounding_qc.py
+```
+
+For syntax-only checks across selected files:
+
+```bash
+./venv/bin/python -m py_compile config.py main.py utils/http.py utils/cache.py
+```
+
+## Background Task Tests
+
+Most tests patch `asyncio.create_task` to prevent fire-and-forget background work from leaking across test boundaries. Tests that need real task scheduling should opt out with:
+
+```python
+@pytest.mark.real_create_task
+```
+
+Use that marker only when task creation is part of the behavior under test.
+
+## Pre-PR Checklist
+
+1. Run the focused tests for the files you changed.
+2. Run `./venv/bin/python -m ruff check .`.
+3. For startup or config changes, run a `py_compile` pass over `config.py` and `main.py`.
+4. For docs-only changes, verify links and environment variable names against `config.py` and `.env.example`.

--- a/wiki/pages/Configuration-Guide.md
+++ b/wiki/pages/Configuration-Guide.md
@@ -4,11 +4,13 @@ SPCBot is configured via a `.env` file in the project root. Below is a comprehen
 
 ## 🔑 Required
 
-| Variable | Description |
-|---|---|
-| `DISCORD_TOKEN` | Your Discord bot token. |
-| `GUILD_ID` | The ID of the Discord server where the bot operates. |
-| `LOG_CHANNEL_ID` | Channel ID for system alerts and errors. |
+| Variable | Description | Default |
+|---|---|---|
+| `DISCORD_TOKEN` | Your Discord bot token. | Required |
+| `GUILD_ID` | The ID of the Discord server where the bot operates. | Required |
+| `SPC_CHANNEL_ID` | Default channel for SPC outlooks, watches, MDs, reports, and health fallback posts. | Required |
+| `MODELS_CHANNEL_ID` | Channel for model/science products such as CSU-MLP, WxNext2, and SCP. | Required |
+| `FAILOVER_TOKEN` | Non-default shared secret used by failover/admin controls. | Required |
 
 ## 📡 Alerting & Data Sources
 
@@ -17,8 +19,10 @@ SPCBot is configured via a `.env` file in the project root. Below is a comprehen
 | `NWWS_USER` | NWWS-OI XMPP username. | (empty) |
 | `NWWS_PASSWORD` | NWWS-OI XMPP password. | (empty) |
 | `NWWS_SERVER` | NWWS-OI XMPP server address. | `nwws-oi.weather.gov` |
-| `WARNINGS_CHANNEL_ID` | Channel for TOR/SVR/FFW alerts. | (Required) |
-| `OUTLOOKS_CHANNEL_ID` | Channel for SPC outlook posts. | (Required) |
+| `WARNINGS_CHANNEL_ID` | Channel for TOR/SVR/FFW alerts. | `SPC_CHANNEL_ID` |
+| `HEALTH_CHANNEL_ID` | Channel for health alerts and watchdog notifications. | `SPC_CHANNEL_ID` |
+| `SOUNDING_CHANNEL_ID` | Channel for automated sounding posts. | `SPC_CHANNEL_ID` |
+| `DEV_CHANNEL_ID` | Channel for developer/admin operational alerts. | `HEALTH_CHANNEL_ID`, then `SPC_CHANNEL_ID` |
 
 ## 🔄 High Availability (Failover)
 
@@ -27,8 +31,7 @@ SPCBot is configured via a `.env` file in the project root. Below is a comprehen
 | `IS_PRIMARY` | Set initial role (`true`/`false`). | `true` |
 | `UPSTASH_REDIS_REST_URL` | Your Upstash Redis REST URL. | (empty) |
 | `UPSTASH_REDIS_REST_TOKEN` | Your Upstash Redis REST token. | (empty) |
-| `FAILOVER_TOKEN` | Shared secret for `/failover` command auth. | (Required for HA) |
-| `ADMIN_USER_ID` | Your Discord User ID (for owner-only commands). | (Required) |
+| `ADMIN_USER_ID` | Discord user ID authorized to use `/failover`. | `0` |
 
 ## 💾 Persistence & Sync
 
@@ -36,22 +39,27 @@ SPCBot is configured via a `.env` file in the project root. Below is a comprehen
 |---|---|---|
 | `CACHE_DIR` | Path to store DBs and image caches. | `cache/` |
 | `EVENTS_DB_PATH` | Path to the historical events archive. | `cache/events.db` |
+| `EVENTS_SYNC_DIR` | Directory used for Syncthing event DB exchange. | `cache/events_sync` |
+| `LOG_FILE` | Main bot log path. | `spc_bot.log` |
+| `NWWS_FIREHOSE_LOG` | Rotating raw NWWS firehose log path inside `CACHE_DIR`. | `nwws_firehose.log` |
+| `MANUAL_CACHE_FILE` | Legacy manual hash cache filename. | `posted_records.json` |
+| `AUTO_CACHE_FILE` | Legacy automatic hash cache filename. | `auto_posted_records.json` |
 | `SYNCTHING_API_KEY` | Local Syncthing API key for `events.db` sync. | (empty) |
 | `SYNCTHING_FOLDER_ID` | Syncthing folder ID for `events.db`. | `spcbot-events` |
 | `RCLONE_REMOTE` | rclone remote name for off-server backups. | `gdrive` |
 | `RCLONE_DEST_DIR` | Destination directory on the rclone remote. | `spc-bot-forensics` |
 
-## 🧪 Science & Thresholds
-
-| Variable | Description | Default |
-|---|---|---|
-| `SOUNDING_TRIGGER_RADIUS` | Radius (km) to find stations near watches. | `150` |
-| `MAX_RADAR_FILES` | Max files allowed per `/download` request. | `50` |
-| `AGGRESSIVE_SPC_POLL` | Use faster polling on High Risk days. | `true` |
-
 ## 🖥️ System
 
 | Variable | Description | Default |
 |---|---|---|
-| `LOG_LEVEL` | Logging verbosity (`DEBUG`, `INFO`, `ERROR`). | `INFO` |
 | `PYTHONUNBUFFERED` | Ensures logs stream immediately in Docker. | `1` |
+
+## Deployment Profiles
+
+| Profile | Required | Optional |
+|---|---|---|
+| Single node | `DISCORD_TOKEN`, `GUILD_ID`, `SPC_CHANNEL_ID`, `MODELS_CHANNEL_ID`, `FAILOVER_TOKEN` | NWWS credentials for lower-latency text products |
+| Single node with split channels | Single-node variables plus any channel override IDs | `HEALTH_CHANNEL_ID`, `WARNINGS_CHANNEL_ID`, `SOUNDING_CHANNEL_ID`, `DEV_CHANNEL_ID` |
+| High availability | Single-node variables plus Upstash credentials, `ADMIN_USER_ID`, and opposite `IS_PRIMARY` values on each node | Syncthing for `events.db` replication |
+| Forensics archive | Single-node variables plus `RCLONE_REMOTE` and `RCLONE_DEST_DIR` | Syncthing if also running HA |

--- a/wiki/pages/Getting-Started.md
+++ b/wiki/pages/Getting-Started.md
@@ -6,6 +6,7 @@ SPCBot is designed for flexibility, supporting both containerized and native Lin
 
 - **Python 3.13+** (matches current production stack).
 - **Discord Bot Token**: Create one at the [Discord Developer Portal](https://discord.com/developers/applications).
+- **Discord Channel IDs**: At minimum, one SPC channel and one model channel.
 - **Upstash Redis** (Optional): Required only for High Availability (Failover).
 - **Syncthing** (Optional): Required for cross-node `events.db` replication.
 
@@ -23,6 +24,12 @@ The easiest way to run SPCBot with all scientific dependencies (MetPy, Cartopy) 
 2. **Configure:** Edit `.env` with your token and channel IDs.
 3. **Launch:** `docker compose up -d`
 
+Check startup logs with:
+
+```bash
+docker compose logs -f bot
+```
+
 ## ⚡ Native Linux (systemd)
 
 Use the portable deploy script for an interactive setup on Ubuntu/Debian.
@@ -33,17 +40,37 @@ cd spc-bot
 sudo ./deploy.sh
 ```
 
-The script creates a virtual environment, configures your service, and installs aliases (`spcon`, `spcoff`, `spclog`) into your `.bashrc`.
+The script creates a virtual environment, configures your service, and installs aliases (`spcon`, `spcoff`, `spcstatus`, `spclog`, `spcupdate`) into your `.bashrc`.
 
 ## ⚙️ Core Configuration (`.env`)
 
-| Variable | Description |
+Minimum required variables for a single-node install:
+
+| Variable | Description | Required |
+|---|---|---|
+| `DISCORD_TOKEN` | Your bot token from Discord. | Yes |
+| `GUILD_ID` | The ID of your primary server. | Yes |
+| `SPC_CHANNEL_ID` | Default channel for SPC outlooks, watches, MDs, and fallback health posts. | Yes |
+| `MODELS_CHANNEL_ID` | Channel for model/science products such as CSU-MLP, WxNext2, and SCP. | Yes |
+| `FAILOVER_TOKEN` | Non-default shared secret used by failover/admin controls. | Yes |
+
+Optional production features:
+
+| Feature | Variables |
 |---|---|
-| `DISCORD_TOKEN` | Your bot token from Discord. |
-| `GUILD_ID` | The ID of your primary server. |
-| `LOG_CHANNEL_ID` | Channel for system alerts and errors. |
-| `NWWS_USER` | NWWS-OI XMPP username. |
-| `NWWS_PASSWORD` | NWWS-OI XMPP password. |
-| `IS_PRIMARY` | Set `true` for your main node. |
+| Warning channel split | `WARNINGS_CHANNEL_ID`, `HEALTH_CHANNEL_ID`, `SOUNDING_CHANNEL_ID`, `DEV_CHANNEL_ID` |
+| NWWS-OI fast path | `NWWS_USER`, `NWWS_PASSWORD`, `NWWS_SERVER` |
+| High availability | `IS_PRIMARY`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `ADMIN_USER_ID` |
+| Events DB sync | `EVENTS_DB_PATH`, `EVENTS_SYNC_DIR`, `SYNCTHING_API_KEY`, `SYNCTHING_FOLDER_ID` |
+| Off-server GIF backups | `RCLONE_REMOTE`, `RCLONE_DEST_DIR` |
 
 For a full list of configuration options, see the [Configuration Guide](Configuration-Guide).
+
+## ✅ Startup Verification
+
+After launch, confirm:
+
+1. Logs show the bot logged in and slash commands synced.
+2. `/status` shows the expected node role, uptime, Discord gateway, and data-source latency fields.
+3. `/spc1` or `/wxnext` can post in the expected channel.
+4. If using HA, only one node shows `PRIMARY`; the standby should not run posting loops.

--- a/wiki/pages/High-Availability-&-Failover.md
+++ b/wiki/pages/High-Availability-&-Failover.md
@@ -9,6 +9,15 @@ The failover system uses **Upstash Redis** as a distributed lock manager (Lease 
 - **Primary Node:** Holds the Upstash lease, runs all polling loops, and posts to Discord.
 - **Standby Node:** Heartbeats to Upstash. If the lease is available or expired, it promotes itself to Primary.
 
+## 🧭 Deployment Decision Table
+
+| Setup | Use When | Required Services | Tradeoffs |
+|---|---|---|---|
+| Single node | Personal server, development, or low operational complexity. | Discord token and channel IDs. | Simple, but one host outage stops automation. |
+| Single node + NWWS | You want the low-latency text-product fast path without HA. | NWWS-OI credentials. | Better alert latency, still one host. |
+| Primary/Standby | Severe-weather operations where host uptime matters. | Upstash Redis and two bot hosts. | More moving parts, but automated promotion. |
+| Primary/Standby + Syncthing | You need the historical events archive available immediately after promotion. | Upstash Redis, Syncthing, shared folder config. | Best continuity, requires storage sync care. |
+
 ## 🗳️ Leader Election Logic
 
 Every node runs a `sync_loop` that heartbeats to Upstash every 10 seconds:
@@ -23,6 +32,21 @@ While the failover manages *who* posts, the state must remain consistent.
 - **SQLite Mirror:** A local `bot_state.db` provides a durable mirror and handles outage survival if Upstash is unreachable.
 - **Syncthing:** Replicates the historical `events.db` archive cross-node, ensuring the Standby has the full record if it promotes.
 
+## ⚙️ Environment Checklist
+
+Set these on both nodes:
+
+| Variable | Primary | Standby |
+|---|---|---|
+| `DISCORD_TOKEN` | Same bot token | Same bot token |
+| `GUILD_ID` | Same guild ID | Same guild ID |
+| `SPC_CHANNEL_ID` / `MODELS_CHANNEL_ID` | Same channel IDs | Same channel IDs |
+| `UPSTASH_REDIS_REST_URL` | Same Upstash URL | Same Upstash URL |
+| `UPSTASH_REDIS_REST_TOKEN` | Same Upstash token | Same Upstash token |
+| `FAILOVER_TOKEN` | Same shared secret | Same shared secret |
+| `ADMIN_USER_ID` | Same authorized operator | Same authorized operator |
+| `IS_PRIMARY` | `true` | `false` |
+
 ## 🎮 Manual Intervention
 
 Authorized operators can force a role swap using:
@@ -35,3 +59,13 @@ To prevent Discord interaction hijacking and double-posting:
 - Standby nodes suppress all automated polling loops.
 - All cogs are set to "idle" state.
 - `CommandNotFound` errors are swallowed to prevent the Standby from responding to commands intended for the Primary.
+
+## ✅ Promotion Verification
+
+After a planned or automatic promotion:
+
+1. `/status` shows exactly one `PRIMARY`.
+2. The promoted node has loaded posting cogs and background loops.
+3. Syncthing folder mode is `send-only` on the primary and `receive-only` on standby when configured.
+4. New MD/watch/warning posts are deduplicated against already-posted state.
+5. The demoted node does not sync slash commands or run auto-post loops.

--- a/wiki/pages/Home.md
+++ b/wiki/pages/Home.md
@@ -1,6 +1,6 @@
 # Welcome to the SPCBot Wiki 🛰️
 
-**SPCBot** (v5.13.0) is a high-performance, severe weather monitoring Discord bot. Built for enthusiasts and researchers, it delivers near-zero latency alerts, real-time analytics, and automated scientific plots.
+**SPCBot** is a high-performance, severe weather monitoring Discord bot. Built for enthusiasts and researchers, it delivers near-zero latency alerts, real-time analytics, and automated scientific plots.
 
 > [!WARNING]
 > **Warning and lifecycle tracking features are in Beta.** These features are under active development and should be considered experimental. Always rely on official NWS sources for life-safety decisions.
@@ -18,19 +18,21 @@
 ### [Getting Started](Getting-Started)
 Learn how to install SPCBot via Docker or systemd, configure your environment, and get the bot online.
 
-### [Core Features](Core-Features)
+### Core Features
 - **[Alerting & Authority](Alerting-Authority-&-NWWS-OI)**: Hierarchy of data sources and latency advantages.
 - **[Warning Lifecycle & Updates](Warning-Lifecycle-&-Updates)**: How VTEC products are parsed and tracked.
 - **[Tornado Dashboard & DAT Integration](Tornado-Dashboard-&-DAT-Integration)**: Survey tracking and photo carousels.
 
-### [Scientific Tools](Scientific-Tools)
+### Scientific Tools
 - **[Soundings & Hodographs](Soundings-&-Hodographs)**: Observed data plotting and auto-posting logic.
 - **[Forecast Models](Forecast-Models)**: CSU-MLP, NCAR WxNext2, and SCP graphics.
+- **[Radar Downloader](Radar-Downloader)**: NOAA S3 Level 2 radar downloads and archive packaging.
 
-### [Advanced Architecture](Advanced-Architecture)
+### Advanced Architecture
 - **[High Availability & Failover](High-Availability-&-Failover)**: Primary/Standby logic and Upstash leases.
 - **[State Persistence Model](State-Persistence-Model)**: Hybrid Upstash Redis + SQLite architecture.
 
-### [Reference](Reference)
+### Reference
 - **[Slash Command Reference](Slash-Command-Reference)**: Complete guide to bot interactions.
 - **[Maintenance & Operations](Maintenance-&-Operations)**: Monitoring tools and admin commands.
+- **[Configuration Guide](Configuration-Guide)**: Environment variables and deployment options.

--- a/wiki/pages/Maintenance-&-Operations.md
+++ b/wiki/pages/Maintenance-&-Operations.md
@@ -53,3 +53,63 @@ For users running via `deploy.sh`, the `spcupdate` alias:
 1. Performs a `git pull`.
 2. Checks for new dependencies (`pip install -r requirements.txt`).
 3. Restarts the systemd service.
+
+## 🚨 Incident Runbooks
+
+### NWWS-OI Disconnected
+Symptoms: `/status` shows NWWS disconnected or stale ping/throughput.
+
+1. Confirm the bot is still logged in and marked `PRIMARY`.
+2. Check `/logs` for XMPP authentication, roster, or reconnect errors.
+3. Confirm `NWWS_USER`, `NWWS_PASSWORD`, and `NWWS_SERVER` are set correctly.
+4. Keep IEMBot/API polling online as fallback; do not restart both HA nodes at once during active weather.
+
+### Upstash Unavailable
+Symptoms: failover lease warnings, dirty-write reconciliation logs, or standby uncertainty.
+
+1. Check `/status` on both nodes and identify which node is posting.
+2. Verify `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`.
+3. Let SQLite mirror continue local durability; dirty writes are replayed when Upstash returns.
+4. Avoid manual role swaps until the lease store recovers unless the current primary is clearly down.
+
+### Split-Brain Suspicion
+Symptoms: both nodes appear to post or both report `PRIMARY`.
+
+1. Use `/status` on both nodes and compare hostname/IP/role.
+2. Stop or demote the less healthy node first.
+3. Confirm only one node loads posting cogs and runs auto-post loops.
+4. Check recent MD/watch/warning posts for duplicates before re-enabling the second node.
+
+### Discord Command Sync Failures
+Symptoms: slash commands are missing, stale, or return interaction errors.
+
+1. Confirm the primary node completed startup and command sync.
+2. Check `/logs` for Discord HTTP errors or permission failures.
+3. Confirm the bot is invited with `applications.commands` scope.
+4. Restart only the primary if command sync failed during startup.
+
+### Cache Disk Pressure
+Symptoms: large `cache/`, slow image/radar commands, or filesystem warnings.
+
+1. Check `cache/`, `cache/event_archive/`, and radar download output size.
+2. Confirm the maintenance loop is running in `/taskmgr`.
+3. Manually archive important GIFs before deleting local forensic files.
+4. Validate rclone backups before lowering local retention.
+
+### SQLite Corruption
+Symptoms: integrity check failures or startup messages about recreating `bot_state.db`.
+
+1. Preserve the `.corrupted` database file for inspection.
+2. Confirm the replacement DB starts and rehydrates from Upstash where available.
+3. For HA setups, verify `events.db` replication before promoting a standby.
+4. If duplicate posts appear, reconcile posted MD/watch/warning state before resuming automation.
+
+## 🧭 Cache & Backup Guide
+
+| Path | Purpose | Backup Priority | Safe to Delete? |
+|---|---|---|---|
+| `cache/bot_state.db` | Operational dedupe and bot state mirror. | Medium; Upstash can rehydrate some state. | No, unless intentionally resetting state. |
+| `cache/events.db` | Historical significant events archive. | High. | No. |
+| `cache/event_archive/` | VAD evolution GIF archive. | High if not backed up remotely. | Only after backup/retention decision. |
+| `cache/vad_recordings/` | Temporary active recording missions. | Low after mission finalization. | Old orphaned dirs are pruned automatically. |
+| Cached images/radar downloads | Re-downloadable product/cache artifacts. | Low. | Usually yes when the bot is stopped. |

--- a/wiki/pages/State-Persistence-Model.md
+++ b/wiki/pages/State-Persistence-Model.md
@@ -34,3 +34,26 @@ For HA pairs, the `events.db` is replicated using **Syncthing**. The bot automat
 - **Primary:** Sets folder to `Send-Only`.
 - **Standby:** Sets folder to `Receive-Only`.
 - Mode flipping occurs automatically during promotion/demotion cycles.
+
+## 🧾 State Ownership Cheat Sheet
+
+| State | Primary Location | Mirror/Fallback | Purpose |
+|---|---|---|---|
+| Active runtime metrics | `bot.state` | None | Latency, uptime, role, current task health. |
+| Image hashes | Upstash / `bot_state.db` | In-memory cache | Prevent duplicate SPC/model image posts. |
+| Posted MD/watch/report IDs | Upstash / `bot_state.db` | In-memory cache | Deduplicate alert products across restarts and HA nodes. |
+| Posted warning metadata | Upstash / `bot_state.db` | In-memory cache | Track lifecycle updates and Discord message targets. |
+| Simple feature state | `bot_state` table | Upstash key/value state | CSU-MLP, NCAR, IEMBot sequence numbers, and similar feature flags. |
+| HTTP validators | `http_validators` table | In-memory LRU | Avoid unnecessary downloads using ETag/Last-Modified. |
+| Product text cache | `product_text_cache` table | Upstash when configured | Short-lived NWS/SPC product text cache. |
+| Significant event history | `events.db` | Syncthing copy in HA setups | Tornado/survey archive and DAT enrichment. |
+| VAD evolution GIFs | Filesystem archive | rclone remote when configured | Forensic media output. |
+
+## 🚀 Startup Hydration Flow
+
+1. `main.py` initializes SQLite and checks DB integrity.
+2. In-memory dedupe caches are hydrated from the state store.
+3. HTTP validators are loaded so conditional GETs work after restart.
+4. Startup cache cleanup runs before cogs begin regular polling.
+5. The failover cog checks the Upstash lease.
+6. Posting cogs load only if the node should run as primary.


### PR DESCRIPTION
## Summary
- align setup/config docs with current environment variables
- remove stale README/wiki drift and duplicate README sections
- add operations runbooks, HA guidance, state ownership notes, and a local testing guide

## Verification
- git diff --check
- checked docs for stale variable/link references