### PR TITLE
fix: bold HAZARD in narratives and finalize cancellation watermarks

### DIFF
--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -557,7 +557,7 @@ def build_concise_warning_text(
                 word = m.group(1).upper()
                 # Only bold if the word (excluding trailing dots) is a high-signal keyword
                 base_word = re.sub(r"\.+$", "", word)
-                if base_word in ("TORNADO", "HAIL", "WIND", "GUST", "WATERSPOUT", "IMPACT", "SOURCE", "MAX", "DAMAGE", "THREAT"):
+                if base_word in ("TORNADO", "HAIL", "WIND", "GUST", "HAZARD", "WATERSPOUT", "IMPACT", "SOURCE", "MAX", "DAMAGE", "THREAT"):
                     return f"**{m.group(1)}**"
                 return m.group(1)
 


### PR DESCRIPTION
Final visual refinements:\n1. Added 'HAZARD' to the list of weather keywords that are automatically bolded in warning narratives.\n2. Confirmed and finalized the 'EVENT NO LONGER ACTIVE' watermark logic for cancellation/expiration posts.