### PR TITLE
fix: sounding cache locking, eviction, and IEM hour filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file. Format
 loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 version numbers follow [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **IEM Hour Filter.** Removed a tautological `if (now - timedelta(hours=h)) < now` guard in `get_available_sounding_times_iem` that silently excluded the current UTC hour from all IEM availability checks.
+- **Station Cache Race.** Added a module-level `asyncio.Lock` with double-checked locking to `get_raob_stations` so concurrent callers at startup no longer each issue a redundant RAOB CSV fetch.
+- **Availability Cache Eviction.** `_AVAILABILITY_CACHE` now evicts expired entries when the cache exceeds 2,000 entries, preventing unbounded memory growth over long uptimes.
+- **Dead `n_times` Parameter.** Removed the unused `n_times` parameter from `filter_stations_with_data`; the IEM fast path returned before it was ever read, and all call sites already omitted it.
+
 ## [5.22.0] — 2026-05-10
 
 ### Added

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -44,6 +44,7 @@ USER_AGENT = "spc-bot-sounding/1.0"
 
 # Cache the station list in memory so we don't fetch it every time
 _station_cache: Optional[pd.DataFrame] = None
+_station_cache_lock: asyncio.Lock = asyncio.Lock()
 
 
 # ── User preferences ──────────────────────────────────────────────────────────
@@ -73,10 +74,13 @@ async def get_raob_stations() -> pd.DataFrame:
     if _station_cache is not None:
         return _station_cache
 
-    loop = asyncio.get_running_loop()
-    df = await loop.run_in_executor(None, _fetch_stations)
-    _station_cache = df
-    return df
+    async with _station_cache_lock:
+        if _station_cache is not None:
+            return _station_cache
+        loop = asyncio.get_running_loop()
+        df = await loop.run_in_executor(None, _fetch_stations)
+        _station_cache = df
+    return _station_cache
 
 def _fetch_stations() -> pd.DataFrame:
     df = pd.read_csv(
@@ -543,7 +547,6 @@ async def get_available_sounding_times_iem(
     times_to_check = [
         now - timedelta(hours=h)
         for h in range(hours_back + 1)
-        if (now - timedelta(hours=h)) < now
     ]
 
     # Limit concurrency to 5 simultaneous requests to avoid overwhelming IEM
@@ -553,8 +556,15 @@ async def get_available_sounding_times_iem(
 
     # Sort most recent first
     found.sort(key=lambda x: (x[0], x[1], x[2], x[3]), reverse=True)
-    # Store in cache
+    # Store in cache; evict expired entries if cache grows too large
     _AVAILABILITY_CACHE[cache_key] = (now, found)
+    if len(_AVAILABILITY_CACHE) > 2000:
+        expired = [
+            k for k, (ts, _) in _AVAILABILITY_CACHE.items()
+            if (now - ts).total_seconds() >= AVAILABILITY_CACHE_TTL
+        ]
+        for k in expired:
+            del _AVAILABILITY_CACHE[k]
     return found
 
 
@@ -884,14 +894,14 @@ async def fetch_acars_sounding(
 # ── SounderPy fetch and plot ──────────────────────────────────────────────────
 
 
-async def filter_stations_with_data(stations: list[dict], n_times: int = 1) -> list[dict]:
+async def filter_stations_with_data(stations: list[dict]) -> list[dict]:
     """
     Check each station in parallel against the single most recent sounding time.
     If the most recent time has no data, try the previous one — but all stations
     are checked concurrently to keep total wait time minimal.
     Returns only stations that have at least one available sounding.
     """
-    times = get_recent_sounding_times(n_times)
+    times = get_recent_sounding_times()
 
     async def has_data(station: dict) -> tuple[dict, bool]:
         station_id = station.get("icao") or station.get("wmo")


### PR DESCRIPTION
## Summary

Four bugs fixed in `cogs/sounding_utils.py`:

- **IEM hour filter (line 543–547):** The `if (now - timedelta(hours=h)) < now` guard was tautologically true for every `h > 0` and false only at `h == 0`, silently dropping the current UTC hour from all IEM availability checks. Filter clause removed; `h = 0` (current hour) is now included as intended.
- **Station cache race (line 70):** `get_raob_stations` populated `_station_cache` without a lock, so concurrent callers at startup each issued a separate RAOB CSV fetch. Added a module-level `asyncio.Lock` and double-checked locking pattern to ensure only one fetch ever runs.
- **Availability cache eviction (line 332):** `_AVAILABILITY_CACHE` grew unbounded — expired entries were skipped on read but never removed. On each insert, if the cache exceeds 2,000 entries, all expired entries are now evicted. No new dependency added (`cachetools` is not in `requirements.txt`).
- **Dead `n_times` parameter (line 887):** `filter_stations_with_data` accepted `n_times` but the IEM fast path returned before any code could consume it; the only reader was an unreachable Wyoming-fallback branch. All three call sites in `sounding.py` already omit the argument, so the parameter was removed cleanly.

## Test plan

- [x] `python3 -c "import cogs.sounding_utils"` — clean import
- [x] `ruff check cogs/sounding_utils.py` — no new errors (two pre-existing E402 lines unrelated to these changes)
- [x] `pytest tests/ -q` — 396 passed, 0 failed (run by pre-push hook)
- [x] Verified all three `filter_stations_with_data` call sites in `sounding.py` pass no positional `n_times` argument