### PR TITLE
fix: pin python:3.13-slim-bookworm digest in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM python:3.13-slim-bookworm AS builder
+FROM python:3.13-slim-bookworm@sha256:386df64585134ba00b1d5e307acb1e72f33e9e87dbbb00aad9b8f24dbb51db72 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip wheel --wheel-dir /build/wheels -r requirements.txt
 
 # Runtime stage
-FROM python:3.13-slim-bookworm
+FROM python:3.13-slim-bookworm@sha256:386df64585134ba00b1d5e307acb1e72f33e9e87dbbb00aad9b8f24dbb51db72
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

The unpinned `FROM python:3.13-slim-bookworm` in `Dockerfile` was resolving to a moving digest. Each time Docker Hub published a new bookworm image, the digest changed, invalidating every downstream layer including the expensive `RUN pip wheel` step. On arm64 (self-hosted runner), this forced Cartopy (~22s) and arm-pyart (~100s) to recompile from source on every release.

## Diagnosis

GHA cache **is** working correctly on the self-hosted ARM runner — last release exported ~14 layers, and this release imported the cache manifest. But the layer cache key didn't match because the base image digest changed between v5.22.0 and v5.23.0 (and again between v5.23.0 and v5.24.0). With a stable digest, the `pip wheel` layer should hit cache cleanly when `requirements.txt` is unchanged.

## Why this fix

Pinning to `sha256:386df64585134ba00b1d5e307acb1e72f33e9e87dbbb00aad9b8f24dbb51db72` — the digest used in the v5.23.0 build — gives the cache a stable parent layer to attach to. Dependabot's existing `package-ecosystem: docker` rule (`.github/dependabot.yml:36-45`) will open a weekly PR to bump the digest when upstream publishes a newer image; that PR is reviewable like any dependency bump.

## Out of scope

`Dockerfile.ci` has the same unpinned `FROM python:3.13-slim-bookworm` but it's built infrequently and isn't the release-time bottleneck. Happy to follow up if desired.

## Expected impact

Next release's arm64 build should drop from ~6 minutes to ~1 minute (skipping wheel rebuilds entirely when requirements.txt is unchanged).

## Test plan
- [x] Dockerfile syntax valid (both FROM lines pinned to same digest)
- [x] No requirements.txt or workflow changes — strictly Dockerfile pin
- [ ] CI green
- [ ] Manual verify on next release that `RUN pip wheel` step is CACHED