### PR TITLE
fix: harden HTTP status types and env var validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,17 +63,36 @@ def _require_int(name: str) -> int:
     val = os.getenv(name)
     if not val:
         raise ValueError(f"{name} environment variable not set")
-    return int(val)
+    try:
+        return int(val)
+    except ValueError:
+        raise ValueError(f"{name}={val!r} must be an integer")
+
+
+def _optional_int(*names: str) -> int:
+    """Return the int value of the first env var that is set.
+
+    Validates the value if set (raises ValueError with a helpful message).
+    The last name is treated as required if none of the preceding names are set.
+    """
+    for name in names[:-1]:
+        val = os.getenv(name)
+        if val:
+            try:
+                return int(val)
+            except ValueError:
+                raise ValueError(f"{name}={val!r} must be an integer")
+    return _require_int(names[-1])
 
 
 CONFIG = {
     "token": os.getenv("DISCORD_TOKEN"),
     "models_channel_id": _require_int("MODELS_CHANNEL_ID"),
     "spc_channel_id": _require_int("SPC_CHANNEL_ID"),
-    "health_channel_id": int(os.getenv("HEALTH_CHANNEL_ID") or os.getenv("SPC_CHANNEL_ID")),
-    "sounding_channel_id": int(os.getenv("SOUNDING_CHANNEL_ID") or os.getenv("SPC_CHANNEL_ID")),
-    "warnings_channel_id": int(os.getenv("WARNINGS_CHANNEL_ID") or os.getenv("SPC_CHANNEL_ID")),
-    "dev_channel_id": int(os.getenv("DEV_CHANNEL_ID") or os.getenv("HEALTH_CHANNEL_ID") or os.getenv("SPC_CHANNEL_ID")),
+    "health_channel_id": _optional_int("HEALTH_CHANNEL_ID", "SPC_CHANNEL_ID"),
+    "sounding_channel_id": _optional_int("SOUNDING_CHANNEL_ID", "SPC_CHANNEL_ID"),
+    "warnings_channel_id": _optional_int("WARNINGS_CHANNEL_ID", "SPC_CHANNEL_ID"),
+    "dev_channel_id": _optional_int("DEV_CHANNEL_ID", "HEALTH_CHANNEL_ID", "SPC_CHANNEL_ID"),
     "manual_cache_file": os.getenv("MANUAL_CACHE_FILE", "posted_records.json"),
     "auto_cache_file": os.getenv("AUTO_CACHE_FILE", "auto_posted_records.json"),
     "guild_id": _require_int("GUILD_ID"),

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -118,7 +118,7 @@ async def test_http_get_bytes_gives_up_after_retries():
          patch("utils.http.asyncio.sleep", _fake_sleep):
         content, status = await http.http_get_bytes("https://x/a", retries=3)
     assert content is None
-    assert status is None
+    assert status == 0
     assert session.get.call_count == 3
 
 

--- a/utils/http.py
+++ b/utils/http.py
@@ -123,7 +123,7 @@ async def http_get_bytes(
     retries: int = 3,
     timeout: int = 30,
     headers: Optional[Dict[str, str]] = None,
-) -> Tuple[Optional[bytes], Optional[int]]:
+) -> Tuple[Optional[bytes], int]:
     content, status, _ = await http_get_bytes_conditional(
         url,
         etag=None,
@@ -142,7 +142,7 @@ async def http_get_bytes_conditional(
     retries: int = 3,
     timeout: int = 30,
     extra_headers: Optional[Dict[str, str]] = None,
-) -> Tuple[Optional[bytes], Optional[int], Optional[Dict[str, str]]]:
+) -> Tuple[Optional[bytes], int, Optional[Dict[str, str]]]:
     parsed = urlparse(url)
     host = parsed.netloc
 
@@ -205,10 +205,10 @@ async def http_get_bytes_conditional(
         # Only record failure in the circuit breaker if it's a "hard" failure
         # (connection/timeout) or a server-side/rate-limit error (5xx, 429).
         # We DON'T trip the circuit on 404s or other user-side 4xx errors.
-        status = getattr(e, 'status', None)
-        if status is None or status >= 500 or status == 429:
+        status: int = getattr(e, 'status', None) or 0
+        if status == 0 or status >= 500 or status == 429:
             circuit_breaker.record_failure(host)
-            
+
         logger.warning(f"Request failed for {url} after {retries} retries: {e}")
         return None, status, None
 


### PR DESCRIPTION
## Summary
- Normalize `None` status to `0` on network errors in `http_get_bytes_conditional` so callers can safely use `status == 200` comparisons without null checks; tighten return type annotation from `Optional[int]` to `int`
- Add `_optional_int()` helper in `config.py` that validates each env var if set before falling back, giving a clear `ValueError` with the variable name and value on non-integer input instead of an unattributed crash at import time

## Test plan
- [ ] Set `HEALTH_CHANNEL_ID=abc` and confirm the error message names the variable
- [ ] Confirm `status == 0` on a timeout in the circuit breaker path
- [ ] Confirm no test regressions (`382 passed`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)