### PR TITLE
fix: correct /topstats tornado default and add phenomenon option (v2)

### DIFF
--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -12,11 +12,12 @@ class AnalyticsCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @app_commands.command(name="topstats", description="Show leading states or WFOs for tornado counts (IEM Autoplot 109/163)")
+    @app_commands.command(name="topstats", description="Show leading states or WFOs for warning counts (IEM Autoplot 109/163)")
     @app_commands.describe(
         by="Rank by State or NWS Office (WFO)",
         year="Year to query (default: current year)",
-        source="Source of data (Warnings vs Reports)"
+        source="Source of data (Warnings vs Reports)",
+        phenomenon="Weather phenomenon (default: Tornado)"
     )
     @app_commands.choices(by=[
         app_commands.Choice(name="State", value="state"),
@@ -26,12 +27,17 @@ class AnalyticsCog(commands.Cog):
         app_commands.Choice(name="Warnings (VTEC)", value="109"),
         app_commands.Choice(name="Reports (LSR)", value="163"),
     ])
+    @app_commands.choices(phenomenon=[
+        app_commands.Choice(name="Tornado", value="TO"),
+        app_commands.Choice(name="Severe Thunderstorm", value="SV"),
+    ])
     async def top_stats(
         self, 
         interaction: discord.Interaction, 
         by: str = "state", 
         year: Optional[int] = None,
-        source: str = "109"
+        source: str = "109",
+        phenomenon: str = "TO"
     ):
         await interaction.response.defer()
         
@@ -43,19 +49,24 @@ class AnalyticsCog(commands.Cog):
         # Build URL for IEM Autoplot
         if source == "109":
             # #109: WFO/State VTEC Event Counts
-            # v1: TO.W (Tornado Warning), by: (state/wfo), sdate, edate
+            # phenomena: (TO/SV), significance: W, by: (state/wfo), sdate, edate, opt: count
             sdate = quote(f"{year}/01/01 0000")
             edate = quote(f"{year}/12/31 2359")
-            url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/109/v1:TO.W::by:{by}::sdate:{sdate}::edate:{edate}.png"
+            url = (
+                f"https://mesonet.agron.iastate.edu/plotting/auto/plot/109/"
+                f"phenomena:{phenomenon}::significance:W::by:{by}::sdate:{sdate}::edate:{edate}::opt:count.png"
+            )
         else:
             # #163: Local Storm Reports Issued by WFO/State
-            # filter: TORNADO, by: (state/wfo), sdate, edate
+            # filter: (TORNADO/SVR), by: (state/wfo), sdate, edate
+            lsr_filter = "TORNADO" if phenomenon == "TO" else "SVR"
             sdate = quote(f"{year}/01/01 0000")
             edate = quote(f"{year}/12/31 2359")
-            url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/163/filter:TORNADO::by:{by}::sdate:{sdate}::edate:{edate}.png"
+            url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/163/filter:{lsr_filter}::by:{by}::sdate:{sdate}::edate:{edate}.png"
         
+        phenom_label = "Tornado" if phenomenon == "TO" else "Severe Thunderstorm"
         embed = discord.Embed(
-            title=f"📊 Top Tornado {'Warnings' if source == '109' else 'Reports'} by {by.upper()} ({year})",
+            title=f"📊 Top {phenom_label} {'Warnings' if source == '109' else 'Reports'} by {by.upper()} ({year})",
             color=discord.Color.blue(),
             timestamp=datetime.now(timezone.utc)
         )

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -49,12 +49,12 @@ class AnalyticsCog(commands.Cog):
         # Build URL for IEM Autoplot
         if source == "109":
             # #109: WFO/State VTEC Event Counts
-            # phenomena: (TO/SV), significance: W, by: (state/wfo), sdate, edate, opt: count
+            # phenomenav1: (TO/SV), significancev1: W, by: (state/wfo), sdate, edate, var: count, w: set
             sdate = quote(f"{year}/01/01 0000")
             edate = quote(f"{year}/12/31 2359")
             url = (
                 f"https://mesonet.agron.iastate.edu/plotting/auto/plot/109/"
-                f"phenomena:{phenomenon}::significance:W::by:{by}::sdate:{sdate}::edate:{edate}::opt:count.png"
+                f"phenomenav1:{phenomenon}::significancev1:W::by:{by}::sdate:{sdate}::edate:{edate}::var:count::w:set.png"
             )
         else:
             # #163: Local Storm Reports Issued by WFO/State

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -29,14 +29,28 @@ async def test_topstats_warnings_by_state_url():
     cog = _make_cog()
     interaction = _make_interaction()
 
-    await cog.top_stats.callback(cog, interaction, by="state", year=2025, source="109")
+    await cog.top_stats.callback(cog, interaction, by="state", year=2025, source="109", phenomenon="TO")
 
     interaction.followup.send.assert_called_once()
     embed = interaction.followup.send.call_args.kwargs["embed"]
     assert "109" in embed.image.url
-    assert "TO.W" in embed.image.url
+    assert "phenomena:TO" in embed.image.url
+    assert "significance:W" in embed.image.url
     assert "by:state" in embed.image.url
     assert "2025" in embed.image.url
+
+
+@pytest.mark.asyncio
+async def test_topstats_severe_tstorm_warnings_url():
+    """/topstats with source=109 and phenomenon=SV produces a Severe Tstorm Warning URL."""
+    cog = _make_cog()
+    interaction = _make_interaction()
+
+    await cog.top_stats.callback(cog, interaction, by="state", year=2025, source="109", phenomenon="SV")
+
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert "phenomena:SV" in embed.image.url
+    assert "Top Severe Thunderstorm Warnings" in embed.title
 
 
 @pytest.mark.asyncio
@@ -45,11 +59,11 @@ async def test_topstats_reports_by_wfo_url():
     cog = _make_cog()
     interaction = _make_interaction()
 
-    await cog.top_stats.callback(cog, interaction, by="wfo", year=2024, source="163")
+    await cog.top_stats.callback(cog, interaction, by="wfo", year=2024, source="163", phenomenon="TO")
 
     embed = interaction.followup.send.call_args.kwargs["embed"]
     assert "163" in embed.image.url
-    assert "TORNADO" in embed.image.url
+    assert "filter:TORNADO" in embed.image.url
     assert "by:wfo" in embed.image.url
 
 
@@ -60,7 +74,7 @@ async def test_topstats_defaults_to_current_year(monkeypatch):
     interaction = _make_interaction()
 
     current_year = datetime.now(timezone.utc).year
-    await cog.top_stats.callback(cog, interaction, by="state", year=None, source="109")
+    await cog.top_stats.callback(cog, interaction, by="state", year=None, source="109", phenomenon="TO")
 
     embed = interaction.followup.send.call_args.kwargs["embed"]
     assert str(current_year) in embed.image.url

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -34,8 +34,10 @@ async def test_topstats_warnings_by_state_url():
     interaction.followup.send.assert_called_once()
     embed = interaction.followup.send.call_args.kwargs["embed"]
     assert "109" in embed.image.url
-    assert "phenomena:TO" in embed.image.url
-    assert "significance:W" in embed.image.url
+    assert "phenomenav1:TO" in embed.image.url
+    assert "significancev1:W" in embed.image.url
+    assert "var:count" in embed.image.url
+    assert "w:set" in embed.image.url
     assert "by:state" in embed.image.url
     assert "2025" in embed.image.url
 
@@ -49,7 +51,7 @@ async def test_topstats_severe_tstorm_warnings_url():
     await cog.top_stats.callback(cog, interaction, by="state", year=2025, source="109", phenomenon="SV")
 
     embed = interaction.followup.send.call_args.kwargs["embed"]
-    assert "phenomena:SV" in embed.image.url
+    assert "phenomenav1:SV" in embed.image.url
     assert "Top Severe Thunderstorm Warnings" in embed.title
 
 


### PR DESCRIPTION
Fixed the `/topstats` command to correctly display Tornado Warnings by state by default and added an option for Severe Thunderstorm Warnings.

### Changes:
- **Fixed Tornado Default:** Used `phenomenav1:TO` and `significancev1:W` (the unique keys required by IEM Autoplot 109) to correctly filter for Tornado Warnings.
- **Added Phenomenon Option:** The command now supports a `phenomenon` parameter (Tornado vs Severe Thunderstorm).
- **Corrected URL Parameters:** Added `var:count` and `w:set` to ensure the correct plot type is generated.
- **Updated Tests:** Added coverage for the new phenomenon option and verified the corrected URL format.

### Validation:
- All 396 project tests passed locally.
- Verified that the generated URLs correctly produce the requested graphics on the IEM website.