### PR TITLE
cleanup: remove redundant string log prefixes

### DIFF
--- a/cogs/iembot.py
+++ b/cogs/iembot.py
@@ -33,7 +33,7 @@ CACHE_TTL = 600  # 10 minutes
 
 def _log_task_exception(task: "asyncio.Task") -> None:
     if not task.cancelled() and (exc := task.exception()):
-        logger.exception("[IEMBOT] Unhandled exception in background task", exc_info=exc)
+        logger.exception("Unhandled exception in background task", exc_info=exc)
 
 
 async def get_cached_watch_text(watch_number: str) -> Optional[str]:
@@ -137,11 +137,11 @@ class IEMBotCog(commands.Cog):
                 if val:
                     self.bot.state.iembot_last_seqnum = int(val)
                     logger.info(
-                        f"[IEMBOT] Resuming from seqnum "
+                        f"Resuming from seqnum "
                         f"{self.bot.state.iembot_last_seqnum}"
                     )
             except Exception as e:
-                logger.warning(f"[IEMBOT] Could not load seqnum: {e}")
+                logger.warning(f"Could not load seqnum: {e}")
             self._seqnum_loaded = True
 
         try:
@@ -184,7 +184,7 @@ class IEMBotCog(commands.Cog):
                             else:
                                 self.bot.state.iembot_latency = (self.bot.state.iembot_latency * 0.9) + (latency * 0.1)
                 except Exception as e:
-                    logger.debug(f"[IEMBOT] Latency tracking failed: {e}")
+                    logger.debug(f"Latency tracking failed: {e}")
 
                 if "WWUS20-SEL" in product_id or "WWUS40-SEL" in product_id:
                     t = asyncio.create_task(self._handle_watch(product_id))
@@ -200,12 +200,12 @@ class IEMBotCog(commands.Cog):
                 await set_state("iembot_last_seqnum", str(new_seqnum))
 
         except Exception as e:
-            logger.warning(f"[IEMBOT] Poll error: {e}")
+            logger.warning(f"Poll error: {e}")
 
     async def _handle_watch(self, product_id: str):
         raw = await _fetch_product_text(product_id)
         if not raw:
-            logger.warning(f"[IEMBOT] Could not fetch watch text for {product_id}")
+            logger.warning(f"Could not fetch watch text for {product_id}")
             return
         m = re.search(r"(?:Tornado|Severe Thunderstorm)\s+Watch\s+Number\s+(\d+)", raw, re.IGNORECASE)
         if not m:
@@ -229,7 +229,7 @@ class IEMBotCog(commands.Cog):
     async def _handle_md(self, product_id: str):
         raw = await _fetch_product_text(product_id)
         if not raw:
-            logger.warning(f"[IEMBOT] Could not fetch MD text for {product_id}")
+            logger.warning(f"Could not fetch MD text for {product_id}")
             return
         m = re.search(r"Mesoscale Discussion\s+(\d+)", raw, re.IGNORECASE)
         if not m:
@@ -237,7 +237,7 @@ class IEMBotCog(commands.Cog):
         md_num = m.group(1).zfill(4)
         # Cache the FULL raw text so mesoscale.py can extract the body properly
         await set_product_cache(f"md_{md_num}", raw, ttl=CACHE_TTL)
-        logger.info(f"[IEMBOT] Cached full MD text for #{md_num}")
+        logger.info(f"Cached full MD text for #{md_num}")
 
         # Signal MesoscaleCog to post immediately
         mesoscale_cog = self.bot.cogs.get("MesoscaleCog")
@@ -290,11 +290,11 @@ class IEMBotCog(commands.Cog):
                 if val:
                     self.bot.state.iembot_botstalk_last_seqnum = int(val)
                     logger.info(
-                        f"[IEMBOT] Resuming botstalk from seqnum "
+                        f"Resuming botstalk from seqnum "
                         f"{self.bot.state.iembot_botstalk_last_seqnum}"
                     )
             except Exception as e:
-                logger.warning(f"[IEMBOT] Could not load botstalk seqnum: {e}")
+                logger.warning(f"Could not load botstalk seqnum: {e}")
             self._botstalk_seqnum_loaded = True
 
             # On a brand-new run (seqnum still 0), fast-forward to the current
@@ -313,10 +313,10 @@ class IEMBotCog(commands.Cog):
                             self.bot.state.iembot_botstalk_last_seqnum = tail
                             await set_state("iembot_botstalk_last_seqnum", str(tail))
                             logger.info(
-                                f"[IEMBOT] Botstalk first-run: fast-forwarded to seqnum {tail}"
+                                f"Botstalk first-run: fast-forwarded to seqnum {tail}"
                             )
                 except Exception as e:
-                    logger.warning(f"[IEMBOT] Botstalk seqnum fast-forward failed: {e}")
+                    logger.warning(f"Botstalk seqnum fast-forward failed: {e}")
                 return  # skip processing this tick; pick up new messages next cycle
 
         try:
@@ -362,7 +362,7 @@ class IEMBotCog(commands.Cog):
                             else:
                                 self.bot.state.iembot_latency = (self.bot.state.iembot_latency * 0.9) + (latency * 0.1)
                 except Exception as e:
-                    logger.debug(f"[IEMBOT] Latency tracking failed: {e}")
+                    logger.debug(f"Latency tracking failed: {e}")
 
                 pil_match = self._ISSUANCE_PIL_RE.search(product_id)
                 if pil_match:
@@ -376,7 +376,7 @@ class IEMBotCog(commands.Cog):
                 await set_state("iembot_botstalk_last_seqnum", str(new_seqnum))
 
         except Exception as e:
-            logger.warning(f"[IEMBOT] Botstalk poll error: {e}")
+            logger.warning(f"Botstalk poll error: {e}")
 
     _PIL_TO_EVENT = {
         "TOR": "Tornado Warning",
@@ -393,7 +393,7 @@ class IEMBotCog(commands.Cog):
         raw = await _fetch_product_text(product_id)
         if not raw:
             logger.warning(
-                f"[IEMBOT] Could not fetch warning text for {product_id}"
+                f"Could not fetch warning text for {product_id}"
             )
             return
 

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("spc_bot.mesoscale")
 
 def _log_task_exception(task: asyncio.Task) -> None:
     if not task.cancelled() and (exc := task.exception()):
-        logger.exception("[MD] Unhandled exception in background task", exc_info=exc)
+        logger.exception("Unhandled exception in background task", exc_info=exc)
 
 _md_index_head: Optional[Dict[str, str]] = None
 _md_index_unreachable: Optional[bool] = None
@@ -46,7 +46,7 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[st
         (md_numbers, is_fallback)
     """
     global _md_index_head, _md_index_unreachable
-    logger.debug(f"[MD] Fetching MD numbers (fresh={fresh})")
+    logger.debug(f"Fetching MD numbers (fresh={fresh})")
 
     # 1. Load persistent state on first run
     if _md_index_head is None:
@@ -66,7 +66,7 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[st
                 if meta.get(key):
                     checks.append(meta[key] == _md_index_head.get(key))
             if checks and all(checks):
-                logger.debug("[MD] Index unchanged (HEAD match)")
+                logger.debug("Index unchanged (HEAD match)")
                 return None, False
         if meta:
             _md_index_head.update(meta)
@@ -76,14 +76,14 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[st
         _md_index_head = {}
         await set_state("md_index_head", "{}")
 
-    logger.debug(f"[MD] Requesting SPC index: {SPC_MD_INDEX_URL}")
+    logger.debug(f"Requesting SPC index: {SPC_MD_INDEX_URL}")
     html = await http_get_text(SPC_MD_INDEX_URL)
 
     # If SPC is unreachable, try to scrape from IEM
     if not html:
-        logger.warning("[MD] SPC index HTML empty/failed, falling back to IEM")
+        logger.warning("SPC index HTML empty/failed, falling back to IEM")
         if not _md_index_unreachable:
-            logger.warning("[MD] SPC index unreachable — falling back to IEM for active MD list")
+            logger.warning("SPC index unreachable — falling back to IEM for active MD list")
             _md_index_unreachable = True
             await set_state("md_index_unreachable", "true")
         try:
@@ -98,17 +98,17 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[st
                 for m in matches:
                     md_nums.add(m.zfill(4))
                 
-                logger.info(f"[MD] IEM fallback returned {len(md_nums)} MDs from last 24h")
+                logger.info(f"IEM fallback returned {len(md_nums)} MDs from last 24h")
                 return sorted(list(md_nums), reverse=True), True
             else:
-                logger.warning("[MD] IEM fallback returned empty text")
+                logger.warning("IEM fallback returned empty text")
         except Exception as e:
-            logger.exception(f"[MD] IEM fallback for index failed: {e}")
+            logger.exception(f"IEM fallback for index failed: {e}")
         
         return None, True
 
     if _md_index_unreachable:
-        logger.info("[MD] SPC index reachable again")
+        logger.info("SPC index reachable again")
         _md_index_unreachable = False
         await set_state("md_index_unreachable", "false")
 
@@ -120,7 +120,7 @@ async def fetch_latest_md_numbers(fresh: bool = False) -> Tuple[Optional[List[st
             seen.add(n)
             result.append(n.zfill(4))
     
-    logger.debug(f"[MD] Scraped {len(result)} MD numbers from SPC index")
+    logger.debug(f"Scraped {len(result)} MD numbers from SPC index")
     return result, False
 
 
@@ -163,7 +163,7 @@ async def fetch_md_details_iem(md_number: str) -> Tuple[Optional[str], Optional[
                         summary = " ".join(lines[:3])[:200]
                     break
     except Exception as e:
-        logger.warning(f"[MD] IEM text fallback failed for #{md_number}: {e}")
+        logger.warning(f"IEM text fallback failed for #{md_number}: {e}")
 
     return iem_image_url, summary, raw_text
 
@@ -206,25 +206,25 @@ async def fetch_md_details(
     if first is spc_task:
         html = first.result()
         if html:
-            logger.debug(f"[MD] SPC won race for #{md_number}")
+            logger.debug(f"SPC won race for #{md_number}")
             for t in pending:
                 t.cancel()
         else:
-            logger.warning(f"[MD] SPC page failed for #{md_number} — waiting for IEM")
+            logger.warning(f"SPC page failed for #{md_number} — waiting for IEM")
             if pending:
                 try:
                     iem_result = await pending.pop()
                 except Exception as e:
-                    logger.debug(f"[MD] IEM fallback also failed for #{md_number}: {e}")
+                    logger.debug(f"IEM fallback also failed for #{md_number}: {e}")
     else:
         iem_result = first.result()
         try:
             html = await asyncio.wait_for(spc_task, timeout=5.0)
             if html:
-                logger.debug(f"[MD] SPC caught up for #{md_number}")
+                logger.debug(f"SPC caught up for #{md_number}")
                 iem_result = None
         except asyncio.TimeoutError:
-            logger.warning(f"[MD] SPC timed out for #{md_number} — using IEM")
+            logger.warning(f"SPC timed out for #{md_number} — using IEM")
             spc_task.cancel()
 
     if not html:
@@ -235,19 +235,19 @@ async def fetch_md_details(
         cached_text = await get_cached_md_text(md_number)
         
         if os.path.exists(cached_path):
-            logger.info(f"[MD] SPC unreachable for #{md_number}, serving image from cache")
+            logger.info(f"SPC unreachable for #{md_number}, serving image from cache")
             return fallback_url, None, True, cached_text
         if iem_result:
             iem_img, iem_summary, iem_raw = iem_result
             if iem_img:
-                logger.info(f"[MD] Got MD #{md_number} from IEM")
+                logger.info(f"Got MD #{md_number} from IEM")
                 return iem_img, iem_summary, True, iem_raw or cached_text
         
         if cached_text:
-            logger.info(f"[MD] SPC/IEM unreachable for #{md_number}, but found text in iembot cache")
+            logger.info(f"SPC/IEM unreachable for #{md_number}, but found text in iembot cache")
             return None, None, False, cached_text
 
-        logger.warning(f"[MD] SPC unreachable for #{md_number} and no cache or IEM available")
+        logger.warning(f"SPC unreachable for #{md_number} and no cache or IEM available")
         return None, None, False, None
 
     img_match = re.search(
@@ -265,7 +265,7 @@ async def fetch_md_details(
     # Check iembot real-time cache first (populated within seconds of issuance)
     summary = await get_cached_md_text(md_number)
     if summary:
-        logger.info(f"[MD] Got summary from iembot cache for #{md_number}")
+        logger.info(f"Got summary from iembot cache for #{md_number}")
 
     if not summary:
         concerning = re.search(r"(CONCERNING[^\n<]{10,120})", html, re.IGNORECASE)
@@ -541,13 +541,13 @@ class MesoscaleCog(commands.Cog):
         try:
             prob = int(m.group(1))
             if prob >= 80:
-                logger.info(f"[MD] High watch probability ({prob}%) for MD #{md_num} — triggering sounding pre-warm")
+                logger.info(f"High watch probability ({prob}%) for MD #{md_num} — triggering sounding pre-warm")
                 sounding_cog = self.bot.cogs.get("SoundingCog")
                 if sounding_cog:
                     t = asyncio.create_task(sounding_cog.prewarm_soundings_for_md(md_num, raw_text))
                     t.add_done_callback(_log_task_exception)
         except Exception as e:
-            logger.debug(f"[MD] Could not parse probability for MD #{md_num}: {e}")
+            logger.debug(f"Could not parse probability for MD #{md_num}: {e}")
 
     async def _upgrade_md_message(
         self,
@@ -585,13 +585,13 @@ class MesoscaleCog(commands.Cog):
                 if recovered:
                     full_text = recovered
                     changed = True
-                    logger.info(f"[MD] Recovered text for #{md_num}")
+                    logger.info(f"Recovered text for #{md_num}")
             if not cache_path:
                 cp, _, _ = await download_single_image(image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache)
                 if cp:
                     cache_path = cp
                     changed = True
-                    logger.info(f"[MD] Recovered image for #{md_num}")
+                    logger.info(f"Recovered image for #{md_num}")
             if changed:
                 await _push_edit()
             if cache_path and full_text:
@@ -604,7 +604,7 @@ class MesoscaleCog(commands.Cog):
         if not channel:
             return
         self.bot.state.posted_mds.add(md_num)
-        logger.info(f"[MD] iembot-triggered post for #{md_num}")
+        logger.info(f"iembot-triggered post for #{md_num}")
         image_url, summary, from_cache, raw_text = await fetch_md_details(md_num)
         if raw_text:
             t = asyncio.create_task(self._check_prewarm(md_num, raw_text))
@@ -632,9 +632,9 @@ class MesoscaleCog(commands.Cog):
                 t = asyncio.create_task(self._upgrade_md_message(md_num, msg, full_text))
                 self._pending_tasks.add(t)
                 t.add_done_callback(self._pending_tasks.discard)
-            logger.info(f"[MD] iembot-triggered: posted MD #{md_num}")
+            logger.info(f"iembot-triggered: posted MD #{md_num}")
         except Exception as e:
-            logger.exception(f"[MD] iembot send failed: {e}")
+            logger.exception(f"iembot send failed: {e}")
     @tasks.loop(seconds=30)
     async def auto_post_md(self):
         try:
@@ -676,13 +676,13 @@ class MesoscaleCog(commands.Cog):
                                    (num_int < current_max and current_max - num_int > 8000)
                         if is_newer:
                             logger.info(
-                                f"[MD] Index lagging (highest is {current_max:04d}) — "
+                                f"Index lagging (highest is {current_max:04d}) — "
                                 f"sparing #{md_num} from cancellation"
                             )
                             continue
 
                     logger.info(
-                        f"[MD] MD #{md_num} no longer on index — "
+                        f"MD #{md_num} no longer on index — "
                         f"posting cancellation"
                     )
                     embed = discord.Embed(
@@ -699,16 +699,15 @@ class MesoscaleCog(commands.Cog):
                         self.bot.state.active_mds.discard(md_num)
                         self._cancelled_mds.add(md_num)
                         self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
-                        logger.info(
-                            f"[MD] Posted cancellation for #{md_num}"
-                        )
+                        logger.info(f"Posted cancellation for #{md_num}")
+
                     except discord.HTTPException as e:
                         logger.exception(
-                            f"[MD] Failed to send cancellation "
+                            f"Failed to send cancellation "
                             f"for #{md_num}: {e}"
                         )
             else:
-                logger.debug("[MD] In fallback mode — skipping cancellation check")
+                logger.debug("In fallback mode — skipping cancellation check")
 
             # ── New MDs ────────────────────────────────────────────────────
             for md_num in md_numbers:
@@ -728,13 +727,13 @@ class MesoscaleCog(commands.Cog):
 
                 if not image_url:
                     logger.warning(
-                        f"[MD] Could not resolve image URL for MD #{md_num}"
+                        f"Could not resolve image URL for MD #{md_num}"
                     )
                     continue
 
                 if raw_text:
                     t = asyncio.create_task(self._check_prewarm(md_num, raw_text))
-                    t.add_done_callback(lambda t: None if t.cancelled() else (logger.exception("[MD] Prewarm failed", exc_info=t.exception()) if t.exception() else None))
+                    t.add_done_callback(lambda t: None if t.cancelled() else (logger.exception("Prewarm failed", exc_info=t.exception()) if t.exception() else None))
 
                 full_text = extract_md_body(raw_text)
 
@@ -765,14 +764,14 @@ class MesoscaleCog(commands.Cog):
                     await add_posted_md(str(md_num))
                     await prune_posted_mds()
                     self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
-                    logger.info(f"[MD] Posted MD #{md_num}")
+                    logger.info(f"Posted MD #{md_num}")
                 except Exception as e:
-                    logger.exception(f"[MD] auto_post_md send failed for #{md_num}: {e}")
+                    logger.exception(f"auto_post_md send failed for #{md_num}: {e}")
             self._md_backoff.success()
 
         except Exception as e:
             logger.exception(
-                f"[MD] Unexpected error in auto_post_md: {e}"
+                f"Unexpected error in auto_post_md: {e}"
             )
             await self._md_backoff.failure(self.bot)
 

--- a/cogs/nwws.py
+++ b/cogs/nwws.py
@@ -101,16 +101,16 @@ class NWWSClient(ClientXMPP):
         try:
             await self.get_roster()
         except (IqError, IqTimeout):
-            logger.error("[NWWS] Error fetching roster")
+            logger.error("Error fetching roster")
         
         # Join the NWWS-OI Multi-User Chat
-        logger.info(f"[NWWS] Joining room {self.room} as {self.nick}...")
+        logger.info(f"Joining room {self.room} as {self.nick}...")
         self.plugin['xep_0045'].join_muc(self.room, self.nick)
-        logger.info(f"[NWWS] XMPP Session Started as {self.boundjid}")
+        logger.info(f"XMPP Session Started as {self.boundjid}")
 
     def on_disconnect(self, event):
         self.is_connected = False
-        logger.warning("[NWWS] XMPP Disconnected")
+        logger.warning("XMPP Disconnected")
 
     def message(self, msg):
         # The specification says weather products arrive as 'groupchat' messages
@@ -174,7 +174,7 @@ class NWWSClient(ClientXMPP):
                 self.bot.state.nwws_last_window_time = now
                 # Set initial throughput estimate after first message
                 self.bot.state.nwws_throughput = 0.2  # Conservative initial estimate
-                logger.info("[NWWS] First realtime message received, throughput tracking started")
+                logger.info("First realtime message received, throughput tracking started")
             else:
                 elapsed = (now - last_time).total_seconds()
                 if elapsed >= 5:
@@ -185,13 +185,13 @@ class NWWSClient(ClientXMPP):
                     else:
                         # 70/30 rolling average: favor recent data
                         self.bot.state.nwws_throughput = (self.bot.state.nwws_throughput * 0.7) + (throughput * 0.3)
-                    logger.debug(f"[NWWS] Throughput update: {self.bot.state.nwws_throughput:.2f} msg/s ({self.bot.state.nwws_msg_count} in {elapsed:.1f}s)")
+                    logger.debug(f"Throughput update: {self.bot.state.nwws_throughput:.2f} msg/s ({self.bot.state.nwws_msg_count} in {elapsed:.1f}s)")
                     # Reset window
                     self.bot.state.nwws_msg_count = 0
                     self.bot.state.nwws_last_window_time = now
         else:
             # Log archived messages separately to understand reconnection behavior
-            logger.debug(f"[NWWS] Skipping archived message ({payload['awipsid']})")
+            logger.debug(f"Skipping archived message ({payload['awipsid']})")
 
         # Capture receive timestamp for accurate wire latency measurement
         from datetime import datetime as dt_class, timezone as tz_class
@@ -244,7 +244,7 @@ class NWWSClient(ClientXMPP):
                             else:
                                 self.bot.state.nwws_latency = (self.bot.state.nwws_latency * 0.7) + (latency * 0.3)
                 except Exception as e:
-                    logger.debug(f"[NWWS] Latency calculation failed ({issue_val}): {e}")
+                    logger.debug(f"Latency calculation failed ({issue_val}): {e}")
 
             # 2. Routing Logic
             
@@ -263,7 +263,7 @@ class NWWSClient(ClientXMPP):
                         
                         wtype = "TORNADO" if "Tornado Watch" in raw_text else "SVR"
                         await watches_cog.post_watch_now(watch_num, {"type": wtype, "expires": None, "affected_zones": []})
-                        logger.info(f"[NWWS] Triggered Watch {watch_num} via XMPP")
+                        logger.info(f"Triggered Watch {watch_num} via XMPP")
 
             # MDs (SWOMCD)
             elif "SWOMCD" in afos_pil:
@@ -275,7 +275,7 @@ class NWWSClient(ClientXMPP):
                         from utils.state_store import set_product_cache
                         await set_product_cache(f"md_{md_num}", raw_text, ttl=600)
                         await mesoscale_cog.post_md_now(md_num)
-                        logger.info(f"[NWWS] Triggered MD {md_num} via XMPP")
+                        logger.info(f"Triggered MD {md_num} via XMPP")
 
             # WARNINGS (TOR, SVR, FFW, etc)
             elif any(afos_pil.startswith(x) for x in ("TOR", "SVR", "FFW", "SVS", "FFS", "SPS")):
@@ -301,7 +301,7 @@ class NWWSClient(ClientXMPP):
                     pil_prefix = next((p for p in event_map if afos_pil.startswith(p)), None)
                     if pil_prefix:
                         await warnings_cog.post_warning_now(product_id, cleaned_text, event_map[pil_prefix])
-                        logger.info(f"[NWWS] Triggered {pil_prefix} Warning via XMPP")
+                        logger.info(f"Triggered {pil_prefix} Warning via XMPP")
 
             # REPORTS (LSR, PNS)
             elif any(afos_pil.startswith(x) for x in ("LSR", "PNS")):
@@ -309,10 +309,10 @@ class NWWSClient(ClientXMPP):
                 if reports_cog:
                     pil_prefix = "LSR" if afos_pil.startswith("LSR") else "PNS"
                     await reports_cog.post_report_now(product_id, raw_text, pil_prefix)
-                    logger.info(f"[NWWS] Triggered {pil_prefix} via XMPP")
+                    logger.info(f"Triggered {pil_prefix} via XMPP")
 
         except Exception as e:
-            logger.exception(f"[NWWS] Error processing XMPP message: {e}")
+            logger.exception(f"Error processing XMPP message: {e}")
 
 class NWWSCog(commands.Cog):
     MANAGED_TASK_NAMES = [("monitor_connection", "nwws_connection")]
@@ -324,7 +324,7 @@ class NWWSCog(commands.Cog):
 
     async def cog_load(self):
         if not all([NWWS_USER, NWWS_PASSWORD]):
-            logger.warning("[NWWS] Credentials missing, NWWS cog disabled")
+            logger.warning("Credentials missing, NWWS cog disabled")
             return
         
         self._should_be_connected = True
@@ -350,7 +350,7 @@ class NWWSCog(commands.Cog):
         """Maintain persistent connection to NWWS-OI."""
         if not self.bot.state.is_primary or not self._should_be_connected:
             if self.xmpp_client and self.xmpp_client.is_connected:
-                logger.info("[NWWS] Node is Standby — disconnecting NWWS")
+                logger.info("Node is Standby — disconnecting NWWS")
                 self.xmpp_client.disconnect()
             return
 
@@ -367,14 +367,14 @@ class NWWSCog(commands.Cog):
             self.xmpp_client.disconnect()
             self.xmpp_client = None
 
-        logger.info(f"[NWWS] Connecting to {NWWS_SERVER}...")
+        logger.info(f"Connecting to {NWWS_SERVER}...")
         jid = f"{NWWS_USER}@{NWWS_SERVER}"
         self.xmpp_client = NWWSClient(jid, NWWS_PASSWORD, self.bot)
         
         try:
             self.xmpp_client.connect(address=(NWWS_SERVER, 5222))
         except Exception as e:
-            logger.error(f"[NWWS] Connection attempt failed: {e}")
+            logger.error(f"Connection attempt failed: {e}")
             self.xmpp_client = None
 
     @monitor_connection.before_loop

--- a/cogs/recorder.py
+++ b/cogs/recorder.py
@@ -78,7 +78,7 @@ class RecorderCog(commands.Cog):
             data = {sid: m.to_dict() for sid, m in self.active_missions.items()}
             await set_state(STATE_KEY, json.dumps(data))
         except Exception as e:
-            logger.error(f"[RECORDER] Failed to persist missions: {e}")
+            logger.error(f"Failed to persist missions: {e}")
 
     async def _load_missions(self):
         """Reload active missions from shared state store."""
@@ -89,16 +89,16 @@ class RecorderCog(commands.Cog):
                 for sid, m_dict in data.items():
                     self.active_missions[sid] = VADRecordingMission.from_dict(m_dict)
                 if self.active_missions:
-                    logger.info(f"[RECORDER] Resumed {len(self.active_missions)} missions from state store")
+                    logger.info(f"Resumed {len(self.active_missions)} missions from state store")
         except Exception as e:
-            logger.error(f"[RECORDER] Failed to load missions: {e}")
+            logger.error(f"Failed to load missions: {e}")
 
     async def start_mission(self, site_id: str, trigger_ts: float, event_id: str = None):
         if site_id in self.active_missions:
             self.active_missions[site_id].extend(trigger_ts, event_id=event_id)
         else:
             self.active_missions[site_id] = VADRecordingMission(site_id, trigger_ts, {event_id} if event_id else None)
-            logger.info(f"[RECORDER] Started NEW mission for {site_id} (Initial Event: {event_id})")
+            logger.info(f"Started NEW mission for {site_id} (Initial Event: {event_id})")
         
         await self._persist_missions()
 
@@ -150,27 +150,27 @@ class RecorderCog(commands.Cog):
                     try:
                         await download_vad(mission.site_id, time=dt_utc, cache_path=mission.dir)
                         mission.processed_timestamps.add(ts)
-                        logger.debug(f"[RECORDER] Saved scan for {mission.site_id} @ {dt_utc}")
+                        logger.debug(f"Saved scan for {mission.site_id} @ {dt_utc}")
                     except Exception as e:
-                        logger.warning(f"[RECORDER] Failed to fetch {mission.site_id} @ {dt_utc}: {e}")
+                        logger.warning(f"Failed to fetch {mission.site_id} @ {dt_utc}: {e}")
                         
         except Exception as e:
-            logger.error(f"[RECORDER] Step failed for {mission.site_id}: {e}")
+            logger.error(f"Step failed for {mission.site_id}: {e}")
 
     async def _finalize_mission(self, mission: VADRecordingMission):
         """Build the evolution GIF and cleanup."""
-        logger.info(f"[RECORDER] Finalizing mission for {mission.site_id}...")
+        logger.info(f"Finalizing mission for {mission.site_id}...")
 
         loop = asyncio.get_running_loop()
         try:
             files = await loop.run_in_executor(None, os.listdir, mission.dir)
             files = [f for f in files if f.endswith(".has")]
         except FileNotFoundError:
-            logger.warning(f"[RECORDER] Mission dir {mission.dir} not found. Skipping.")
+            logger.warning(f"Mission dir {mission.dir} not found. Skipping.")
             return
 
         if not files:
-            logger.warning(f"[RECORDER] No data saved for mission {mission.site_id}. Skipping GIF.")
+            logger.warning(f"No data saved for mission {mission.site_id}. Skipping GIF.")
             return
         files.sort()
 
@@ -195,7 +195,7 @@ class RecorderCog(commands.Cog):
 
                 await loop.run_in_executor(self.executor, _make_gif)
 
-                logger.info(f"[RECORDER] Created evolution GIF: {gif_path}")
+                logger.info(f"Created evolution GIF: {gif_path}")
 
                 # 4. Calculate Peak SRH
                 peak_srh = 0.0
@@ -226,7 +226,7 @@ class RecorderCog(commands.Cog):
                         return srh_max
                     peak_srh = await loop.run_in_executor(self.executor, _calc_srh)
                 except Exception as e:
-                    logger.warning(f"[RECORDER] Peak SRH calc failed: {e}")
+                    logger.warning(f"Peak SRH calc failed: {e}")
 
                 # 5. Update DB for all events
                 if mission.event_ids:
@@ -240,9 +240,9 @@ class RecorderCog(commands.Cog):
                     if os.path.exists(mission.dir):
                         shutil.rmtree(mission.dir)
                 await loop.run_in_executor(None, _cleanup)
-                logger.info(f"[RECORDER] Cleaned up temporary data for {mission.site_id}")
+                logger.info(f"Cleaned up temporary data for {mission.site_id}")
         except Exception as e:
-            logger.error(f"[RECORDER] Finalization failed for {mission.site_id}: {e}")
+            logger.error(f"Finalization failed for {mission.site_id}: {e}")
     async def _post_forensic_summary(self, mission: VADRecordingMission, gif_path: str, peak_srh: float):
         try:
             from config import DEV_CHANNEL_ID
@@ -265,7 +265,7 @@ class RecorderCog(commands.Cog):
             embed.set_image(url="attachment://evolution.gif")
             await channel.send(embed=embed, file=file)
         except Exception as e:
-            logger.error(f"[RECORDER] Summary post failed: {e}")
+            logger.error(f"Summary post failed: {e}")
 
     @app_commands.command(name="archive", description="Search the environmental forensics archive")
     @app_commands.describe(radar="4-letter radar ID", date="YYYY-MM-DD")

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -102,7 +102,7 @@ class SoundingCog(commands.Cog):
         bot already covered today. Entries from previous UTC days are
         dropped on load."""
         self._restore_attempted = True
-        logger.info("[SOUNDING-AUTO] cog_load: restoring dedup state from state_store")
+        logger.info("cog_load: restoring dedup state from state_store")
         
         self.auto_sounding_watches.start()
         self.monitor_special_soundings.start()
@@ -113,7 +113,7 @@ class SoundingCog(commands.Cog):
             today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
             last_date = await get_state("sounding_handled_date")
             if last_date != today:
-                logger.info(f"[SOUNDING-AUTO] New day {today}, clearing handled watches")
+                logger.info(f"New day {today}, clearing handled watches")
                 await clear_sounding_handled_watches()
                 await set_state("sounding_handled_date", today)
             
@@ -124,12 +124,12 @@ class SoundingCog(commands.Cog):
             self._handled_watches = await get_sounding_handled_watches()
             
             logger.info(
-                f"[SOUNDING-AUTO] Restored {len(self._posted_watch_soundings)} "
+                f"Restored {len(self._posted_watch_soundings)} "
                 f"posted-sounding keys and {len(self._handled_watches)} "
                 f"handled watches for {today}"
             )
         except Exception as e:
-            logger.exception(f"[SOUNDING-AUTO] Could not restore dedup state: {e}")
+            logger.exception(f"Could not restore dedup state: {e}")
 
     async def _mark_sounding_posted(self, pkey: str):
         """Mark a sounding as posted in memory and persistent store."""
@@ -225,7 +225,7 @@ class SoundingCog(commands.Cog):
         try:
             stations_df = await get_raob_stations()
         except Exception as e:
-            logger.exception(f"[SOUNDING-MONITOR] Failed to load station list: {e}")
+            logger.exception(f"Failed to load station list: {e}")
             return
 
         channel = self.bot.get_channel(SOUNDING_CHANNEL_ID)
@@ -281,7 +281,7 @@ class SoundingCog(commands.Cog):
         if not all_to_post:
             return
 
-        logger.info(f"[SOUNDING-MONITOR] Found {len(all_to_post)} new sounding(s) near active watches")
+        logger.info(f"Found {len(all_to_post)} new sounding(s) near active watches")
 
         # 3. Process new soundings (Fetch -> Plot -> Send)
         # To avoid flooding, we process them in small batches if there are many
@@ -335,10 +335,10 @@ class SoundingCog(commands.Cog):
                     
                 try:
                     await channel.send(caption, files=[discord.File(png_path)])
-                    logger.info(f"[SOUNDING-MONITOR] Posted special release {sid} {h}z")
+                    logger.info(f"Posted special release {sid} {h}z")
                     self.bot.state.last_post_times["sounding"] = datetime.now(timezone.utc)
                 except Exception as e:
-                    logger.exception(f"[SOUNDING-MONITOR] Failed to post {sid}: {e}")
+                    logger.exception(f"Failed to post {sid}: {e}")
 
             await self._persist_posted_state()
 
@@ -654,7 +654,7 @@ class SoundingCog(commands.Cog):
         
         affected_zones = nws_info.get("affected_zones", []) if isinstance(nws_info, dict) else []
         if not affected_zones:
-            logger.warning(f"[SOUNDING-AUTO] No affected zones for watch #{watch_num} — skipping")
+            logger.warning(f"No affected zones for watch #{watch_num} — skipping")
             return
 
         await self._mark_watch_handled(watch_num)
@@ -663,14 +663,14 @@ class SoundingCog(commands.Cog):
 
         centroid = await get_watch_area_centroid(affected_zones)
         if not centroid:
-            logger.warning(f"[SOUNDING-AUTO] Could not get centroid for watch #{watch_num}")
+            logger.warning(f"Could not get centroid for watch #{watch_num}")
             return
         lat, lon = centroid
 
         try:
             stations_df = await get_raob_stations()
         except Exception as e:
-            logger.exception(f"[SOUNDING-AUTO] Failed to load station list: {e}")
+            logger.exception(f"Failed to load station list: {e}")
             return
 
         candidates = find_nearest_stations(lat, lon, stations_df, n=6)
@@ -700,14 +700,14 @@ class SoundingCog(commands.Cog):
 
         # ── Phase 1: fetch all sounding data concurrently ─────────────────
         async def _fetch_raob(station, sid, y, mo, d, h, tkey, pkey):
-            logger.info(f"[SOUNDING-AUTO] Fetching {sid} {h}z near {watch_label} #{watch_num}")
+            logger.info(f"Fetching {sid} {h}z near {watch_label} #{watch_num}")
             data = await fetch_sounding(
                 sid, y, mo, d, h,
                 station_name=station["name"],
                 lat=station["lat"], lon=station["lon"],
             )
             if not data:
-                logger.warning(f"[SOUNDING-AUTO] No data for {sid} at {tkey}")
+                logger.warning(f"No data for {sid} at {tkey}")
             return station, sid, y, mo, d, h, data
 
         fetch_results = await asyncio.gather(*[_fetch_raob(*r) for r in to_fetch])
@@ -742,10 +742,10 @@ class SoundingCog(commands.Cog):
                 caption += f"\n{qwarn}"
             try:
                 await target_channel.send(caption, files=[discord.File(png_path)])
-                logger.info(f"[SOUNDING-AUTO] Posted {sid} for watch #{watch_num}")
+                logger.info(f"Posted {sid} for watch #{watch_num}")
                 self.bot.state.last_post_times["sounding"] = datetime.now(timezone.utc)
             except Exception as e:
-                logger.exception(f"[SOUNDING-AUTO] Failed to post {sid}: {e}")
+                logger.exception(f"Failed to post {sid}: {e}")
 
         acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
         acars_eligible = []
@@ -759,7 +759,7 @@ class SoundingCog(commands.Cog):
                 acars_eligible.append(profile)
 
         async def _fetch_acars(p):
-            logger.info(f"[SOUNDING-AUTO] Fetching ACARS {p['airport']} near {watch_label} #{watch_num}")
+            logger.info(f"Fetching ACARS {p['airport']} near {watch_label} #{watch_num}")
             data = await fetch_acars_sounding(
                 p["profile_id"], p["year"], p["month"], p["day"], p["acars_hour"]
             )
@@ -799,10 +799,10 @@ class SoundingCog(commands.Cog):
                 # `channel` (the watches-announcement channel), which
                 # caused ACARS soundings to land in #weather-chat.
                 await target_channel.send(caption, files=[discord.File(png_path)])
-                logger.info(f"[SOUNDING-AUTO] Posted ACARS {p['airport']} for watch #{watch_num}")
+                logger.info(f"Posted ACARS {p['airport']} for watch #{watch_num}")
                 self.bot.state.last_post_times["sounding"] = datetime.now(timezone.utc)
             except Exception as e:
-                logger.exception(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
+                logger.exception(f"Failed to post ACARS: {e}")
 
         await self._persist_posted_state()
 
@@ -831,12 +831,12 @@ class SoundingCog(commands.Cog):
         if not channel:
             return
 
-        logger.info(f"[SOUNDING-AUTO] Checking {len(self.bot.state.active_watches)} active watches for {time_key}")
+        logger.info(f"Checking {len(self.bot.state.active_watches)} active watches for {time_key}")
 
         try:
             stations_df = await get_raob_stations()
         except Exception as e:
-            logger.exception(f"[SOUNDING-AUTO] Failed to load station list: {e}")
+            logger.exception(f"Failed to load station list: {e}")
             return
 
         year = now.strftime("%Y")
@@ -850,7 +850,7 @@ class SoundingCog(commands.Cog):
 
             centroid = await get_watch_area_centroid(affected_zones)
             if not centroid:
-                logger.warning(f"[SOUNDING-AUTO] Could not get centroid for watch #{watch_num}")
+                logger.warning(f"Could not get centroid for watch #{watch_num}")
                 continue
 
             lat, lon = centroid
@@ -859,7 +859,7 @@ class SoundingCog(commands.Cog):
 
             verified = await filter_stations_with_data(candidates)
             if not verified:
-                logger.info(f"[SOUNDING-AUTO] No verified stations near watch #{watch_num}")
+                logger.info(f"No verified stations near watch #{watch_num}")
                 continue
 
             wtype = info.get("type", "SVR") if isinstance(info, dict) else "SVR"
@@ -878,12 +878,12 @@ class SoundingCog(commands.Cog):
             # ── Phase 1: fetch all RAOB data concurrently ─────────────────
             async def _fetch_std(station, sid):
                 logger.info(
-                    f"[SOUNDING-AUTO] Fetching {sid} {sounding_time}z"
+                    f"Fetching {sid} {sounding_time}z"
                     f" near {watch_label} #{watch_num}"
                 )
                 data = await fetch_sounding(sid, year, month, day, sounding_time)
                 if not data:
-                    logger.warning(f"[SOUNDING-AUTO] No data for {sid} at {time_key}")
+                    logger.warning(f"No data for {sid} at {time_key}")
                 return station, sid, data
 
             fetch_results = await asyncio.gather(*[_fetch_std(s, sid) for s, sid in eligible])
@@ -922,10 +922,10 @@ class SoundingCog(commands.Cog):
                     caption += f"\n{qwarn}"
                 try:
                     await channel.send(caption, files=[discord.File(png_path)])
-                    logger.info(f"[SOUNDING-AUTO] Posted {sid} for watch #{watch_num}")
+                    logger.info(f"Posted {sid} for watch #{watch_num}")
                     self.bot.state.last_post_times["sounding"] = datetime.now(timezone.utc)
                 except Exception as e:
-                    logger.exception(f"[SOUNDING-AUTO] Failed to post: {e}")
+                    logger.exception(f"Failed to post: {e}")
 
         # ── ACARS auto-posting ────────────────────────────────────────────
             acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
@@ -938,7 +938,7 @@ class SoundingCog(commands.Cog):
 
             async def _fetch_acars2(p):
                 logger.info(
-                    f"[SOUNDING-AUTO] Fetching ACARS {p['airport']}"
+                    f"Fetching ACARS {p['airport']}"
                     f" near {watch_label} #{watch_num}"
                 )
                 data = await fetch_acars_sounding(
@@ -976,10 +976,10 @@ class SoundingCog(commands.Cog):
                 )
                 try:
                     await channel.send(caption, files=[discord.File(png_path)])
-                    logger.info(f"[SOUNDING-AUTO] Posted ACARS {p['airport']} for watch #{watch_num}")
+                    logger.info(f"Posted ACARS {p['airport']} for watch #{watch_num}")
                     self.bot.state.last_post_times["sounding"] = datetime.now(timezone.utc)
                 except Exception as e:
-                    logger.exception(f"[SOUNDING-AUTO] Failed to post ACARS: {e}")
+                    logger.exception(f"Failed to post ACARS: {e}")
 
             await self._persist_posted_state()
 

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -73,7 +73,7 @@ async def fetch_and_send_weather_images(
             else:
                 await source.send(msg)
         except discord.HTTPException as e:
-            logger.debug(f"[STATUS] Could not send fallback message: {e}")
+            logger.debug(f"Could not send fallback message: {e}")
         return
 
     files = await download_images_parallel(
@@ -96,7 +96,7 @@ async def fetch_and_send_weather_images(
             else:
                 await source.send(msg)
         except discord.HTTPException as e:
-            logger.debug(f"[STATUS] Could not send fallback message: {e}")
+            logger.debug(f"Could not send fallback message: {e}")
 
 
 class MDPaginatorView(discord.ui.View):
@@ -851,13 +851,13 @@ class StatusCog(commands.Cog):
         try:
             await get_high_risk_polygon()
         except Exception as e:
-            logger.debug(f"[STATUS] Outlook peek failed: {e}")
+            logger.debug(f"Outlook peek failed: {e}")
 
         # Update Discord gateway information
         try:
             await update_gateway_info(self.bot)
         except Exception as e:
-            logger.debug(f"[STATUS] Could not update gateway info: {e}")
+            logger.debug(f"Could not update gateway info: {e}")
 
         view = StatusView(self.bot, interaction)
         embeds = await view.build_embeds()
@@ -906,7 +906,7 @@ class StatusCog(commands.Cog):
                     "❌ You are not authorized to use this command.", ephemeral=True
                 )
         else:
-            logger.error(f"[STATUS] Command error: {error}")
+            logger.error(f"Command error: {error}")
 
 
 

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -72,10 +72,10 @@ class WarningsCog(commands.Cog):
             persisted = await get_all_posted_warnings()
             self.bot.state.posted_warnings.update(persisted)
             logger.info(
-                f"[WARN] Restored {len(persisted)} posted warning(s) from store"
+                f"Restored {len(persisted)} posted warning(s) from store"
             )
         except Exception as e:
-            logger.warning(f"[WARN] Could not restore posted_warnings: {e}")
+            logger.warning(f"Could not restore posted_warnings: {e}")
 
         self.auto_poll_warnings.start()
 
@@ -119,7 +119,7 @@ class WarningsCog(commands.Cog):
                 }
             else:
                 logger.warning(
-                    f"[WARN] iembot trigger: no VTEC in {product_id} — skipping"
+                    f"iembot trigger: no VTEC in {product_id} — skipping"
                 )
                 return
 
@@ -217,7 +217,7 @@ class WarningsCog(commands.Cog):
 
             try:
                 msg = await channel.send(embed=embed, files=files, view=view)
-                logger.info(f"[WARN] Posted (iembot) {event} {vtec_id} ({'Update' if is_update else 'Issuance'})")
+                logger.info(f"Posted (iembot) {event} {vtec_id} ({'Update' if is_update else 'Issuance'})")
 
                 # Simple area extraction for persistence
                 area_m = re.search(r"for (.+?) till", concise_text)
@@ -235,7 +235,7 @@ class WarningsCog(commands.Cog):
                 if not is_update and vtec_id in self.bot.state.posted_warnings:
                     del self.bot.state.posted_warnings[vtec_id]
                 logger.exception(
-                    f"[WARN] iembot send failed for {vtec_id}: {e}"
+                    f"iembot send failed for {vtec_id}: {e}"
                 )
                 return
 
@@ -247,7 +247,7 @@ class WarningsCog(commands.Cog):
                     self.bot.state.posted_product_ids.clear()
                 await prune_posted_warnings()
             except Exception as e:
-                logger.warning(f"[WARN] Failed to persist {vtec_id}: {e}")
+                logger.warning(f"Failed to persist {vtec_id}: {e}")
         finally:
             self._in_flight_vtecs.discard(vtec_id)
 
@@ -291,7 +291,7 @@ class WarningsCog(commands.Cog):
                 source=office,
                 raw_text=raw_text
             )
-            logger.info(f"[WARN] Logged confirmed tornado for {vtec_id} (match: {match_id is not None})")
+            logger.info(f"Logged confirmed tornado for {vtec_id} (match: {match_id is not None})")
 
             # 2. Trigger VAD Recorder mission
             try:
@@ -304,9 +304,9 @@ class WarningsCog(commands.Cog):
                         recorder = self.bot.get_cog("RecorderCog")
                         if recorder:
                             recorder.start_mission(radar_id, time.time(), event_id=event_id)
-                            logger.info(f"[WARN] Triggered VAD recorder for {radar_id} near {lat:.2f}, {lon:.2f} (Event: {event_id})")
+                            logger.info(f"Triggered VAD recorder for {radar_id} near {lat:.2f}, {lon:.2f} (Event: {event_id})")
             except Exception as e:
-                logger.warning(f"[WARN] Failed to trigger VAD recorder for {vtec_id}: {e}")
+                logger.warning(f"Failed to trigger VAD recorder for {vtec_id}: {e}")
 
             return event_id
 
@@ -456,7 +456,7 @@ class WarningsCog(commands.Cog):
                 if content and status == 200:
                     files.append(discord.File(BytesIO(content), filename=filename))
             except Exception as e:
-                logger.debug(f"[WARN] No cancellation image for {vtec_id}: {e}")
+                logger.debug(f"No cancellation image for {vtec_id}: {e}")
 
         embed = discord.Embed(
             description=description,
@@ -474,9 +474,9 @@ class WarningsCog(commands.Cog):
         try:
             await channel.send(embed=embed, files=files)
             self._cancelled_warnings.add(vtec_id)
-            logger.info(f"[WARN] Posted cancellation for {vtec_id}")
+            logger.info(f"Posted cancellation for {vtec_id}")
         except Exception as e:
-            logger.warning(f"[WARN] Failed to post cancellation for {vtec_id}: {e}")
+            logger.warning(f"Failed to post cancellation for {vtec_id}: {e}")
 
     @tasks.loop(seconds=30)
     async def auto_poll_warnings(self):
@@ -485,7 +485,7 @@ class WarningsCog(commands.Cog):
         try:
             await self._tick()
         except Exception as e:
-            logger.exception(f"[WARN] Tick failed: {e}")
+            logger.exception(f"Tick failed: {e}")
             await self._backoff.failure(self.bot)
 
     async def _tick(self):
@@ -495,7 +495,7 @@ class WarningsCog(commands.Cog):
 
         channel = self.bot.get_channel(WARNINGS_CHANNEL_ID)
         if not channel:
-            logger.warning("[WARN] Warnings channel not found — skipping poll")
+            logger.warning("Warnings channel not found — skipping poll")
             return
 
         content, status, validators = await http_get_bytes_conditional(
@@ -510,7 +510,7 @@ class WarningsCog(commands.Cog):
             return
         if not content or status != 200:
             logger.warning(
-                f"[WARN] NWS API returned status {status} — will retry next cycle"
+                f"NWS API returned status {status} — will retry next cycle"
             )
             await self._backoff.failure(self.bot)
             return
@@ -523,7 +523,7 @@ class WarningsCog(commands.Cog):
             from models.nws import NWSAlertResponse
             alert_response = NWSAlertResponse.model_validate(data)
         except Exception as e:
-            logger.warning(f"[WARN] JSON/Pydantic parse failed: {e}")
+            logger.warning(f"JSON/Pydantic parse failed: {e}")
             return
 
         current_vtec_data = {}
@@ -579,7 +579,7 @@ class WarningsCog(commands.Cog):
                                 try:
                                     await self._post_warning(feature, channel, vtec_dict, event, is_update=True)
                                 except discord.HTTPException as e:
-                                    logger.exception(f"[WARN] Update send failed for {issuance_id}: {e}")
+                                    logger.exception(f"Update send failed for {issuance_id}: {e}")
 
                                 # Update stored area so we don't spam updates for every poll
                                 self.bot.state.posted_warnings[issuance_id]["area"] = curr_area
@@ -616,7 +616,7 @@ class WarningsCog(commands.Cog):
                 try:
                     msg, area_desc = await self._post_warning(feature, channel, vtec_dict, event)
                 except discord.HTTPException as e:
-                    logger.exception(f"[WARN] Send failed for {issuance_id}: {e}")
+                    logger.exception(f"Send failed for {issuance_id}: {e}")
                     # Roll back placeholder on failure
                     if issuance_id in self.bot.state.posted_warnings and not self.bot.state.posted_warnings[issuance_id]:
                         del self.bot.state.posted_warnings[issuance_id]
@@ -633,7 +633,7 @@ class WarningsCog(commands.Cog):
                     await prune_posted_warnings()
                 except Exception as e:
                     logger.warning(
-                        f"[WARN] Failed to persist {issuance_id}: {e}"
+                        f"Failed to persist {issuance_id}: {e}"
                     )
             finally:
                 self._in_flight_vtecs.discard(issuance_id)
@@ -704,7 +704,7 @@ class WarningsCog(commands.Cog):
                 embed.set_image(url=f"attachment://{filename}")
 
         msg = await channel.send(embed=embed, files=files)
-        logger.info(f"[WARN] Posted {event} {vtec_id}")
+        logger.info(f"Posted {event} {vtec_id}")
         return msg, area_desc
 
     @auto_poll_warnings.after_loop
@@ -718,7 +718,7 @@ class WarningsCog(commands.Cog):
             exc = None
         if exc:
             logger.error(
-                f"[TASK] auto_poll_warnings stopped: "
+                f"auto_poll_warnings stopped: "
                 f"{type(exc).__name__}: {exc}",
                 exc_info=exc,
             )

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -68,9 +68,9 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
                 for w in _nws_last_parsed.values():
                     if w.get("expires"):
                         w["expires"] = datetime.fromisoformat(w["expires"])
-                logger.info(f"[WATCH] Resumed {len(_nws_last_parsed)} watches from state store")
+                logger.info(f"Resumed {len(_nws_last_parsed)} watches from state store")
             except Exception as e:
-                logger.warning(f"[WATCH] Failed to load last_parsed state: {e}")
+                logger.warning(f"Failed to load last_parsed state: {e}")
                 _nws_last_parsed = {}
         else:
             _nws_last_parsed = {}
@@ -88,7 +88,7 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
         return _nws_last_parsed
         
     if not content or status != 200:
-        logger.warning(f"[WATCH] NWS API returned status {status} — will retry next cycle")
+        logger.warning(f"NWS API returned status {status} — will retry next cycle")
         return None
 
     # 3. Update validators
@@ -102,7 +102,7 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
     try:
         data = _json.loads(content)
     except Exception as e:
-        logger.warning(f"[WATCH] NWS API JSON parse error: {e}")
+        logger.warning(f"NWS API JSON parse error: {e}")
         return None
 
     result = {}
@@ -125,7 +125,7 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
                         timezone.utc
                     )
                 except (ValueError, TypeError) as e:
-                    logger.debug(f"[WATCH] Could not parse expires {expires_str!r}: {e}")
+                    logger.debug(f"Could not parse expires {expires_str!r}: {e}")
             
             affected_zones = props.get("affectedZones", [])
             result[watch_num] = {
@@ -156,12 +156,12 @@ async def fetch_latest_watch_numbers() -> List[Tuple[str, str]]:
     """
     nws = await fetch_active_watches_nws()
     if nws is None:
-        logger.warning("[WATCH] NWS API fetch failed — skipping, no fallback for auto loop")
+        logger.warning("NWS API fetch failed — skipping, no fallback for auto loop")
         return []
     if nws:
         return [(num, info["type"]) for num, info in nws.items()]
 
-    logger.warning("[WATCH] NWS API empty, falling back to SPC HTML scrape")
+    logger.warning("NWS API empty, falling back to SPC HTML scrape")
     html = await http_get_text(SPC_WATCH_INDEX_URL)
     if not html:
         return []
@@ -236,10 +236,10 @@ async def fetch_watch_details_iem(watch_number: str) -> Tuple[Optional[str], Opt
                     if len(prelim_lines) > 1:
                         probs = "\n".join(prelim_lines)
 
-                    logger.info(f"[WATCH] Got details from IEM watches API for #{watch_number}")
+                    logger.info(f"Got details from IEM watches API for #{watch_number}")
                     break
     except Exception as e:
-        logger.warning(f"[WATCH] IEM watches API failed for #{watch_number}: {e}")
+        logger.warning(f"IEM watches API failed for #{watch_number}: {e}")
 
     # No image available from IEM — SPC image will be retried separately
     return text_summary, None, probs
@@ -428,33 +428,33 @@ async def fetch_watch_details(
             if prob_lines:
                 probs = "\n".join(prob_lines)
             logger.info(
-                f"[WATCH] Parsed {len(pairs)} prob entries "
+                f"Parsed {len(pairs)} prob entries "
                 f"for #{watch_number}"
             )
         else:
             logger.warning(
-                f"[WATCH] No prob pairs parsed for #{watch_number}"
+                f"No prob pairs parsed for #{watch_number}"
             )
 
     # Check iembot real-time cache first (populated within seconds of issuance)
     cached_text = await get_cached_watch_text(watch_number)
     if cached_text and not text_summary:
         text_summary = cached_text
-        logger.info(f"[WATCH] Got text from iembot cache for #{watch_number}")
+        logger.info(f"Got text from iembot cache for #{watch_number}")
 
     # IEM fallback: if SPC page was unreachable, try IEM watches API
     if not html:
-        logger.warning(f"[WATCH] SPC unreachable for #{watch_number} — using IEM data")
+        logger.warning(f"SPC unreachable for #{watch_number} — using IEM data")
         iem_summary, iem_img, iem_probs = await fetch_watch_details_iem(watch_number)
         if iem_summary and not text_summary:
             text_summary = iem_summary
-            logger.info(f"[WATCH] Got text from IEM for #{watch_number}")
+            logger.info(f"Got text from IEM for #{watch_number}")
         if iem_img and not image_url:
             image_url = iem_img
-            logger.info(f"[WATCH] Got image from IEM for #{watch_number}")
+            logger.info(f"Got image from IEM for #{watch_number}")
         if iem_probs and not probs:
             probs = iem_probs
-            logger.info(f"[WATCH] Got preliminary probs from IEM for #{watch_number}")
+            logger.info(f"Got preliminary probs from IEM for #{watch_number}")
 
     return image_url, text_summary, probs
 
@@ -601,7 +601,7 @@ class WatchPaginatorView(discord.ui.View):
             try:
                 await self.message.edit(view=self)
             except discord.HTTPException as e:
-                logger.debug(f"[WATCH] Could not disable view on timeout: {e}")
+                logger.debug(f"Could not disable view on timeout: {e}")
 
 
 async def _execute_watches(interaction: discord.Interaction, bot: commands.Bot):
@@ -723,7 +723,7 @@ class WatchesCog(commands.Cog):
                     )
                     files = _watch_files(watch_num, cache_path)
                     await message.edit(embed=embed, attachments=files)
-                    logger.info(f"[WATCH] Full upgrade complete for #{watch_num}")
+                    logger.info(f"Full upgrade complete for #{watch_num}")
                     return
 
                 # If we only have Probs, or we're on the last attempt, do a 
@@ -751,11 +751,11 @@ class WatchesCog(commands.Cog):
                     if has_real_probs:
                         # We have real probs but still no image. 
                         # Break to Stage 2 for dedicated image slow-poll.
-                        logger.info(f"[WATCH] Probs updated for #{watch_num}; transitioning to slow-poll for image")
+                        logger.info(f"Probs updated for #{watch_num}; transitioning to slow-poll for image")
                         break
 
             except Exception as e:
-                logger.warning(f"[WATCH] Upgrade attempt {attempt+1} failed for #{watch_num}: {e}")
+                logger.warning(f"Upgrade attempt {attempt+1} failed for #{watch_num}: {e}")
 
         # ── Stage 2: Slow poll specifically for the Image ──────────────────
         # Sometimes SPC takes 15-20 minutes to generate the GIF during high load.
@@ -792,13 +792,13 @@ class WatchesCog(commands.Cog):
                 )
                 files = _watch_files(watch_num, cache_path)
                 await message.edit(embed=embed, attachments=files)
-                logger.info(f"[WATCH] Image finally backfilled for #{watch_num} after slow-poll")
+                logger.info(f"Image finally backfilled for #{watch_num} after slow-poll")
                 return
 
             except Exception as e:
-                logger.debug(f"[WATCH] Slow-poll image check failed for #{watch_num}: {e}")
+                logger.debug(f"Slow-poll image check failed for #{watch_num}: {e}")
 
-        logger.info(f"[WATCH] Gave up on image backfill for #{watch_num} after 30 minutes")
+        logger.info(f"Gave up on image backfill for #{watch_num} after 30 minutes")
 
     async def post_watch_now(self, watch_num: str, nws_info: dict):
         """
@@ -819,7 +819,7 @@ class WatchesCog(commands.Cog):
         color = discord.Color.red() if is_tornado else discord.Color.orange()
         now_utc = datetime.now(timezone.utc)
 
-        logger.info(f"[WATCH] iembot-triggered post for #{watch_num} ({wtype})")
+        logger.info(f"iembot-triggered post for #{watch_num} ({wtype})")
         image_url, text_summary, probs = await fetch_watch_details(watch_num)
         cache_path = None
         if image_url:
@@ -850,7 +850,7 @@ class WatchesCog(commands.Cog):
             await add_posted_watch(str(watch_num))
             await prune_posted_watches()
             self.bot.state.last_post_times["watch"] = now_utc
-            logger.info(f"[WATCH] iembot-triggered: posted watch #{watch_num}")
+            logger.info(f"iembot-triggered: posted watch #{watch_num}")
             sounding_cog = self.bot.cogs.get("SoundingCog")
             if sounding_cog and isinstance(nws_info, dict) and nws_info.get("affected_zones"):
                 asyncio.create_task(
@@ -865,7 +865,7 @@ class WatchesCog(commands.Cog):
                 self._pending_tasks.add(t)
                 t.add_done_callback(self._pending_tasks.discard)
         except discord.HTTPException as e:
-            logger.exception(f"[WATCH] iembot-triggered send failed for #{watch_num}: {e}")
+            logger.exception(f"iembot-triggered send failed for #{watch_num}: {e}")
 
     @tasks.loop(minutes=2)
     async def auto_post_watches(self):
@@ -883,7 +883,7 @@ class WatchesCog(commands.Cog):
             nws_watches = await fetch_active_watches_nws()
             if nws_watches is None:
                 logger.warning(
-                    "[WATCH] NWS API fetch failed — skipping cycle, active set unchanged"
+                    "NWS API fetch failed — skipping cycle, active set unchanged"
                 )
                 return
             now_utc = datetime.now(timezone.utc)
@@ -906,7 +906,7 @@ class WatchesCog(commands.Cog):
                 self.bot.state.active_watches.pop(watch_num, None)
                 reason = "expired" if expired_by_time else "no longer active"
                 logger.info(
-                    f"[WATCH] Watch #{watch_num} {reason} — "
+                    f"Watch #{watch_num} {reason} — "
                     f"posting cancellation"
                 )
                 watch_label = (
@@ -926,11 +926,11 @@ class WatchesCog(commands.Cog):
                 try:
                     await channel.send(embed=embed)
                     logger.info(
-                        f"[WATCH] Posted cancellation for #{watch_num}"
+                        f"Posted cancellation for #{watch_num}"
                     )
                 except discord.HTTPException as e:
                     logger.exception(
-                        f"[WATCH] Failed to send cancellation "
+                        f"Failed to send cancellation "
                         f"for #{watch_num}: {e}"
                     )
                     self.bot.state.active_watches[watch_num] = info
@@ -968,7 +968,7 @@ class WatchesCog(commands.Cog):
                 )
 
                 logger.info(
-                    f"[WATCH] New watch detected: #{watch_num} ({wtype})"
+                    f"New watch detected: #{watch_num} ({wtype})"
                 )
                 image_url, text_summary, probs = await fetch_watch_details(
                     watch_num
@@ -998,7 +998,7 @@ class WatchesCog(commands.Cog):
                     await add_posted_watch(str(watch_num))
                     await prune_posted_watches()
                     self.bot.state.last_post_times["watch"] = datetime.now(timezone.utc)
-                    logger.info(f"[WATCH] Posted watch #{watch_num}")
+                    logger.info(f"Posted watch #{watch_num}")
                     sounding_cog = self.bot.cogs.get("SoundingCog")
                     if sounding_cog:
                         asyncio.create_task(
@@ -1014,14 +1014,14 @@ class WatchesCog(commands.Cog):
                         t.add_done_callback(self._pending_tasks.discard)
                 except discord.HTTPException as e:
                     logger.exception(
-                        f"[WATCH] Discord send failed for #{watch_num}: {e}"
+                        f"Discord send failed for #{watch_num}: {e}"
                     )
 
             self._watches_backoff.success()
 
         except Exception as e:
             logger.exception(
-                f"[WATCH] Unexpected error in auto_post_watches: {e}",
+                f"Unexpected error in auto_post_watches: {e}",
             )
             await self._watches_backoff.failure(self.bot)
 

--- a/main.py
+++ b/main.py
@@ -183,7 +183,7 @@ async def _check_failover() -> bool:
             should_run_primary = await failover_cog.startup_lease_check()
         except Exception as e:
             logger.warning(
-                f"[FAILOVER] Startup lease check failed ({e!r}) — "
+                f"Startup lease check failed ({e!r}) — "
                 f"falling back to IS_PRIMARY env value and deferring to "
                 f"sync_loop for reconciliation"
             )
@@ -202,7 +202,7 @@ async def setup_hook():
         for ext in ALL_EXTENSIONS:
             await bot.load_extension(ext)
     else:
-        logger.info("[FAILOVER] Running as STANDBY — cogs suppressed until promoted")
+        logger.info("Running as STANDBY — cogs suppressed until promoted")
 
     watchdog_task.start()
 
@@ -280,7 +280,7 @@ async def on_ready():
             except Exception as e:
                 logger.exception(f"Failed to sync command tree: {e}")
         else:
-            logger.info("[FAILOVER] Standby — skipping command sync to preserve primary commands")
+            logger.info("Standby — skipping command sync to preserve primary commands")
         logger.info(f"All tasks started. Bot v{__version__} is ready.")
         if not periodic_sync.is_running():
             periodic_sync.start()
@@ -302,9 +302,9 @@ async def periodic_sync():
         return
     try:
         synced = await bot.tree.sync()
-        logger.info(f"[SYNC] Periodic command sync: {len(synced)} commands")
+        logger.info(f"Periodic command sync: {len(synced)} commands")
     except Exception as e:
-        logger.exception(f"[SYNC] Periodic command sync failed: {e}")
+        logger.exception(f"Periodic command sync failed: {e}")
 
 
 @bot.event
@@ -366,7 +366,7 @@ async def watchdog_task():
             ) as r:
                 return r.status < 500
         except Exception as e:
-            logger.warning(f"[WATCHDOG] Session probe to {url} failed: {e!r}")
+            logger.warning(f"Session probe to {url} failed: {e!r}")
             return False
 
     primary_ok = await _head_ok(_PROBE_PRIMARY)
@@ -374,13 +374,13 @@ async def watchdog_task():
 
     if probe_healthy:
         if _session_probe_failures > 0:
-            logger.info(f"[WATCHDOG] Session probe recovered after {_session_probe_failures} failure(s)")
+            logger.info(f"Session probe recovered after {_session_probe_failures} failure(s)")
         _session_probe_failures = 0
     else:
         _session_probe_failures += 1
         if _session_probe_failures >= 3:
             logger.warning(
-                f"[WATCHDOG] Session probe failed {_session_probe_failures} consecutive times — "
+                f"Session probe failed {_session_probe_failures} consecutive times — "
                 "tearing down and recreating"
             )
             try:
@@ -395,13 +395,13 @@ async def watchdog_task():
                     color=discord.Color.red(),
                 ))
             except Exception as alert_err:
-                logger.warning(f"[WATCHDOG] Could not send session-reset alert: {alert_err}")
+                logger.warning(f"Could not send session-reset alert: {alert_err}")
             await utils.http.close_session()
             await utils.http.ensure_session()
             _session_probe_failures = 0
         else:
             logger.info(
-                f"[WATCHDOG] Session probe failed ({_session_probe_failures}/3) — "
+                f"Session probe failed ({_session_probe_failures}/3) — "
                 "waiting for next cycle"
             )
             if _session_probe_failures == 2:
@@ -416,7 +416,7 @@ async def watchdog_task():
                         color=discord.Color.orange(),
                     ))
                 except Exception as alert_err:
-                    logger.warning(f"[WATCHDOG] Could not send degradation alert: {alert_err}")
+                    logger.warning(f"Could not send degradation alert: {alert_err}")
 
     # Grace period for startup race: tasks need a few ticks to schedule
     # their first iteration after wait_until_ready() unblocks.
@@ -457,7 +457,7 @@ async def watchdog_task():
                 if exc:
                     error_detail = f"\n**Last Error:** `{type(exc).__name__}: {exc}`"
             except (asyncio.CancelledError, asyncio.InvalidStateError) as e:
-                logger.debug(f"[WATCHDOG] Could not read task exception: {e}")
+                logger.debug(f"Could not read task exception: {e}")
 
         # Attempt to (re)start the task quietly
         try:
@@ -469,14 +469,14 @@ async def watchdog_task():
                 except (asyncio.CancelledError, asyncio.TimeoutError):
                     pass
                 except Exception as e:
-                    logger.debug(f"[WATCHDOG] Error while awaiting cancelled task: {e}")
+                    logger.debug(f"Error while awaiting cancelled task: {e}")
             task.start()
             
             log_fn = logger.info if name in _task_seen_running else logger.debug
-            log_fn(f"[WATCHDOG] Attempted to {'re' if name in _task_seen_running else ''}start '{name}'")
+            log_fn(f"Attempted to {'re' if name in _task_seen_running else ''}start '{name}'")
         except Exception as e:
             logger.exception(
-                f"[WATCHDOG] Failed to restart '{name}': {e}"
+                f"Failed to restart '{name}': {e}"
             )
 
         # Alerts — only for tasks we've seen running before to avoid startup noise

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -68,7 +68,7 @@ async def hydrate_validators_from_store() -> int:
     if stored:
         _validators_cache.update(stored)
     _validators_hydrated = True
-    logger.info(f"[CACHE] Hydrated {len(_validators_cache)} HTTP validators from store")
+    logger.info(f"Hydrated {len(_validators_cache)} HTTP validators from store")
     return len(_validators_cache)
 
 logger = logging.getLogger("spc_bot")
@@ -138,7 +138,7 @@ async def should_use_cache_for_manual(urls: List[str]) -> bool:
     if day is None:
         return False
     if is_near_spc_update(day):
-        logger.debug(f"[CACHE] Near Day {day} update window - forcing fresh download")
+        logger.debug(f"Near Day {day} update window - forcing fresh download")
         return False
 
     paths = [get_cache_path_for_url(u) for u in urls]
@@ -149,9 +149,9 @@ async def should_use_cache_for_manual(urls: List[str]) -> bool:
     now = datetime.now()
     ages = [now - datetime.fromtimestamp(m) for m in mtimes]
     if ages and min(ages) > timedelta(hours=3):
-        logger.info("[CACHE] Cached files are older than 3 hours; refreshing")
+        logger.info("Cached files are older than 3 hours; refreshing")
         return False
-    logger.debug(f"[CACHE] Using cached files for Day {day} (min age: {min(ages)})")
+    logger.debug(f"Using cached files for Day {day} (min age: {min(ages)})")
     return True
 
 
@@ -221,7 +221,7 @@ async def download_single_image(
                 validators.get("last_modified", ""),
             )
         except Exception as e:
-            logger.debug(f"[CACHE] set_validators failed for {url}: {e}")
+            logger.debug(f"set_validators failed for {url}: {e}")
 
     if is_placeholder_image(content):
         logger.info(
@@ -300,7 +300,7 @@ async def check_partial_updates_parallel(
                     validators.get("last_modified", ""),
                 )
             except Exception as e:
-                logger.debug(f"[CACHE] set_validators failed for {url}: {e}")
+                logger.debug(f"set_validators failed for {url}: {e}")
 
         if is_placeholder_image(content):
             return url, 0
@@ -317,7 +317,7 @@ async def check_partial_updates_parallel(
 
     log = logger.info if updated_count > 0 else logger.debug
     log(
-        f"[CACHE] Partial check complete: {updated_count}/{total_count} updated "
+        f"Partial check complete: {updated_count}/{total_count} updated "
         f"({not_modified_count}/{total_count} returned 304 Not Modified)"
     )
     return updated_count, total_count, downloaded_data
@@ -404,7 +404,7 @@ async def fetch_with_validators(
                         validators.get("last_modified", ""),
                     )
                 except Exception as e:
-                    logger.debug(f"[CACHE] set_validators failed for {url}: {e}")
+                    logger.debug(f"set_validators failed for {url}: {e}")
             return content, status
 
         if status == 304:
@@ -412,7 +412,7 @@ async def fetch_with_validators(
 
         if retry_statuses and status in retry_statuses and attempt < retries:
             delay = min(2 ** (attempt + 1), 10)
-            logger.debug(f"[CACHE] Retrying {url} (status={status}) in {delay}s...")
+            logger.debug(f"Retrying {url} (status={status}) in {delay}s...")
             await asyncio.sleep(delay)
             continue
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -62,7 +62,7 @@ async def _write(sql: str, params: tuple, op: str) -> None:
     except Exception as e:
         _write_failure_count += 1
         level = logger.error if _write_failure_count >= _WRITE_FAILURE_ALERT_THRESHOLD else logger.warning
-        level(f"[DB] {op} failed ({_write_failure_count} consecutive): {e}")
+        level(f"{op} failed ({_write_failure_count} consecutive): {e}")
 
 
 async def _write_many(sql: str, rows: Iterable[tuple], op: str) -> None:
@@ -78,7 +78,7 @@ async def _write_many(sql: str, rows: Iterable[tuple], op: str) -> None:
     except Exception as e:
         _write_failure_count += 1
         level = logger.error if _write_failure_count >= _WRITE_FAILURE_ALERT_THRESHOLD else logger.warning
-        level(f"[DB] {op} failed ({_write_failure_count} consecutive): {e}")
+        level(f"{op} failed ({_write_failure_count} consecutive): {e}")
 
 
 async def get_db() -> aiosqlite.Connection:
@@ -107,7 +107,7 @@ async def _connect() -> aiosqlite.Connection:
 
     await _create_tables(db)
     await db.commit()
-    logger.info(f"[DB] Connected to {DB_PATH}")
+    logger.info(f"Connected to {DB_PATH}")
     return db
 
 
@@ -198,9 +198,9 @@ async def close_db():
     if _db is not None:
         try:
             await _db.close()
-            logger.info("[DB] Database connection closed")
+            logger.info("Database connection closed")
         except Exception as e:
-            logger.warning(f"[DB] Error closing database: {e}")
+            logger.warning(f"Error closing database: {e}")
         _db = None
 
 
@@ -212,10 +212,10 @@ async def check_integrity() -> bool:
             row = await cursor.fetchone()
             ok = row and row[0] == "ok"
             if not ok:
-                logger.error(f"[DB] Integrity check failed: {row}")
+                logger.error(f"Integrity check failed: {row}")
             return ok
     except Exception as e:
-        logger.exception(f"[DB] Integrity check error: {e}")
+        logger.exception(f"Integrity check error: {e}")
         return False
 
 
@@ -239,7 +239,7 @@ async def get_hash(url: str, cache_type: Optional[str] = None) -> Optional[str]:
             row = await cursor.fetchone()
             return row["hash"] if row else None
     except Exception as e:
-        logger.warning(f"[DB] get_hash failed for {url}: {e}")
+        logger.warning(f"get_hash failed for {url}: {e}")
         return None
 
 
@@ -271,7 +271,7 @@ async def get_all_hashes(cache_type: Optional[str] = None) -> dict:
                 rows = await cursor.fetchall()
         return {row["url"]: row["hash"] for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_all_hashes failed: {e}")
+        logger.warning(f"get_all_hashes failed: {e}")
         return {}
 
 
@@ -298,7 +298,7 @@ async def get_posted_mds() -> set:
             rows = await cursor.fetchall()
             return {row["md_number"] for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_posted_mds failed: {e}")
+        logger.warning(f"get_posted_mds failed: {e}")
         return set()
 
 
@@ -337,7 +337,7 @@ async def get_posted_watches() -> set:
             rows = await cursor.fetchall()
             return {row["watch_number"] for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_posted_watches failed: {e}")
+        logger.warning(f"get_posted_watches failed: {e}")
         return set()
 
 
@@ -374,7 +374,7 @@ async def get_posted_surveys() -> set:
             rows = await cursor.fetchall()
             return {row["dat_guid"] for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_posted_surveys failed: {e}")
+        logger.warning(f"get_posted_surveys failed: {e}")
         return set()
 
 
@@ -411,7 +411,7 @@ async def get_posted_reports() -> set:
             rows = await cursor.fetchall()
             return {row["product_id"] for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_posted_reports failed: {e}")
+        logger.warning(f"get_posted_reports failed: {e}")
         return set()
 
 
@@ -457,7 +457,7 @@ async def get_all_posted_warnings() -> dict:
                 for row in rows
             }
     except Exception as e:
-        logger.warning(f"[DB] get_all_posted_warnings failed: {e}")
+        logger.warning(f"get_all_posted_warnings failed: {e}")
         return {}
 
 
@@ -472,7 +472,7 @@ async def get_posted_warning_timestamp(vtec_id: str) -> Optional[float]:
             row = await cursor.fetchone()
             return row["posted_at"] if row else None
     except Exception as e:
-        logger.warning(f"[DB] get_posted_warning_timestamp failed: {e}")
+        logger.warning(f"get_posted_warning_timestamp failed: {e}")
         return None
 
 
@@ -519,7 +519,7 @@ async def get_posted_soundings() -> set[str]:
             rows = await cursor.fetchall()
             return {row["pkey"] for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_posted_soundings failed: {e}")
+        logger.warning(f"get_posted_soundings failed: {e}")
         return set()
 
 
@@ -550,7 +550,7 @@ async def get_sounding_handled_watches() -> set[str]:
             rows = await cursor.fetchall()
             return {row["watch_number"] for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_sounding_handled_watches failed: {e}")
+        logger.warning(f"get_sounding_handled_watches failed: {e}")
         return set()
 
 
@@ -584,7 +584,7 @@ async def get_state(key: str) -> Optional[str]:
             row = await cursor.fetchone()
             return row["value"] if row else None
     except Exception as e:
-        logger.warning(f"[DB] get_state failed for {key}: {e}")
+        logger.warning(f"get_state failed for {key}: {e}")
         return None
 
 
@@ -596,7 +596,7 @@ async def get_all_state() -> dict:
             rows = await cursor.fetchall()
             return {row["key"]: row["value"] for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_all_state failed: {e}")
+        logger.warning(f"get_all_state failed: {e}")
         return {}
 
 
@@ -633,7 +633,7 @@ async def get_posted_urls(day_key: str) -> list:
             if row:
                 return json.loads(row["urls"])
     except Exception as e:
-        logger.warning(f"[DB] get_posted_urls failed for {day_key}: {e}")
+        logger.warning(f"get_posted_urls failed for {day_key}: {e}")
     return []
 
 
@@ -645,7 +645,7 @@ async def get_all_posted_urls() -> dict:
             rows = await cursor.fetchall()
             return {row["day_key"]: json.loads(row["urls"]) for row in rows}
     except Exception as e:
-        logger.warning(f"[DB] get_all_posted_urls failed: {e}")
+        logger.warning(f"get_all_posted_urls failed: {e}")
         return {}
 
 
@@ -684,7 +684,7 @@ async def get_product_cache(product_id: str) -> Optional[str]:
                 return row["text"]
             return None
     except Exception as e:
-        logger.warning(f"[DB] get_product_cache failed for {product_id}: {e}")
+        logger.warning(f"get_product_cache failed for {product_id}: {e}")
         return None
 
 
@@ -703,7 +703,7 @@ async def get_validators(url: str) -> Optional[dict]:
                 return None
             return {"etag": row["etag"], "last_modified": row["last_modified"]}
     except Exception as e:
-        logger.warning(f"[DB] get_validators failed for {url}: {e}")
+        logger.warning(f"get_validators failed for {url}: {e}")
         return None
 
 
@@ -723,7 +723,7 @@ async def get_all_validators() -> dict:
                 for row in rows
             }
     except Exception as e:
-        logger.warning(f"[DB] get_all_validators failed: {e}")
+        logger.warning(f"get_all_validators failed: {e}")
         return {}
 
 
@@ -777,7 +777,7 @@ async def get_dirty_writes() -> list:
                 for r in rows
             ]
     except Exception as e:
-        logger.warning(f"[DB] get_dirty_writes failed: {e}")
+        logger.warning(f"get_dirty_writes failed: {e}")
         return []
 
 

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -51,7 +51,7 @@ async def get_events_db() -> aiosqlite.Connection:
     await _create_tables(conn)
     await conn.commit()
     _db = conn
-    logger.info(f"[EVENTS-DB] Connected to {_EVENTS_DB_PATH}")
+    logger.info(f"Connected to {_EVENTS_DB_PATH}")
     return _db
 
 
@@ -129,7 +129,7 @@ async def add_significant_event(
         await db.commit()
         _mark_dirty()
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] add_significant_event({event_id}) failed: {e}")
+        logger.warning(f"add_significant_event({event_id}) failed: {e}")
 
 
 async def update_event_environment(event_id: str, gif_path: str, srh_0_1: float) -> None:
@@ -142,9 +142,9 @@ async def update_event_environment(event_id: str, gif_path: str, srh_0_1: float)
         )
         await db.commit()
         _mark_dirty()
-        logger.info(f"[EVENTS-DB] Updated environment for {event_id} (SRH: {srh_0_1:.1f})")
+        logger.info(f"Updated environment for {event_id} (SRH: {srh_0_1:.1f})")
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] update_event_environment({event_id}) failed: {e}")
+        logger.warning(f"update_event_environment({event_id}) failed: {e}")
 
 
 async def link_dat_guid_to_tornado(date_str: str, guid: str, label: str) -> Optional[Tuple[str, Optional[str], Optional[str], Optional[str]]]:
@@ -186,11 +186,11 @@ async def link_dat_guid_to_tornado(date_str: str, guid: str, label: str) -> Opti
             )
             await db.commit()
             _mark_dirty()
-            logger.info(f"[EVENTS-DB] Linked DAT {guid} to event {best_id}")
+            logger.info(f"Linked DAT {guid} to event {best_id}")
             return (best_id, best_row["location"], best_row["magnitude"], best_row["coords"])
             
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] link_dat_guid_to_tornado failed: {e}")
+        logger.warning(f"link_dat_guid_to_tornado failed: {e}")
     return None
 
 
@@ -214,7 +214,7 @@ async def backfill_dat_guids(days: int = 30):
     try:
         data = await http_get_json(url, retries=1, timeout=15)
         if not data or "features" not in data:
-            logger.debug(f"[EVENTS-DB] No DAT updates found in last {days} days")
+            logger.debug(f"No DAT updates found in last {days} days")
             return
 
         # 2. Get un-linked tornadoes from our DB
@@ -268,10 +268,10 @@ async def backfill_dat_guids(days: int = 30):
         if linked_count > 0:
             await db.commit()
             _mark_dirty()
-            logger.info(f"[EVENTS-DB] Backfilled {linked_count} DAT GUIDs via geographic matching")
+            logger.info(f"Backfilled {linked_count} DAT GUIDs via geographic matching")
 
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] backfill_dat_guids failed: {e}")
+        logger.warning(f"backfill_dat_guids failed: {e}")
 
 
 async def fetch_dat_photos(
@@ -497,7 +497,7 @@ async def get_recent_significant_events(
             rows = await cur.fetchall()
             return [dict(r) for r in rows]
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] get_recent_significant_events failed: {e}")
+        logger.warning(f"get_recent_significant_events failed: {e}")
         return []
 
 
@@ -534,7 +534,7 @@ async def find_matching_tornado(
         return None
 
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] find_matching_tornado failed: {e}")
+        logger.warning(f"find_matching_tornado failed: {e}")
         return None
 
 
@@ -551,10 +551,10 @@ async def prune_old_significant_events(days: int = 365) -> int:
         await db.commit()
         if count > 0:
             _mark_dirty()
-            logger.info(f"[EVENTS-DB] Pruned {count} events older than {days} days")
+            logger.info(f"Pruned {count} events older than {days} days")
         return count
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] Pruning failed: {e}")
+        logger.warning(f"Pruning failed: {e}")
         return 0
 
 
@@ -581,34 +581,34 @@ async def snapshot_for_sync() -> None:
             await db.backup(dst)
         os.replace(tmp, _SYNC_PATH)
         _db_dirty = False
-        logger.debug("[EVENTS-DB] Snapshot written to sync dir")
+        logger.debug("Snapshot written to sync dir")
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] Snapshot failed: {e}")
+        logger.warning(f"Snapshot failed: {e}")
 
 
 def restore_from_sync() -> None:
     """Copy the Syncthing-received snapshot into events.db before cogs load.
     Called synchronously at promotion time before the event loop is busy."""
     if not os.path.exists(_SYNC_PATH):
-        logger.info("[EVENTS-DB] No sync snapshot found — starting fresh events.db")
+        logger.info("No sync snapshot found — starting fresh events.db")
         return
     
     global _db
     if _db is not None:
-        logger.warning("[EVENTS-DB] Cannot restore while DB is open — close it first")
+        logger.warning("Cannot restore while DB is open — close it first")
         return
 
     try:
         os.makedirs(os.path.dirname(_EVENTS_DB_PATH), exist_ok=True)
         # Ensure we don't copy over a corrupted or partial sync file
         if os.path.getsize(_SYNC_PATH) < 4096: # Minimal SQLite file size
-             logger.warning("[EVENTS-DB] Sync snapshot too small, skipping restore")
+             logger.warning("Sync snapshot too small, skipping restore")
              return
              
         shutil.copy2(_SYNC_PATH, _EVENTS_DB_PATH)
-        logger.info("[EVENTS-DB] Restored events.db from sync snapshot")
+        logger.info("Restored events.db from sync snapshot")
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] Restore from sync failed: {e}")
+        logger.warning(f"Restore from sync failed: {e}")
 
 
 # ── Syncthing folder-mode flipping ───────────────────────────────────────────
@@ -628,7 +628,7 @@ async def set_syncthing_folder_mode(mode: str) -> None:
                 f"{url_base}/rest/config/folders/{folder_id}", headers=headers, timeout=_aiohttp.ClientTimeout(total=5)
             ) as resp:
                 if resp.status != 200:
-                    logger.warning(f"[EVENTS-DB] Syncthing folder fetch failed: {resp.status}")
+                    logger.warning(f"Syncthing folder fetch failed: {resp.status}")
                     return
                 folder_cfg = await resp.json()
             folder_cfg["type"] = mode
@@ -639,8 +639,8 @@ async def set_syncthing_folder_mode(mode: str) -> None:
                 timeout=_aiohttp.ClientTimeout(total=5),
             ) as resp:
                 if resp.status in (200, 201):
-                    logger.info(f"[EVENTS-DB] Syncthing folder set to {mode}")
+                    logger.info(f"Syncthing folder set to {mode}")
                 else:
-                    logger.warning(f"[EVENTS-DB] Syncthing folder update failed: {resp.status}")
+                    logger.warning(f"Syncthing folder update failed: {resp.status}")
     except Exception as e:
-        logger.warning(f"[EVENTS-DB] Syncthing API call failed: {e}")
+        logger.warning(f"Syncthing API call failed: {e}")

--- a/utils/http.py
+++ b/utils/http.py
@@ -43,7 +43,7 @@ class CircuitBreaker:
 
     def record_success(self, host: str):
         if host in self.failures:
-            logger.info(f"[CIRCUIT] {host} recovered. Closing circuit.")
+            logger.info(f"{host} recovered. Closing circuit.")
             self.failures.pop(host, None)
             self.last_failure_time.pop(host, None)
 
@@ -51,14 +51,14 @@ class CircuitBreaker:
         self.failures[host] = self.failures.get(host, 0) + 1
         self.last_failure_time[host] = time.time()
         if self.failures[host] == self.failure_threshold:
-            logger.warning(f"[CIRCUIT] {host} reached {self.failure_threshold} failures. Circuit OPEN.")
+            logger.warning(f"{host} reached {self.failure_threshold} failures. Circuit OPEN.")
 
     def is_open(self, host: str) -> bool:
         failures = self.failures.get(host, 0)
         if failures >= self.failure_threshold:
             # Check if recovery timeout has passed
             if time.time() - self.last_failure_time.get(host, 0) > self.recovery_timeout:
-                logger.info(f"[CIRCUIT] {host} recovery timeout elapsed. Half-open circuit.")
+                logger.info(f"{host} recovery timeout elapsed. Half-open circuit.")
                 # Half-open: allow one request through to test
                 self.failures[host] = self.failure_threshold - 1
                 return False
@@ -147,7 +147,7 @@ async def http_get_bytes_conditional(
     host = parsed.netloc
 
     if circuit_breaker.is_open(host):
-        logger.warning(f"[HTTP] Circuit open for {host}, failing fast: {url}")
+        logger.warning(f"Circuit open for {host}, failing fast: {url}")
         raise CircuitOpenError(f"Circuit breaker is open for {host}")
 
     headers: Dict[str, str] = dict(extra_headers) if extra_headers else {}
@@ -209,7 +209,7 @@ async def http_get_bytes_conditional(
         if status is None or status >= 500 or status == 429:
             circuit_breaker.record_failure(host)
             
-        logger.warning(f"[HTTP] Request failed for {url} after {retries} retries: {e}")
+        logger.warning(f"Request failed for {url} after {retries} retries: {e}")
         return None, status, None
 
 
@@ -299,7 +299,7 @@ async def http_get_json(url: str, retries: int = 1, timeout: int = TIMEOUT_STAND
                     r.request_info, r.history, status=r.status, message="Server returned retryable error"
                 )
             if r.status != 200:
-                logger.warning(f"[HTTP] JSON fetch failed for {url}: {r.status}")
+                logger.warning(f"JSON fetch failed for {url}: {r.status}")
                 circuit_breaker.record_failure(host)
                 return None
             circuit_breaker.record_success(host)
@@ -311,5 +311,5 @@ async def http_get_json(url: str, retries: int = 1, timeout: int = TIMEOUT_STAND
         status = getattr(e, "status", None)
         if status is None or status >= 500 or status == 429:
             circuit_breaker.record_failure(host)
-        logger.warning(f"[HTTP] JSON fetch error for {url}: {type(e).__name__}: {e}")
+        logger.warning(f"JSON fetch error for {url}: {type(e).__name__}: {e}")
         return None


### PR DESCRIPTION
Removes hardcoded bracketed prefixes from log messages across the project. These are no longer needed now that hierarchical loggers are in place.