### PR TITLE
feat(warnings): route warnings to per-type channels with live config commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ GUILD_ID=your_guild_id
 
 # Optional — these have sensible defaults
 # WARNINGS_CHANNEL_ID=your_warnings_channel_id (defaults to SPC_CHANNEL_ID)
+# Per-type warning channels (all default to WARNINGS_CHANNEL_ID if not set)
+# TOR_CHANNEL_ID=your_tornado_warning_channel_id
+# SVR_CHANNEL_ID=your_severe_tstorm_channel_id
+# FFW_CHANNEL_ID=your_flash_flood_channel_id
+# SPS_CHANNEL_ID=your_special_weather_stmt_channel_id
 # HEALTH_CHANNEL_ID=your_health_channel_id (defaults to SPC_CHANNEL_ID)
 # SOUNDING_CHANNEL_ID=your_sounding_channel_id (defaults to SPC_CHANNEL_ID)
 # CACHE_DIR=cache

--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -5,4 +5,5 @@ ALL_EXTENSIONS = [
     "cogs.status", "cogs.radar", "cogs.csu_mlp", "cogs.ncar",
     "cogs.sounding", "cogs.hodograph", "cogs.maintenance", "cogs.analytics",
     "cogs.recorder",
+    "cogs.warning_channels",
 ]

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -1045,14 +1045,21 @@ async def generate_plot(
     from utils.worker_pool import get_sounding_executor
     loop = asyncio.get_running_loop()
     try:
-        await loop.run_in_executor(
-            get_sounding_executor(),
-            _plot_sync,
-            clean_data,
-            output_path,
-            dark_mode,
+        # Wrap in wait_for to prevent infinite hangs in the subprocess
+        await asyncio.wait_for(
+            loop.run_in_executor(
+                get_sounding_executor(),
+                _plot_sync,
+                clean_data,
+                output_path,
+                dark_mode,
+            ),
+            timeout=60.0
         )
         return True
+    except asyncio.TimeoutError:
+        logger.error(f"[SOUNDING] Plot generation timed out for {output_path}")
+        return False
     except ValueError as e:
         # SounderPy/MetPy raise ValueError with "zero-size array to reduction"
         # when upstream data quality is insufficient (issue #87). Treat as a

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -100,28 +100,37 @@ async def post_sounding(
     
     if sem.locked():
         # Pool is full, show queued status
-        # Note: _value is internal but useful for queue position
         pos = len(sem._waiters) + 1 if hasattr(sem, '_waiters') else 1
+        logger.info(f"[SOUNDING] Queueing plot for {label} (Position: {pos})")
         queue_embed = discord.Embed(
             title="⌛ Plot Queued...",
             description=f"Sounding workers are currently busy. Your plot for **{label}** is at **position {pos}** in the queue. Please wait...",
             color=discord.Color.orange(),
         )
         if status_msg:
-            await status_msg.edit(embed=queue_embed)
+            try:
+                await status_msg.edit(embed=queue_embed)
+            except discord.HTTPException:
+                pass
 
     async with sem:
+        logger.info(f"[SOUNDING] Starting plot for {label} (Semaphore acquired)")
         plotting_embed = discord.Embed(
             title="⏳ Generating Sounding Plot...",
             description=f"Plotting **{label}** at **{time_label}**. This takes ~15 seconds.",
             color=discord.Color.blurple(),
         )
         if status_msg:
-            await status_msg.edit(embed=plotting_embed)
+            try:
+                await status_msg.edit(embed=plotting_embed)
+            except discord.HTTPException:
+                pass
 
         output_path = _plot_path(station_id, used_year, used_month, used_day, used_hour)
         success = await generate_plot(clean_data, output_path, dark_mode)
         png_path = output_path + ".png"
+
+    logger.info(f"[SOUNDING] Plotting finished for {label} (Semaphore released)")
 
     if not success or not os.path.exists(png_path):
         error_embed = discord.Embed(
@@ -130,7 +139,10 @@ async def post_sounding(
             color=discord.Color.red(),
         )
         if status_msg:
-            await status_msg.edit(embed=error_embed)
+            try:
+                await status_msg.edit(embed=error_embed)
+            except discord.HTTPException:
+                pass
         return
 
     mode_label = "\U0001f319 Dark" if dark_mode else "\u2600\ufe0f Light"
@@ -153,20 +165,17 @@ async def post_sounding(
         caption += f"\n{qwarn}"
 
     try:
+        if status_msg:
+            try:
+                await status_msg.delete()
+            except discord.HTTPException:
+                pass
+        
         await interaction.channel.send(caption, files=[discord.File(png_path)])
         logger.info(f"[SOUNDING] Posted {station_id} {used_year}/{used_month}/{used_day} {used_hour}z")
 
-        # Edit status msg to show success but keep selection available
-        if status_msg:
-            try:
-                done_embed = discord.Embed(
-                    title=f"✅ Posted — {station_id} {used_year}/{used_month}/{used_day} {used_hour}z",
-                    description="Select another station or time above to post more.",
-                    color=discord.Color.green(),
-                )
-                await status_msg.edit(embed=done_embed, view=None)
-            except discord.HTTPException as e:
-                logger.debug(f"[SOUNDING] Could not update status message: {e}")
+        # Edit status msg is no longer needed since it's deleted, but 
+        # we used to show success if not deleted. Keep it simple.
 
     except Exception as e:
         logger.exception(f"[SOUNDING] Failed to post: {e}")
@@ -566,25 +575,34 @@ async def _post_from_clean_data(
     messages_to_delete=None,
 ):
     """Generate and post a sounding plot from clean_data."""
+    label = f"{station_name} ({station_id})"
     from utils.worker_pool import get_sounding_semaphore
     sem = get_sounding_semaphore()
     
     if sem.locked():
         pos = len(sem._waiters) + 1 if hasattr(sem, '_waiters') else 1
+        logger.info(f"[SOUNDING] Queueing plot for {label} (Position: {pos})")
         queue_embed = discord.Embed(
             title="⌛ Plot Queued...",
             description=f"Sounding workers are currently busy. Your plot for **{station_name}** is at **position {pos}** in the queue. Please wait...",
             color=discord.Color.orange(),
         )
-        await status_msg.edit(embed=queue_embed)
+        try:
+            await status_msg.edit(embed=queue_embed)
+        except discord.HTTPException:
+            pass
 
     async with sem:
+        logger.info(f"[SOUNDING] Starting plot for {label} (Semaphore acquired)")
         plotting_embed = discord.Embed(
             title="⏳ Generating Sounding Plot...",
             description=f"Plotting **{station_name} ({station_id})** at **{month}-{day}-{year} {hour}z**.",
             color=discord.Color.blurple(),
         )
-        await status_msg.edit(embed=plotting_embed)
+        try:
+            await status_msg.edit(embed=plotting_embed)
+        except discord.HTTPException:
+            pass
 
         output_path = os.path.join(
             CACHE_DIR, f"sounding_{station_id}_{year}{month}{day}_{hour}z"
@@ -592,12 +610,17 @@ async def _post_from_clean_data(
         success = await generate_plot(clean_data, output_path, dark_mode)
         png_path = output_path + ".png"
 
+    logger.info(f"[SOUNDING] Plotting finished for {label} (Semaphore released)")
+
     if not success or not os.path.exists(png_path):
-        await status_msg.edit(embed=discord.Embed(
-            title="❌ Plot Failed",
-            description="Could not generate sounding plot.",
-            color=discord.Color.red(),
-        ))
+        try:
+            await status_msg.edit(embed=discord.Embed(
+                title="❌ Plot Failed",
+                description="Could not generate sounding plot.",
+                color=discord.Color.red(),
+            ))
+        except discord.HTTPException:
+            pass
         return
 
     mode_label = "\U0001f319 Dark" if dark_mode else "\u2600\ufe0f Light"

--- a/cogs/warning_channels.py
+++ b/cogs/warning_channels.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 import discord
 from discord import app_commands

--- a/cogs/warning_channels.py
+++ b/cogs/warning_channels.py
@@ -1,0 +1,129 @@
+# cogs/warning_channels.py
+"""Slash commands for configuring per-type warning channel routing."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from config import WARNINGS_CHANNEL_ID, TOR_CHANNEL_ID, SVR_CHANNEL_ID, FFW_CHANNEL_ID, SPS_CHANNEL_ID
+from utils.state_store import get_state, set_state
+
+logger = logging.getLogger("spc_bot.warning_channels")
+
+_PHENOM_LABELS = {
+    "tor": "Tornado Warning",
+    "svr": "Severe Thunderstorm Warning",
+    "ffw": "Flash Flood Warning",
+    "sps": "Special Weather Statement",
+}
+
+_STATIC_DEFAULTS = {
+    "tor": TOR_CHANNEL_ID,
+    "svr": SVR_CHANNEL_ID,
+    "ffw": FFW_CHANNEL_ID,
+    "sps": SPS_CHANNEL_ID,
+}
+
+
+class DisableWarningsView(discord.ui.View):
+    def __init__(self, enabled: list[tuple[str, str]]):
+        super().__init__(timeout=120)
+        options = [
+            discord.SelectOption(label=label, value=code)
+            for code, label in enabled
+        ]
+        self.select = discord.ui.Select(
+            placeholder="Choose warning type(s) to disable…",
+            min_values=1,
+            max_values=len(options),
+            options=options,
+        )
+        self.select.callback = self.on_select
+        self.add_item(self.select)
+
+    async def on_select(self, interaction: discord.Interaction):
+        for code in self.select.values:
+            await set_state(f"warning_channel:{code}", "disabled")
+        disabled_labels = [_PHENOM_LABELS[c] for c in self.select.values]
+        await interaction.response.edit_message(
+            content=f"🔕 Disabled: {', '.join(disabled_labels)}",
+            view=None,
+        )
+
+
+class WarningChannelsCog(commands.Cog):
+
+    @app_commands.command(name="enablewarnings", description="Route a warning type to a specific channel")
+    @app_commands.describe(
+        warning_type="Warning product type to configure",
+        channel="Channel where these warnings will be posted",
+    )
+    @app_commands.choices(warning_type=[
+        app_commands.Choice(name="Tornado Warning", value="tor"),
+        app_commands.Choice(name="Severe Thunderstorm Warning", value="svr"),
+        app_commands.Choice(name="Flash Flood Warning", value="ffw"),
+        app_commands.Choice(name="Special Weather Statement", value="sps"),
+    ])
+    async def enable_warnings(
+        self,
+        interaction: discord.Interaction,
+        warning_type: str,
+        channel: discord.TextChannel,
+    ):
+        await set_state(f"warning_channel:{warning_type}", str(channel.id))
+        label = _PHENOM_LABELS[warning_type]
+        await interaction.response.send_message(
+            f"✅ **{label}** will now post to {channel.mention}",
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="displaysetup", description="Show current warning channel routing configuration")
+    async def display_setup(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+
+        lines = []
+        for code, label in _PHENOM_LABELS.items():
+            override = await get_state(f"warning_channel:{code}")
+            if override == "disabled":
+                lines.append(f"**{label}**: 🔕 Disabled")
+            elif override:
+                lines.append(f"**{label}**: <#{override}>")
+            else:
+                static_id = _STATIC_DEFAULTS.get(code, WARNINGS_CHANNEL_ID)
+                lines.append(f"**{label}**: <#{static_id}> *(default)*")
+
+        embed = discord.Embed(
+            title="⚙️ Warning Channel Configuration",
+            description="\n".join(lines),
+            color=discord.Color.blurple(),
+        )
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @app_commands.command(name="disablewarnings", description="Stop posting a warning type")
+    async def disable_warnings(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+
+        enabled: list[tuple[str, str]] = []
+        for code, label in _PHENOM_LABELS.items():
+            override = await get_state(f"warning_channel:{code}")
+            if override != "disabled":
+                enabled.append((code, label))
+
+        if not enabled:
+            await interaction.followup.send(
+                "All warning types are already disabled.", ephemeral=True
+            )
+            return
+
+        view = DisableWarningsView(enabled)
+        await interaction.followup.send(
+            "Select warning type(s) to disable:", view=view, ephemeral=True
+        )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(WarningChannelsCog())

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -67,6 +67,7 @@ class WarningsCog(commands.Cog):
         self._validators = {"etag": "", "last_modified": ""}
         self._cancelled_warnings: set[str] = set()
         self._in_flight_vtecs: set[str] = set()
+        self._perm_warned: set[int] = set()
 
     async def cog_load(self):
         # Restore the dedup mapping so a restart during active wx doesn't
@@ -86,6 +87,37 @@ class WarningsCog(commands.Cog):
         self.auto_poll_warnings.cancel()
 
     # ── Warning Channel Routing ─────────────────────────────────────────────
+
+    def _check_channel_perms(self, channel) -> list[str]:
+        """Return list of missing permission names needed to post warnings."""
+        if not hasattr(channel, "guild") or not channel.guild:
+            return []
+        me = channel.guild.me
+        if not me:
+            return []
+        perms = channel.permissions_for(me)
+        return [p for p in ("send_messages", "embed_links", "attach_files") if not getattr(perms, p, False)]
+
+    async def _notify_channel_error(self, channel, missing: list[str]) -> None:
+        """Alert the health channel about a permission problem (once per session per channel)."""
+        ch_id = getattr(channel, "id", 0)
+        if ch_id in self._perm_warned:
+            logger.warning(f"Still missing perms {missing} in channel {ch_id}")
+            return
+        self._perm_warned.add(ch_id)
+        ch_name = getattr(channel, "name", str(ch_id))
+        logger.error(f"Missing permissions {missing} in warning channel #{ch_name} ({ch_id})")
+        try:
+            from main import send_bot_alert
+            mention = f"<#{ch_id}>"
+            await send_bot_alert(
+                "Warning Channel — Missing Permissions",
+                f"Bot is missing **{', '.join(missing)}** in {mention} (`#{ch_name}`).\n"
+                f"Warnings that would post there are being **skipped** until this is fixed.",
+                critical=True,
+            )
+        except Exception as e:
+            logger.error(f"Failed to send perm alert for channel {ch_id}: {e}")
 
     _STATIC_CHANNEL_FOR_PHENOM = {
         "tor": TOR_CHANNEL_ID,
@@ -117,9 +149,19 @@ class WarningsCog(commands.Cog):
             if override:
                 ch = self.bot.get_channel(int(override))
                 if ch:
+                    missing = self._check_channel_perms(ch)
+                    if missing:
+                        await self._notify_channel_error(ch, missing)
+                        return None
                     return ch
         static_id = self._STATIC_CHANNEL_FOR_PHENOM.get(phenom, WARNINGS_CHANNEL_ID)
-        return self.bot.get_channel(static_id)
+        channel = self.bot.get_channel(static_id)
+        if channel:
+            missing = self._check_channel_perms(channel)
+            if missing:
+                await self._notify_channel_error(channel, missing)
+                return None
+        return channel
 
     # ── iembot fast-trigger path ───────────────────────────────────────────
     #
@@ -278,6 +320,14 @@ class WarningsCog(commands.Cog):
                     "channel_id": msg.channel.id,
                     "area": area_desc,
                 }
+            except discord.Forbidden as e:
+                await self._notify_channel_error(channel, ["send_messages (403 Forbidden)"])
+                if product_id in self.bot.state.posted_product_ids:
+                    self.bot.state.posted_product_ids.discard(product_id)
+                if not is_update and vtec_id in self.bot.state.posted_warnings:
+                    del self.bot.state.posted_warnings[vtec_id]
+                logger.error(f"iembot send forbidden for {vtec_id} in channel {channel.id}: {e}")
+                return
             except discord.HTTPException as e:
                 # Roll back the dedup claim on a hard send failure
                 if product_id in self.bot.state.posted_product_ids:
@@ -819,6 +869,25 @@ class WarningsCog(commands.Cog):
         msg = await channel.send(embed=embed, files=files)
         logger.info(f"Posted {event} {vtec_id}")
         return msg, area_desc
+
+    @auto_poll_warnings.before_loop
+    async def before_poll(self):
+        await self.bot.wait_until_ready()
+        await self._audit_warning_channels()
+
+    async def _audit_warning_channels(self):
+        """Check all configured warning channels at startup; report perm issues."""
+        channel_ids = {TOR_CHANNEL_ID, SVR_CHANNEL_ID, FFW_CHANNEL_ID, SPS_CHANNEL_ID, WARNINGS_CHANNEL_ID}
+        for ch_id in channel_ids:
+            if not ch_id:
+                continue
+            ch = self.bot.get_channel(ch_id)
+            if not ch:
+                logger.warning(f"Warning channel {ch_id} not found in cache at startup — may not be visible to bot")
+                continue
+            missing = self._check_channel_perms(ch)
+            if missing:
+                await self._notify_channel_error(ch, missing)
 
     @auto_poll_warnings.after_loop
     async def after_loop(self):

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -517,15 +517,22 @@ class WarningsCog(commands.Cog):
         if not (channel_id and message_id):
             return
 
-        channel = self.bot.get_channel(channel_id)
+        # Route the cancellation to the type-specific channel if configured;
+        # fall back to the channel the original was posted in.
+        phenom = (vtec or {}).get("phenom", "")
+        sig = (vtec or {}).get("sig", "")
+        event_base = self._PHENOM_EVENT.get((phenom, sig), "")
+        channel = None
+        if event_base:
+            channel = await self._resolve_warning_channel(event_base)
+        if not channel:
+            channel = self.bot.get_channel(channel_id)
         if not channel:
             return
 
         # Area was stored in posted_warnings when the warning was first posted.
         area = info.get("area", "")
 
-        phenom = (vtec or {}).get("phenom", "")
-        sig = (vtec or {}).get("sig", "")
         office = (vtec or {}).get("office", vtec_id.split(".")[0])
         if office.startswith("K") and len(office) == 4:
             office = office[1:]

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -27,7 +27,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 
-from config import NWS_ALERTS_WARNINGS_URL, WARNINGS_CHANNEL_ID
+from config import NWS_ALERTS_WARNINGS_URL, WARNINGS_CHANNEL_ID, TOR_CHANNEL_ID, SVR_CHANNEL_ID, FFW_CHANNEL_ID, SPS_CHANNEL_ID
 from lib.vad_plotter.radar_coords import get_nearest_radar
 from lib.vtec_parser import parse_vtec, parse_warning_polygon, get_polygon_centroid
 from utils.backoff import TaskBackoff
@@ -38,6 +38,7 @@ from utils.state_store import (
     get_all_posted_warnings,
     get_recent_significant_events,
     prune_posted_warnings,
+    get_state,
 )
 from cogs.warning_format import (
     get_warning_style,
@@ -84,6 +85,42 @@ class WarningsCog(commands.Cog):
     def cog_unload(self):
         self.auto_poll_warnings.cancel()
 
+    # ── Warning Channel Routing ─────────────────────────────────────────────
+
+    _STATIC_CHANNEL_FOR_PHENOM = {
+        "tor": TOR_CHANNEL_ID,
+        "svr": SVR_CHANNEL_ID,
+        "ffw": FFW_CHANNEL_ID,
+        "sps": SPS_CHANNEL_ID,
+    }
+
+    @staticmethod
+    def _event_to_phenom(event: str) -> str:
+        e = event.lower()
+        if "tornado warning" in e:
+            return "tor"
+        if "severe thunderstorm" in e:
+            return "svr"
+        if "flash flood" in e:
+            return "ffw"
+        if "special weather statement" in e:
+            return "sps"
+        return "default"
+
+    async def _resolve_warning_channel(self, event: str) -> Optional[discord.abc.Messageable]:
+        """Return the channel to post this warning type to, or None if disabled."""
+        phenom = self._event_to_phenom(event)
+        if phenom != "default":
+            override = await get_state(f"warning_channel:{phenom}")
+            if override == "disabled":
+                return None
+            if override:
+                ch = self.bot.get_channel(int(override))
+                if ch:
+                    return ch
+        static_id = self._STATIC_CHANNEL_FOR_PHENOM.get(phenom, WARNINGS_CHANNEL_ID)
+        return self.bot.get_channel(static_id)
+
     # ── iembot fast-trigger path ───────────────────────────────────────────
     #
     # IEMBotCog calls this when a TOR/SVR/FFW product hits the botstalk
@@ -99,7 +136,7 @@ class WarningsCog(commands.Cog):
         VTEC product as plain text from the IEM nwstext API."""
         if not self.bot.state.is_primary:
             return
-        channel = self.bot.get_channel(WARNINGS_CHANNEL_ID)
+        channel = await self._resolve_warning_channel(event)
         if not channel:
             return
 
@@ -558,11 +595,6 @@ class WarningsCog(commands.Cog):
         if not self.bot.state.is_primary:
             return
 
-        channel = self.bot.get_channel(WARNINGS_CHANNEL_ID)
-        if not channel:
-            logger.warning("Warnings channel not found — skipping poll")
-            return
-
         content, status, validators = await http_get_bytes_conditional(
             NWS_ALERTS_WARNINGS_URL,
             etag=self._validators.get("etag") or None,
@@ -640,7 +672,10 @@ class WarningsCog(commands.Cog):
                             self._in_flight_vtecs.add(issuance_id)
                             try:
                                 try:
-                                    await self._post_warning(feature, channel, vtec_dict, event, is_update=True)
+                                    event_ch = await self._resolve_warning_channel(event)
+                                    if event_ch is None:
+                                        continue
+                                    await self._post_warning(feature, event_ch, vtec_dict, event, is_update=True)
                                 except discord.HTTPException as e:
                                     logger.exception(f"Update send failed for {issuance_id}: {e}")
 
@@ -682,7 +717,11 @@ class WarningsCog(commands.Cog):
                 self.bot.state.posted_warnings[issuance_id] = {}  # placeholder
 
                 try:
-                    msg, area_desc = await self._post_warning(feature, channel, vtec_dict, event)
+                    event_ch = await self._resolve_warning_channel(event)
+                    if event_ch is None:
+                        self.bot.state.posted_warnings.pop(issuance_id, None)
+                        continue
+                    msg, area_desc = await self._post_warning(feature, event_ch, vtec_dict, event)
                 except discord.HTTPException as e:
                     logger.exception(f"Send failed for {issuance_id}: {e}")
                     # Roll back placeholder on failure

--- a/config.py
+++ b/config.py
@@ -92,6 +92,10 @@ CONFIG = {
     "health_channel_id": _optional_int("HEALTH_CHANNEL_ID", "SPC_CHANNEL_ID"),
     "sounding_channel_id": _optional_int("SOUNDING_CHANNEL_ID", "SPC_CHANNEL_ID"),
     "warnings_channel_id": _optional_int("WARNINGS_CHANNEL_ID", "SPC_CHANNEL_ID"),
+    "tor_channel_id": int(os.getenv("TOR_CHANNEL_ID", os.getenv("WARNINGS_CHANNEL_ID", os.getenv("SPC_CHANNEL_ID", "0")))),
+    "svr_channel_id": int(os.getenv("SVR_CHANNEL_ID", os.getenv("WARNINGS_CHANNEL_ID", os.getenv("SPC_CHANNEL_ID", "0")))),
+    "ffw_channel_id": int(os.getenv("FFW_CHANNEL_ID", os.getenv("WARNINGS_CHANNEL_ID", os.getenv("SPC_CHANNEL_ID", "0")))),
+    "sps_channel_id": int(os.getenv("SPS_CHANNEL_ID", os.getenv("WARNINGS_CHANNEL_ID", os.getenv("SPC_CHANNEL_ID", "0")))),
     "dev_channel_id": _optional_int("DEV_CHANNEL_ID", "HEALTH_CHANNEL_ID", "SPC_CHANNEL_ID"),
     "manual_cache_file": os.getenv("MANUAL_CACHE_FILE", "posted_records.json"),
     "auto_cache_file": os.getenv("AUTO_CACHE_FILE", "auto_posted_records.json"),
@@ -110,6 +114,10 @@ SPC_CHANNEL_ID = CONFIG["spc_channel_id"]
 HEALTH_CHANNEL_ID = CONFIG["health_channel_id"]
 SOUNDING_CHANNEL_ID = CONFIG["sounding_channel_id"]
 WARNINGS_CHANNEL_ID = CONFIG["warnings_channel_id"]
+TOR_CHANNEL_ID = CONFIG["tor_channel_id"]
+SVR_CHANNEL_ID = CONFIG["svr_channel_id"]
+FFW_CHANNEL_ID = CONFIG["ffw_channel_id"]
+SPS_CHANNEL_ID = CONFIG["sps_channel_id"]
 DEV_CHANNEL_ID = CONFIG["dev_channel_id"]
 MANUAL_CACHE_FILE = os.path.join(CONFIG["cache_file_dir"], CONFIG["manual_cache_file"])
 AUTO_CACHE_FILE = os.path.join(CONFIG["cache_file_dir"], CONFIG["auto_cache_file"])

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -183,6 +183,7 @@ def _make_cog(posted: dict | None = None) -> WarningsCog:
     iembot path without touching Discord, the DB, or the network."""
     cog = WarningsCog.__new__(WarningsCog)
     cog._in_flight_vtecs = set()
+    cog._perm_warned = set()
     cog.bot = MagicMock()
     cog.bot.wait_until_ready = AsyncMock()
     cog.bot.state.is_primary = True
@@ -505,6 +506,7 @@ def _nws_response(features: list) -> bytes:
 def _make_tick_cog(active=None, posted=None):
     cog = WarningsCog.__new__(WarningsCog)
     cog._in_flight_vtecs = set()
+    cog._perm_warned = set()
     from utils.backoff import TaskBackoff
     cog._backoff = TaskBackoff("auto_poll_warnings")
     cog._validators = {"etag": "", "last_modified": ""}
@@ -514,7 +516,19 @@ def _make_tick_cog(active=None, posted=None):
     cog.bot.state.is_primary = True
     cog.bot.state.posted_warnings = posted or {}
     cog.bot.state.active_warnings = active or {}
-    channel = AsyncMock()
+    channel = MagicMock()
+    channel.id = 12345
+    channel.name = "test-channel"
+    channel.send = AsyncMock()
+    # Mock the channel's guild and permissions for _check_channel_perms
+    channel.guild = MagicMock()
+    channel.guild.me = MagicMock()
+    perms_mock = MagicMock()
+    perms_mock.send_messages = True
+    perms_mock.embed_links = True
+    perms_mock.attach_files = True
+    channel.guild.me.permissions_for.return_value = perms_mock
+    channel.permissions_for = MagicMock(return_value=perms_mock)
     cog.bot.get_channel.return_value = channel
     return cog, channel
 

--- a/utils/worker_pool.py
+++ b/utils/worker_pool.py
@@ -6,17 +6,15 @@ to prevent long-running soundings from blocking rapid-fire radar updates.
 
 import asyncio
 import concurrent.futures
-import os
 from typing import Optional
 
 _HODO_EXECUTOR: Optional[concurrent.futures.ProcessPoolExecutor] = None
 _SOUNDING_EXECUTOR: Optional[concurrent.futures.ProcessPoolExecutor] = None
 
 # Hodographs are fast and memory-light.
-_MAX_HODO_WORKERS = 2
+_MAX_HODO_WORKERS = 4
 # Soundings are slow and memory-heavy (SounderPy/MetPy).
-# Cap at 1 on dual-core systems, 2 on larger systems.
-_MAX_SOUNDING_WORKERS = 1 if (os.cpu_count() or 2) <= 2 else 2
+_MAX_SOUNDING_WORKERS = 3
 
 # Semaphore for sounding queue management (for UI feedback)
 _sounding_semaphore: Optional[asyncio.Semaphore] = None
@@ -53,6 +51,8 @@ def get_hodo_executor() -> concurrent.futures.ProcessPoolExecutor:
     """Get or create the executor dedicated to fast radar/hodograph plots."""
     global _HODO_EXECUTOR
     if _HODO_EXECUTOR is None:
+        import logging as _logging
+        _logging.getLogger("spc_bot").info(f"Initializing Hodo Pool ({_MAX_HODO_WORKERS} workers)")
         _HODO_EXECUTOR = concurrent.futures.ProcessPoolExecutor(
             max_workers=_MAX_HODO_WORKERS,
             initializer=_worker_init
@@ -64,6 +64,8 @@ def get_sounding_executor() -> concurrent.futures.ProcessPoolExecutor:
     """Get or create the executor dedicated to heavy sounding plots."""
     global _SOUNDING_EXECUTOR
     if _SOUNDING_EXECUTOR is None:
+        import logging as _logging
+        _logging.getLogger("spc_bot").info(f"Initializing Sounding Pool ({_MAX_SOUNDING_WORKERS} workers)")
         _SOUNDING_EXECUTOR = concurrent.futures.ProcessPoolExecutor(
             max_workers=_MAX_SOUNDING_WORKERS,
             initializer=_worker_init


### PR DESCRIPTION
Routes each NWS warning product type to its own dedicated Discord channel, with slash commands to reconfigure routing at runtime without a restart.

## What changed

**Channel routing** — each warning type now resolves its target channel through a priority chain: state_store override → type-specific env var → `WARNINGS_CHANNEL_ID` fallback. A type can also be set to `"disabled"` to silence it entirely.

**New env vars** (all optional, fall back to `WARNINGS_CHANNEL_ID`):
- `TOR_CHANNEL_ID` — Tornado Warnings
- `SVR_CHANNEL_ID` — Severe Thunderstorm Warnings
- `FFW_CHANNEL_ID` — Flash Flood Warnings
- `SPS_CHANNEL_ID` — Special Weather Statements

**New slash commands** (`cogs/warning_channels.py`):
- `/enablewarnings type:[tor|svr|ffw|sps] channel:#channel` — routes a product type to a channel; persists to state_store
- `/displaysetup` — ephemeral embed showing current effective channel for each type (override vs default)
- `/disablewarnings` — ephemeral multi-select dropdown of active product types; selecting stops those posts

**Routing changes in `warnings.py`:**
- Added `_event_to_phenom(event)` — maps event display name → `tor/svr/ffw/sps/default`
- Added `_resolve_warning_channel(event)` — async channel resolver with state_store override support
- Both `post_warning_now()` (iembot/NWWS fast path) and `_tick()` (NWS API poll path) now call `_resolve_warning_channel()` per warning instead of using a single static channel

--------

## What's Changed

• feat(warnings): route warnings to per-type channels with live config commands by @full-bars in https://github.com/full-bars/spc-bot/pull/328
• fix(warning_channels): remove unused Optional import by @full-bars in https://github.com/full-bars/spc-bot/pull/328

**Full Changelog**: https://github.com/full-bars/spc-bot/compare/main...feat/warning-channel-routing