### PR TITLE
perf: persist watch centroids to DB with 12h TTL

### DIFF
--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -35,6 +35,7 @@ from cogs.sounding_utils import (
 )
 from cogs.sounding_views import CombinedSoundingView, post_sounding
 from config import CACHE_DIR, SOUNDING_CHANNEL_ID
+from utils.db import get_watch_centroid_cache, set_watch_centroid_cache
 from utils.spc_outlook import get_high_risk_polygon, is_inside_polygon
 from utils.state_store import (
     add_posted_sounding,
@@ -144,15 +145,25 @@ class SoundingCog(commands.Cog):
     async def _resolve_watch_centroid(
         self, watch_num: str, info: dict
     ) -> Optional[tuple]:
-        """Memoized centroid lookup for a watch. Returns (lat, lon) or None."""
+        """Memoized centroid lookup for a watch. Returns (lat, lon) or None.
+
+        Check order: in-memory dict → DB cache (12h TTL) → NWS zone HTTP calls.
+        """
         if watch_num in self._watch_centroids:
             return self._watch_centroids[watch_num]
+
+        cached = await get_watch_centroid_cache(watch_num)
+        if cached:
+            self._watch_centroids[watch_num] = cached
+            return cached
+
         zones = info.get("affected_zones", []) if isinstance(info, dict) else []
         if not zones:
             return None
         centroid = await get_watch_area_centroid(zones)
         if centroid:
             self._watch_centroids[watch_num] = centroid
+            await set_watch_centroid_cache(watch_num, centroid)
         return centroid
 
     async def _watches_near(

--- a/utils/db.py
+++ b/utils/db.py
@@ -775,6 +775,34 @@ async def set_product_cache(product_id: str, text: str, ttl: int = 600):
     )
 
 
+# ── Watch centroid cache ──────────────────────────────────────────────────────
+# Reuses product_text_cache with a 12h TTL so zone-geometry HTTP calls
+# (up to 10 per watch) survive bot restarts during active weather.
+
+_CENTROID_TTL = 12 * 3600  # 12 hours
+
+
+async def get_watch_centroid_cache(watch_num: str) -> Optional[tuple]:
+    """Return cached (lat, lon) for a watch number, or None if absent/expired."""
+    text = await get_product_cache(f"centroid:{watch_num}")
+    if text is None:
+        return None
+    try:
+        lat, lon = json.loads(text)
+        return float(lat), float(lon)
+    except Exception:
+        return None
+
+
+async def set_watch_centroid_cache(watch_num: str, centroid: tuple) -> None:
+    """Persist (lat, lon) for a watch number with a 12h TTL."""
+    await set_product_cache(
+        f"centroid:{watch_num}",
+        json.dumps(list(centroid)),
+        ttl=_CENTROID_TTL,
+    )
+
+
 # ── Dirty writes (Upstash sync queue) ───────────────────────────────────────
 
 async def add_dirty_write(op: str, args: tuple):


### PR DESCRIPTION
## Summary
- Each watch centroid requires up to 10 NWS zone geometry HTTP calls. With 8 active watches and a bot restart during an active event, that's up to 80 redundant upstream requests.
- Add `get_watch_centroid_cache()`/`set_watch_centroid_cache()` backed by the existing `product_text_cache` SQLite table (TTL-evicted, no schema change) in `utils/db.py`
- Wire them into `_resolve_watch_centroid()` in `cogs/sounding.py` so the lookup order is: in-memory dict → DB cache → NWS zone HTTP calls

## Test plan
- [ ] On restart during an active watch event, verify no zone HTTP calls are made for already-cached watches
- [ ] Verify the DB cache expires after 12h (or at product_text_cache prune time)
- [ ] `382 passed` — no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)