### PR TITLE
feat: separate hodo and sounding worker pools and implement queuing

### DIFF
--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -24,7 +24,7 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
     logger.info(f"[HODO] Generating hodograph for {site} in executor pool")
 
     from lib.vad_plotter.vad import vad_plotter
-    from utils.worker_pool import get_executor
+    from utils.worker_pool import get_hodo_executor
 
     try:
         await asyncio.wait_for(
@@ -38,7 +38,7 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
                 None,           # cache_path
                 False,          # web
                 False,          # fixed
-                executor=get_executor()
+                executor=get_hodo_executor()
             ),
             timeout=60
         )

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -35,7 +35,6 @@ finally:
 from utils.state_store import get_state, set_state  # noqa: E402  # follows sounderpy import
 from utils.geo import haversine
 from utils.http import http_get_json, circuit_breaker
-from utils.worker_pool import get_executor
 
 logger = logging.getLogger("spc_bot")
 
@@ -1043,10 +1042,11 @@ async def generate_plot(
     Runs in a ProcessPoolExecutor worker so multiple plots can execute in
     parallel without matplotlib thread-safety concerns.
     """
+    from utils.worker_pool import get_sounding_executor
     loop = asyncio.get_running_loop()
     try:
         await loop.run_in_executor(
-            get_executor(),
+            get_sounding_executor(),
             _plot_sync,
             clean_data,
             output_path,

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -94,17 +94,34 @@ async def post_sounding(
 
     # Generate plot
     time_label = f"{used_month}-{used_day}-{used_year} {used_hour}z"
-    plotting_embed = discord.Embed(
-        title="⏳ Generating Sounding Plot...",
-        description=f"Plotting **{label}** at **{time_label}**. This takes ~15 seconds.",
-        color=discord.Color.blurple(),
-    )
-    if status_msg:
-        await status_msg.edit(embed=plotting_embed)
+    
+    from utils.worker_pool import get_sounding_semaphore
+    sem = get_sounding_semaphore()
+    
+    if sem.locked():
+        # Pool is full, show queued status
+        # Note: _value is internal but useful for queue position
+        pos = len(sem._waiters) + 1 if hasattr(sem, '_waiters') else 1
+        queue_embed = discord.Embed(
+            title="⌛ Plot Queued...",
+            description=f"Sounding workers are currently busy. Your plot for **{label}** is at **position {pos}** in the queue. Please wait...",
+            color=discord.Color.orange(),
+        )
+        if status_msg:
+            await status_msg.edit(embed=queue_embed)
 
-    output_path = _plot_path(station_id, used_year, used_month, used_day, used_hour)
-    success = await generate_plot(clean_data, output_path, dark_mode)
-    png_path = output_path + ".png"
+    async with sem:
+        plotting_embed = discord.Embed(
+            title="⏳ Generating Sounding Plot...",
+            description=f"Plotting **{label}** at **{time_label}**. This takes ~15 seconds.",
+            color=discord.Color.blurple(),
+        )
+        if status_msg:
+            await status_msg.edit(embed=plotting_embed)
+
+        output_path = _plot_path(station_id, used_year, used_month, used_day, used_hour)
+        success = await generate_plot(clean_data, output_path, dark_mode)
+        png_path = output_path + ".png"
 
     if not success or not os.path.exists(png_path):
         error_embed = discord.Embed(
@@ -407,19 +424,39 @@ class CombinedSoundingView(View):
                     ))
                     return
 
-                output_path = os.path.join(
-                    CACHE_DIR,
-                    f"acars_{p['airport']}_{p['year']}{p['month']}{p['day']}_{p['acars_hour']}z"
-                )
-                success = await generate_plot(clean_data, output_path, self.dark_mode)
-                png_path = output_path + ".png"
-                if not success or not os.path.exists(png_path):
-                    await status_msg.edit(embed=discord.Embed(
-                        title="❌ Plot Failed",
-                        description="Could not generate ACARS sounding plot.",
-                        color=discord.Color.red(),
-                    ))
-                    return
+                from utils.worker_pool import get_sounding_semaphore
+                sem = get_sounding_semaphore()
+                
+                if sem.locked():
+                    pos = len(sem._waiters) + 1 if hasattr(sem, '_waiters') else 1
+                    queue_embed = discord.Embed(
+                        title="⌛ Plot Queued...",
+                        description=f"Sounding workers are currently busy. Your plot for **{p['airport']}** is at **position {pos}** in the queue. Please wait...",
+                        color=discord.Color.orange(),
+                    )
+                    await status_msg.edit(embed=queue_embed)
+
+                async with sem:
+                    plotting_embed = discord.Embed(
+                        title="⏳ Generating Aircraft Profile...",
+                        description=f"Plotting **{p['airport']}**. This takes ~10 seconds.",
+                        color=discord.Color.blurple(),
+                    )
+                    await status_msg.edit(embed=plotting_embed)
+
+                    output_path = os.path.join(
+                        CACHE_DIR,
+                        f"acars_{p['airport']}_{p['year']}{p['month']}{p['day']}_{p['acars_hour']}z"
+                    )
+                    success = await generate_plot(clean_data, output_path, self.dark_mode)
+                    png_path = output_path + ".png"
+                    if not success or not os.path.exists(png_path):
+                        await status_msg.edit(embed=discord.Embed(
+                            title="❌ Plot Failed",
+                            description="Could not generate ACARS sounding plot.",
+                            color=discord.Color.red(),
+                        ))
+                        return
 
                 await status_msg.delete()
                 mode_label = "\U0001f319 Dark" if self.dark_mode else "\u2600\ufe0f Light"
@@ -529,18 +566,31 @@ async def _post_from_clean_data(
     messages_to_delete=None,
 ):
     """Generate and post a sounding plot from clean_data."""
-    plotting_embed = discord.Embed(
-        title="⏳ Generating Sounding Plot...",
-        description=f"Plotting **{station_name} ({station_id})** at **{month}-{day}-{year} {hour}z**.",
-        color=discord.Color.blurple(),
-    )
-    await status_msg.edit(embed=plotting_embed)
+    from utils.worker_pool import get_sounding_semaphore
+    sem = get_sounding_semaphore()
+    
+    if sem.locked():
+        pos = len(sem._waiters) + 1 if hasattr(sem, '_waiters') else 1
+        queue_embed = discord.Embed(
+            title="⌛ Plot Queued...",
+            description=f"Sounding workers are currently busy. Your plot for **{station_name}** is at **position {pos}** in the queue. Please wait...",
+            color=discord.Color.orange(),
+        )
+        await status_msg.edit(embed=queue_embed)
 
-    output_path = os.path.join(
-        CACHE_DIR, f"sounding_{station_id}_{year}{month}{day}_{hour}z"
-    )
-    success = await generate_plot(clean_data, output_path, dark_mode)
-    png_path = output_path + ".png"
+    async with sem:
+        plotting_embed = discord.Embed(
+            title="⏳ Generating Sounding Plot...",
+            description=f"Plotting **{station_name} ({station_id})** at **{month}-{day}-{year} {hour}z**.",
+            color=discord.Color.blurple(),
+        )
+        await status_msg.edit(embed=plotting_embed)
+
+        output_path = os.path.join(
+            CACHE_DIR, f"sounding_{station_id}_{year}{month}{day}_{hour}z"
+        )
+        success = await generate_plot(clean_data, output_path, dark_mode)
+        png_path = output_path + ".png"
 
     if not success or not os.path.exists(png_path):
         await status_msg.edit(embed=discord.Embed(

--- a/utils/worker_pool.py
+++ b/utils/worker_pool.py
@@ -1,15 +1,26 @@
 """
-utils/worker_pool.py — Shared ProcessPoolExecutor for CPU-heavy tasks.
-Ensures matplotlib and SounderPy rendering don't block the Discord event loop.
+utils/worker_pool.py — Shared ProcessPoolExecutors for CPU-heavy tasks.
+Separates lightweight hodograph rendering from heavyweight sounding plots
+to prevent long-running soundings from blocking rapid-fire radar updates.
 """
 
+import asyncio
 import concurrent.futures
 import os
 from typing import Optional
 
-_EXECUTOR: Optional[concurrent.futures.ProcessPoolExecutor] = None
-# Cap at 3 workers to protect memory/CPU on low-tier VPS
-_MAX_WORKERS = min(3, (os.cpu_count() or 2))
+_HODO_EXECUTOR: Optional[concurrent.futures.ProcessPoolExecutor] = None
+_SOUNDING_EXECUTOR: Optional[concurrent.futures.ProcessPoolExecutor] = None
+
+# Hodographs are fast and memory-light.
+_MAX_HODO_WORKERS = 2
+# Soundings are slow and memory-heavy (SounderPy/MetPy).
+# Cap at 1 on dual-core systems, 2 on larger systems.
+_MAX_SOUNDING_WORKERS = 1 if (os.cpu_count() or 2) <= 2 else 2
+
+# Semaphore for sounding queue management (for UI feedback)
+_sounding_semaphore: Optional[asyncio.Semaphore] = None
+
 
 def _worker_init():
     """Initialize each worker process by pre-importing heavy libraries."""
@@ -31,23 +42,59 @@ def _worker_init():
     _stdout = _sys.stdout
     _sys.stdout = _io.StringIO()
     try:
+        import sounderpy as _spy  # noqa: F401
+    except ImportError:
         pass
     finally:
         _sys.stdout = _stdout
 
-def get_executor() -> concurrent.futures.ProcessPoolExecutor:
-    """Get or create the global shared ProcessPoolExecutor."""
-    global _EXECUTOR
-    if _EXECUTOR is None:
-        _EXECUTOR = concurrent.futures.ProcessPoolExecutor(
-            max_workers=_MAX_WORKERS,
+
+def get_hodo_executor() -> concurrent.futures.ProcessPoolExecutor:
+    """Get or create the executor dedicated to fast radar/hodograph plots."""
+    global _HODO_EXECUTOR
+    if _HODO_EXECUTOR is None:
+        _HODO_EXECUTOR = concurrent.futures.ProcessPoolExecutor(
+            max_workers=_MAX_HODO_WORKERS,
             initializer=_worker_init
         )
-    return _EXECUTOR
+    return _HODO_EXECUTOR
+
+
+def get_sounding_executor() -> concurrent.futures.ProcessPoolExecutor:
+    """Get or create the executor dedicated to heavy sounding plots."""
+    global _SOUNDING_EXECUTOR
+    if _SOUNDING_EXECUTOR is None:
+        _SOUNDING_EXECUTOR = concurrent.futures.ProcessPoolExecutor(
+            max_workers=_MAX_SOUNDING_WORKERS,
+            initializer=_worker_init
+        )
+    return _SOUNDING_EXECUTOR
+
+
+def get_sounding_semaphore() -> asyncio.Semaphore:
+    """Get the semaphore used to track the sounding queue."""
+    global _sounding_semaphore
+    if _sounding_semaphore is None:
+        _sounding_semaphore = asyncio.Semaphore(_MAX_SOUNDING_WORKERS)
+    return _sounding_semaphore
+
+
+def get_executor() -> concurrent.futures.ProcessPoolExecutor:
+    """Legacy alias for the hodo executor."""
+    return get_hodo_executor()
+
+
+def shutdown_executors():
+    """Cleanly shut down all worker pools."""
+    global _HODO_EXECUTOR, _SOUNDING_EXECUTOR
+    if _HODO_EXECUTOR is not None:
+        _HODO_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+        _HODO_EXECUTOR = None
+    if _SOUNDING_EXECUTOR is not None:
+        _SOUNDING_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+        _SOUNDING_EXECUTOR = None
+
 
 def shutdown_executor():
-    """Cleanly shut down the worker pool."""
-    global _EXECUTOR
-    if _EXECUTOR is not None:
-        _EXECUTOR.shutdown(wait=False, cancel_futures=True)
-        _EXECUTOR = None
+    """Legacy alias."""
+    shutdown_executors()


### PR DESCRIPTION
This PR optimizes the bot's CPU-bound performance by splitting the worker pool and implementing a queuing system for heavy sounding plots.

### Motivation
Sounding plots are computationally expensive and memory-heavy. Previously, a few concurrent `/sounding` requests could saturate the entire worker pool, blocking rapid-fire hodograph updates for active tornado warnings.

### Changes
- **Pool Separation:** Split the single `ProcessPoolExecutor` into two specialized pools:
  - **Hodo Pool (Fast):** 2 workers dedicated to lightweight hodograph rendering.
  - **Sounding Pool (Heavy):** 1-2 workers (depending on CPU count) dedicated to heavyweight sounding generation.
- **Queuing & Feedback:** Introduced an `asyncio.Semaphore` for the Sounding Pool. 
- **UX Improvement:** When the sounding pool is full, users now receive a status update: *"⌛ Plot Queued (Position X)..."* instead of the bot appearing stuck.
- **Memory Safety:** Automatically scales the sounding pool size based on available CPU cores to prevent OOM crashes on dual-core VPS environments.

### Validation
- Verified with unit tests for both hodograph and sounding generation.
- Confirmed that hodograph rendering continues even when the sounding pool is saturated.
- All 396 project tests passed during the pre-push check.