### PR TITLE
fix: robust warning area extraction and unified ACARS dedup keys

### DIFF
--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -529,11 +529,8 @@ class SoundingCog(commands.Cog):
 
         acars_to_post = []
         for p in acars_in_poly:
-            pkey = (
-                f"acars:{p['airport']}:"
-                f"{p['year']}{p['month']}{p['day']}_{p['acars_hour']}z"
-            )
-            if pkey not in self._posted_watch_soundings:
+            pkey = p.get("pkey")
+            if pkey and pkey not in self._posted_watch_soundings:
                 await self._mark_sounding_posted(pkey)
                 acars_to_post.append(p)
 
@@ -750,12 +747,9 @@ class SoundingCog(commands.Cog):
         acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
         acars_eligible = []
         for profile in acars_profiles[:2]:
-            post_key = (
-                f"acars:{profile['airport']}:"
-                f"{profile['year']}{profile['month']}{profile['day']}_{profile['acars_hour']}z"
-            )
-            if post_key not in self._posted_watch_soundings:
-                await self._mark_sounding_posted(post_key)
+            pkey = profile.get("pkey")
+            if pkey and pkey not in self._posted_watch_soundings:
+                await self._mark_sounding_posted(pkey)
                 acars_eligible.append(profile)
 
         async def _fetch_acars(p):
@@ -931,9 +925,9 @@ class SoundingCog(commands.Cog):
             acars_profiles = await get_acars_profiles_near(lat, lon, max_dist_km=300, hours_back=1)
             acars_eligible2 = []
             for profile in acars_profiles[:2]:
-                post_key = f"acars:{profile['airport']}:{time_key}"
-                if post_key not in self._posted_watch_soundings:
-                    await self._mark_sounding_posted(post_key)
+                pkey = profile.get("pkey")
+                if pkey and pkey not in self._posted_watch_soundings:
+                    await self._mark_sounding_posted(pkey)
                     acars_eligible2.append(profile)
 
             async def _fetch_acars2(p):

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -621,6 +621,8 @@ async def get_acars_profiles_near(
             if dist <= max_dist_km:
                 seen_airports.add(airport_code)
                 time_part = profile_id.split("_")[1] if "_" in profile_id else hour + "00"
+                # High-precision deduplication key used by SoundingCog
+                pkey = f"acars:{airport_code}:{year}{month}{day}_{time_part}z"
                 results.append({
                     "profile_id": profile_id,
                     "airport": airport_code,
@@ -632,6 +634,7 @@ async def get_acars_profiles_near(
                     "month": month,
                     "day": day,
                     "acars_hour": hour,
+                    "pkey": pkey,
                     "time_label": f"{time_part[:2]}:{time_part[2:]}z" if len(time_part) >= 4 else f"{time_part}z",
                 })
 
@@ -658,7 +661,7 @@ async def get_acars_profiles_in_polygon(
         return []
 
     import sounderpy as spy  # noqa: PLC0415
-    from shapely.geometry import Point  # noqa: PLC0415
+    from utils.spc_outlook import is_inside_polygon
 
     now = datetime.now(timezone.utc)
     results: list[dict] = []
@@ -699,23 +702,24 @@ async def get_acars_profiles_in_polygon(
                     logger.debug(f"[ACARS] Airport lookup failed for {airport_code!r}: {e}")
                     continue
 
-            if not polygon.contains(Point(airport_latlon[1], airport_latlon[0])):
-                continue
-
-            seen_airports.add(airport_code)
-            time_part = profile_id.split("_")[1] if "_" in profile_id else hour + "00"
-            results.append({
-                "profile_id": profile_id,
-                "airport": airport_code,
-                "name": airport_code,
-                "lat": airport_latlon[0],
-                "lon": airport_latlon[1],
-                "year": year,
-                "month": month,
-                "day": day,
-                "acars_hour": hour,
-                "time_label": f"{time_part[:2]}:{time_part[2:]}z" if len(time_part) >= 4 else f"{time_part}z",
-            })
+            if is_inside_polygon(airport_latlon[0], airport_latlon[1], polygon):
+                seen_airports.add(airport_code)
+                time_part = profile_id.split("_")[1] if "_" in profile_id else hour + "00"
+                # High-precision deduplication key used by SoundingCog
+                pkey = f"acars:{airport_code}:{year}{month}{day}_{time_part}z"
+                results.append({
+                    "profile_id": profile_id,
+                    "airport": airport_code,
+                    "name": airport_code,
+                    "lat": airport_latlon[0],
+                    "lon": airport_latlon[1],
+                    "year": year,
+                    "month": month,
+                    "day": day,
+                    "acars_hour": hour,
+                    "pkey": pkey,
+                    "time_label": f"{time_part[:2]}:{time_part[2:]}z" if len(time_part) >= 4 else f"{time_part}z",
+                })
             if len(results) >= max_results:
                 return results
 

--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -428,7 +428,8 @@ def build_concise_warning_text(
         area = feature.get("properties", {}).get("areaDesc", area)
     elif raw_text:
         # Step A: Look for the standard "Warning for..." bullet
-        m_area = re.search(r"(?:Warning for|Statement for|IMPACT)\s+(.+?)(?=\n\s*\*|\n\s*At\s+|\n\s*LAT\.\.\.LON|$)", raw_text, re.I | re.DOTALL)
+        # The [\s.]+ handles both "Warning for..." and "Warning for   ..."
+        m_area = re.search(r"(?:Warning for|Statement for|IMPACT)[\s.]+(.+?)(?=\n\s*\*|\n\s*At\s+|\n\s*LAT\.\.\.LON|$)", raw_text, re.I | re.DOTALL)
         
         # Step B: Fallback to the technical header line (e.g., "CLEVELAND OK-MCCLAIN OK-")
         # This is usually between the VTEC line and the timestamp.


### PR DESCRIPTION
Fixes two issues:\n1. Refined the area extraction regex to handle 'for...' with dots, which was causing the 'affected area' bug in new warnings.\n2. Unified ACARS deduplication keys to use a consistent, high-precision format (acars:airport:timestamp) across all automated tasks. This prevents double-posts when different tasks overlap and ensures reboots correctly restore previous post state.