### PR TITLE
test: NWWS connection state machine and centroid memoization (13 new tests)

### DIFF
--- a/tests/test_nwws_connection.py
+++ b/tests/test_nwws_connection.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for NWWSCog.monitor_connection — the reconnect state machine.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def bot():
+    b = MagicMock()
+    b.state.is_primary = True
+    b.wait_until_ready = AsyncMock()
+    return b
+
+
+@pytest.fixture
+def cog(bot):
+    from cogs.nwws import NWWSCog
+    c = NWWSCog.__new__(NWWSCog)
+    c.bot = bot
+    c.xmpp_client = None
+    c._should_be_connected = True
+    return c
+
+
+@pytest.mark.asyncio
+async def test_monitor_skips_when_standby(cog, bot):
+    """Does nothing when the node is on standby."""
+    bot.state.is_primary = False
+    cog.xmpp_client = None
+
+    with patch("cogs.nwws.NWWSClient") as MockClient:
+        await cog.monitor_connection()
+        MockClient.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_monitor_disconnects_client_on_standby(cog, bot):
+    """Disconnects an existing XMPP client when demoted to standby."""
+    bot.state.is_primary = False
+    mock_client = MagicMock()
+    mock_client.is_connected = True
+    cog.xmpp_client = mock_client
+
+    with patch("cogs.nwws.NWWSClient"):
+        await cog.monitor_connection()
+
+    mock_client.disconnect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_monitor_noop_when_already_connected(cog, bot):
+    """Returns early without creating a new client if already connected."""
+    mock_client = MagicMock()
+    mock_client.is_connected = True
+    cog.xmpp_client = mock_client
+
+    with patch("cogs.nwws.NWWSClient") as MockClient:
+        await cog.monitor_connection()
+        MockClient.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_monitor_noop_when_connection_in_flight(cog, bot):
+    """Returns early if transport is non-None (connection attempt ongoing)."""
+    mock_client = MagicMock()
+    mock_client.is_connected = False
+    mock_client.transport = MagicMock()  # in-flight
+    cog.xmpp_client = mock_client
+
+    with patch("cogs.nwws.NWWSClient") as MockClient:
+        await cog.monitor_connection()
+        MockClient.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_monitor_cleans_up_and_reconnects(cog, bot):
+    """Disconnects stale client and creates a new one when transport is None."""
+    from config import NWWS_SERVER, NWWS_USER, NWWS_PASSWORD
+    mock_client = MagicMock()
+    mock_client.is_connected = False
+    mock_client.transport = None  # stale — not in-flight
+    cog.xmpp_client = mock_client
+
+    with patch("cogs.nwws.NWWSClient") as MockClient:
+        new_client = MagicMock()
+        MockClient.return_value = new_client
+
+        await cog.monitor_connection()
+
+    mock_client.disconnect.assert_called_once()
+    MockClient.assert_called_once()
+    new_client.connect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_monitor_creates_client_when_none(cog, bot):
+    """Creates NWWSClient and calls connect() when no client exists."""
+    assert cog.xmpp_client is None
+
+    with patch("cogs.nwws.NWWSClient") as MockClient:
+        new_client = MagicMock()
+        MockClient.return_value = new_client
+
+        await cog.monitor_connection()
+
+    MockClient.assert_called_once()
+    new_client.connect.assert_called_once()
+    assert cog.xmpp_client is new_client
+
+
+@pytest.mark.asyncio
+async def test_monitor_clears_client_on_connect_exception(cog, bot):
+    """Clears xmpp_client if connect() raises so next cycle retries cleanly."""
+    with patch("cogs.nwws.NWWSClient") as MockClient:
+        new_client = MagicMock()
+        new_client.connect.side_effect = Exception("connection refused")
+        MockClient.return_value = new_client
+
+        await cog.monitor_connection()
+
+    assert cog.xmpp_client is None

--- a/tests/test_nwws_connection.py
+++ b/tests/test_nwws_connection.py
@@ -77,7 +77,6 @@ async def test_monitor_noop_when_connection_in_flight(cog, bot):
 @pytest.mark.asyncio
 async def test_monitor_cleans_up_and_reconnects(cog, bot):
     """Disconnects stale client and creates a new one when transport is None."""
-    from config import NWWS_SERVER, NWWS_USER, NWWS_PASSWORD
     mock_client = MagicMock()
     mock_client.is_connected = False
     mock_client.transport = None  # stale — not in-flight

--- a/tests/test_sounding_centroid.py
+++ b/tests/test_sounding_centroid.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for SoundingCog._resolve_watch_centroid — in-memory memoization
+and graceful handling of missing zone data.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def bot():
+    b = MagicMock()
+    b.state.active_watches = {}
+    return b
+
+
+@pytest.fixture
+def cog(bot):
+    from cogs.sounding import SoundingCog
+    c = SoundingCog.__new__(SoundingCog)
+    c.bot = bot
+    c._watch_centroids = {}
+    c._posted_watch_soundings = set()
+    c._handled_watches = set()
+    c._restore_attempted = True
+    return c
+
+
+@pytest.mark.asyncio
+async def test_returns_from_memory_cache(cog):
+    """Returns immediately from in-memory dict without hitting NWS API."""
+    cog._watch_centroids["0042"] = (35.5, -97.5)
+    info = {"affected_zones": ["https://api.weather.gov/zones/county/OKC031"]}
+
+    with patch("cogs.sounding.get_watch_area_centroid") as nws_get:
+        result = await cog._resolve_watch_centroid("0042", info)
+
+    assert result == (35.5, -97.5)
+    nws_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetches_from_nws_on_memory_miss(cog):
+    """Calls get_watch_area_centroid when not in memory; stores result."""
+    info = {"affected_zones": ["https://api.weather.gov/zones/county/OKC031"]}
+
+    with patch("cogs.sounding.get_watch_area_centroid", AsyncMock(return_value=(35.5, -97.5))):
+        result = await cog._resolve_watch_centroid("0042", info)
+
+    assert result == (35.5, -97.5)
+    assert cog._watch_centroids["0042"] == (35.5, -97.5)
+
+
+@pytest.mark.asyncio
+async def test_second_call_uses_memory(cog):
+    """Second call for the same watch uses the memoized value, not NWS."""
+    info = {"affected_zones": ["https://api.weather.gov/zones/county/OKC031"]}
+
+    with patch("cogs.sounding.get_watch_area_centroid", AsyncMock(return_value=(35.5, -97.5))):
+        await cog._resolve_watch_centroid("0042", info)
+
+    with patch("cogs.sounding.get_watch_area_centroid") as nws_get:
+        result = await cog._resolve_watch_centroid("0042", info)
+
+    assert result == (35.5, -97.5)
+    nws_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_zones(cog):
+    """Returns None immediately when the watch has no affected zones."""
+    info = {"affected_zones": []}
+
+    with patch("cogs.sounding.get_watch_area_centroid") as nws_get:
+        result = await cog._resolve_watch_centroid("0042", info)
+
+    assert result is None
+    nws_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_does_not_cache_none_from_api(cog):
+    """Does not store None in memory when NWS API returns None."""
+    info = {"affected_zones": ["https://api.weather.gov/zones/county/OKC031"]}
+
+    with patch("cogs.sounding.get_watch_area_centroid", AsyncMock(return_value=None)):
+        result = await cog._resolve_watch_centroid("0042", info)
+
+    assert result is None
+    assert "0042" not in cog._watch_centroids
+
+
+@pytest.mark.asyncio
+async def test_handles_non_dict_info(cog):
+    """Returns None gracefully when info is not a dict (e.g. legacy string value)."""
+    with patch("cogs.sounding.get_watch_area_centroid") as nws_get:
+        result = await cog._resolve_watch_centroid("0042", "TORNADO")
+
+    assert result is None
+    nws_get.assert_not_called()


### PR DESCRIPTION
## Summary
- `tests/test_nwws_connection.py` (7 tests): covers all branches of `NWWSCog.monitor_connection` — standby skip, standby disconnect, already-connected no-op, in-flight no-op, stale client cleanup + reconnect, fresh client creation, connect() failure recovery. These were all previously untested paths.
- `tests/test_sounding_centroid.py` (6 tests): covers `SoundingCog._resolve_watch_centroid` — in-memory hit, NWS API fetch + memoization, second-call cache hit, empty zones short-circuit, None-result non-caching, and non-dict info guard.

## Test plan
- [ ] All 13 new tests pass: `pytest tests/test_nwws_connection.py tests/test_sounding_centroid.py -v`
- [ ] Full suite: `382 passed`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)