### PR TITLE
perf: Rust haversine batch + precompiled geographic regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ version numbers follow [SemVer](https://semver.org/).
 - **Availability Cache Eviction.** `_AVAILABILITY_CACHE` now evicts expired entries when the cache exceeds 2,000 entries, preventing unbounded memory growth over long uptimes.
 - **Dead `n_times` Parameter.** Removed the unused `n_times` parameter from `filter_stations_with_data`; the IEM fast path returned before it was ever read, and all call sites already omitted it.
 
+### Performance
+- **Haversine Batch Vectorisation.** `find_nearest_stations` now calls `haversine_batch` (Rust fast-path) instead of a row-wise `df.apply` across ~900 RAOB stations. Eliminates the unnecessary DataFrame copy and reduces per-call overhead from ~900 Python haversine calls to a single Rust batch call.
+- **Pre-compiled Geographic Regex.** `_GEOGRAPHIC_GARBAGE` (133 keywords) is now compiled once into a single `re.Pattern` (`_GEOGRAPHIC_GARBAGE_RE`) at module load instead of recompiling up to 133 patterns per county string. `_STATE_REGEX` is likewise pre-compiled. Combined, this drops per-county regex overhead from 133 fresh `re.compile` calls to 1 `.search()` call.
+
 ## [5.22.0] — 2026-05-10
 
 ### Added

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -33,8 +33,8 @@ finally:
     sys.stdout = _stdout
 
 from utils.state_store import get_state, set_state  # noqa: E402  # follows sounderpy import
-from utils.geo import haversine
-from utils.http import http_get_json, circuit_breaker
+from utils.geo import haversine, haversine_batch  # noqa: E402
+from utils.http import http_get_json, circuit_breaker  # noqa: E402
 
 logger = logging.getLogger("spc_bot")
 
@@ -106,10 +106,9 @@ def _fetch_stations() -> pd.DataFrame:
 
 def find_nearest_stations(lat: float, lon: float, df: pd.DataFrame, n: int = 3) -> list[dict]:
     """Return the n nearest RAOB stations as a list of dicts."""
-    df = df.copy()
-    df["dist_km"] = df.apply(
-        lambda r: haversine(lat, lon, r["lat"], r["lon"]), axis=1
-    )
+    targets = list(zip(df["lat"], df["lon"]))
+    distances = haversine_batch(lat, lon, targets)
+    df = df.assign(dist_km=distances)
     nearest = df.nsmallest(n, "dist_km")
     results = []
     for _, row in nearest.iterrows():

--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -18,7 +18,10 @@ from utils.http import http_get_bytes
 
 logger = logging.getLogger("spc_bot.warnings")
 
-_STATE_REGEX = r"[\s,]+(?:[A-Z]{2}|ALABAMA|ALASKA|ARIZONA|ARKANSAS|CALIFORNIA|COLORADO|CONNECTICUT|DELAWARE|FLORIDA|GEORGIA|HAWAII|IDAHO|ILLINOIS|INDIANA|IOWA|KANSAS|KENTUCKY|LOUISIANA|MAINE|MARYLAND|MASSACHUSETTS|MICHIGAN|MINNESOTA|MISSISSIPPI|MISSOURI|MONTANA|NEBRASKA|NEVADA|NEW\s+HAMPSHIRE|NEW\s+JERSEY|NEW\s+MEXICO|NEW\s+YORK|NORTH\s+CAROLINA|NORTH\s+DAKOTA|OHIO|OKLAHOMA|OREGON|PENNSYLVANIA|RHODE\s+ISLAND|SOUTH\s+CAROLINA|SOUTH\s+DAKOTA|TENNESSEE|TEXAS|UTAH|VERMONT|VIRGINIA|WASHINGTON|WEST\s+VIRGINIA|WISCONSIN|WYOMING)$"
+_STATE_REGEX = re.compile(
+    r"[\s,]+(?:[A-Z]{2}|ALABAMA|ALASKA|ARIZONA|ARKANSAS|CALIFORNIA|COLORADO|CONNECTICUT|DELAWARE|FLORIDA|GEORGIA|HAWAII|IDAHO|ILLINOIS|INDIANA|IOWA|KANSAS|KENTUCKY|LOUISIANA|MAINE|MARYLAND|MASSACHUSETTS|MICHIGAN|MINNESOTA|MISSISSIPPI|MISSOURI|MONTANA|NEBRASKA|NEVADA|NEW\s+HAMPSHIRE|NEW\s+JERSEY|NEW\s+MEXICO|NEW\s+YORK|NORTH\s+CAROLINA|NORTH\s+DAKOTA|OHIO|OKLAHOMA|OREGON|PENNSYLVANIA|RHODE\s+ISLAND|SOUTH\s+CAROLINA|SOUTH\s+DAKOTA|TENNESSEE|TEXAS|UTAH|VERMONT|VIRGINIA|WASHINGTON|WEST\s+VIRGINIA|WISCONSIN|WYOMING)$",
+    re.IGNORECASE,
+)
 
 _STATES_LIST = [
     "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
@@ -26,12 +29,17 @@ _STATES_LIST = [
 ]
 
 _GEOGRAPHIC_GARBAGE = [
-    "AND", "INJURED", "EXPECT", "DAMAGE", "TORNADO", "THUNDERSTORM", 
+    "AND", "INJURED", "EXPECT", "DAMAGE", "TORNADO", "THUNDERSTORM",
     "ROOF", "SIDING", "VEHICLE", "REMAIN", "ALERT", "ROOM", "BASEMENT",
     "PEOPLE", "LOCATIONS", "PRECAUTIONARY", "PREPAREDNESS", "ACTIONS",
     "FLYING", "DEBRIS", "BUILDING", "TREES", "SHELTER", "LIKELY", "PROTECT",
     "LIGHTNING", "INDOORS", "THUNDER", "KILLERS", "REMEMBER", "ENOUGH", "STRUCK", "STORM"
 ] + _STATES_LIST
+
+_GEOGRAPHIC_GARBAGE_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(kw) for kw in _GEOGRAPHIC_GARBAGE) + r")\b",
+    re.IGNORECASE,
+)
 
 _WARNING_STYLE = {
     "Tornado Warning":             ("🌪️", discord.Color.red()),
@@ -310,7 +318,7 @@ def _area_with_state(area_desc: str, ugc_codes: List[str], state_fallback: Optio
             # Clean up county names that already have state info (e.g. "Caddo, OK" -> "Caddo")
             cleaned_group = []
             for c in group:
-                c_clean = re.sub(_STATE_REGEX, "", c.strip(), flags=re.I).strip()
+                c_clean = _STATE_REGEX.sub("", c.strip()).strip()
                 # Filter out standalone state abbreviations that got split out
                 if len(c_clean) > 2 or not c_clean.isupper():
                     cleaned_group.append(c_clean)
@@ -323,7 +331,7 @@ def _area_with_state(area_desc: str, ugc_codes: List[str], state_fallback: Optio
         remainder = counties[idx:]
         cleaned_remainder = []
         for r in remainder:
-            r_clean = re.sub(_STATE_REGEX, "", r.strip(), flags=re.I).strip()
+            r_clean = _STATE_REGEX.sub("", r.strip()).strip()
             if r_clean and (len(r_clean) > 2 or not r_clean.isupper()):
                 cleaned_remainder.append(r_clean)
         
@@ -508,7 +516,7 @@ def build_concise_warning_text(
                     c = re.split(r"\s+THROUGH\s+", c, flags=re.I)[0]
                     
                 # Skip if it contains garbage keywords as whole words
-                if any(re.search(rf"\b{kw}\b", c, re.I) for kw in _GEOGRAPHIC_GARBAGE):
+                if _GEOGRAPHIC_GARBAGE_RE.search(c):
                     continue
                 # Skip remaining structural text
                 if any(x in c.upper() for x in ["UNTIL", "PORTIONS", "AM", "PM", "EDT", "CDT", "MDT", "PDT", "HST", "AKDT", "LOCATED"]):
@@ -517,13 +525,13 @@ def build_concise_warning_text(
                 c = re.sub(r"^(?:Northeastern|Northwestern|Southeastern|Southwestern|Northern|Southern|Eastern|Western|Central)\s+", "", c, flags=re.I)
                 c = re.split(r"\s+in\s+", c, flags=re.I)[0]
                 c = re.sub(r"\s+(?:Count[iy]|Parish).*$", "", c, flags=re.I)
-                
+
                 # Suffix removal: strip ", OK" or " OK" or " OKLAHOMA"
-                c = re.sub(_STATE_REGEX, "", c.strip(), flags=re.I).strip()
-                
+                c = _STATE_REGEX.sub("", c.strip()).strip()
+
                 # Final check: skip if standalone state or still contains garbage keywords
                 if c and (len(c) > 2 or not c.isupper()):
-                    if not any(re.search(rf"\b{kw}\b", c, re.I) for kw in _GEOGRAPHIC_GARBAGE):
+                    if not _GEOGRAPHIC_GARBAGE_RE.search(c):
                         if c not in counties:
                             counties.append(c)
             
@@ -542,9 +550,9 @@ def build_concise_warning_text(
         raw_curr = [c.strip() for c in re.split(r'[;,]\s*', area) if c.strip()]
         curr_parts = []
         for c in raw_curr:
-            c_clean = re.sub(_STATE_REGEX, "", c, flags=re.I).strip()
+            c_clean = _STATE_REGEX.sub("", c).strip()
             if c_clean and (len(c_clean) > 2 or not c_clean.isupper()):
-                if not any(re.search(rf"\b{kw}\b", c_clean, re.I) for kw in _GEOGRAPHIC_GARBAGE):
+                if not _GEOGRAPHIC_GARBAGE_RE.search(c_clean):
                     if c_clean not in curr_parts:
                         curr_parts.append(c_clean)
 


### PR DESCRIPTION
## Summary

- **Fix 1 — Rust haversine batch in `find_nearest_stations`:** Replaced a row-wise `df.apply(haversine, axis=1)` loop across ~900 RAOB stations with a single `haversine_batch` call (Rust fast-path via `spc_rust_core`, pure-Python fallback). Also dropped the unnecessary `df.copy()` at the start of the function. Before: ~900 individual Python-level haversine invocations per lookup. After: 1 Rust batch call.
- **Fix 2 — Pre-compiled regex in `warning_format.py`:** The `_GEOGRAPHIC_GARBAGE` filter was recompiling up to 133 patterns per county string via a generator of `re.search(rf"\b{kw}\b", county)` calls. Now a single `_GEOGRAPHIC_GARBAGE_RE` pattern is compiled once at module load. `_STATE_REGEX` was also a raw string recompiled on every `re.sub` call — now a `re.Pattern` compiled at module load. Before: 133 fresh `re.compile` + `re.search` per county. After: 1 `.search()` call per county. Original `_GEOGRAPHIC_GARBAGE` list is preserved for any code that reads it directly.

## Test plan

- [x] AST parse confirms no syntax errors in both modified files
- [x] Inline equivalence check: old `any(re.search(...) for kw in list)` == new `_GEOGRAPHIC_GARBAGE_RE.search()` for 8 representative samples including word-boundary edge cases (e.g. `"Andover"` does not match `"AND"`)
- [x] `ruff check` passes on both files (pre-existing E402 suppressed with `# noqa`)
- [x] `pytest tests/ -k 'warning or sounding'` — 89 passed, 0 failures
- [x] Full suite via pre-push hook — 396 passed, 0 failures