### PR TITLE
chore: bump version to 5.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. Format
 loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 version numbers follow [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [5.24.0] — 2026-05-11
 
 ### Fixed
 - **IEM Hour Filter.** Removed a tautological `if (now - timedelta(hours=h)) < now` guard in `get_available_sounding_times_iem` that silently excluded the current UTC hour from all IEM availability checks.


### PR DESCRIPTION
## Summary
Tags v5.24.0 — 4 bug fixes, 3 performance improvements, and a new CI tooling floor (mypy/pre-commit/clippy gates). See `CHANGELOG.md` for full entries.

## Test plan
- [x] `ruff check --select=E9,F63,F7,F82,F401` passes locally
- [x] `pytest -q` — 396/396 pass locally
- [ ] CI green (lint, test, docker-build)