### PR TITLE
fix: demote circuit-breaker fast-fail log from WARNING to DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. Format
 loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 version numbers follow [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Circuit Breaker Log Noise.** Demoted the per-request "Circuit open for {host}, failing fast" log from WARNING to DEBUG. The breaker fast-failing is the desired behavior — the actual state transition is still logged at WARNING (`reached N failures. Circuit OPEN`) and INFO (`recovered. Closing circuit`). A single upstream outage was producing 20× amplification (one trip warning + tens of fast-fail warnings until recovery).
+
 ## [5.24.0] — 2026-05-11
 
 ### Fixed

--- a/utils/http.py
+++ b/utils/http.py
@@ -147,7 +147,7 @@ async def http_get_bytes_conditional(
     host = parsed.netloc
 
     if circuit_breaker.is_open(host):
-        logger.warning(f"Circuit open for {host}, failing fast: {url}")
+        logger.debug(f"Circuit open for {host}, failing fast: {url}")
         raise CircuitOpenError(f"Circuit breaker is open for {host}")
 
     headers: Dict[str, str] = dict(extra_headers) if extra_headers else {}


### PR DESCRIPTION
## Summary

`utils/http.py:150` logged a WARNING every time a request was blocked by an open circuit breaker. But fast-failing **is** the desired behavior — the breaker tripping is already logged once at WARNING (`reached N failures. Circuit OPEN`), and recovery is logged at INFO (`recovered. Closing circuit`). Logging every blocked request creates ~20× amplification on real outages.

## Concrete impact

Recent 3-day log window for `rucsoundings.noaa.gov` (intermittent NOAA outage):

| Count | Severity | Message |
|------:|----------|---------|
| 151 | WARNING | `Circuit open for rucsoundings.noaa.gov, failing fast: ...` ← **this PR** |
| 69 | WARNING | `Request failed for ... after 1 retries` ← legitimate, untouched |
| 4 | WARNING | `reached 5 failures. Circuit OPEN.` ← legitimate, untouched |
| 4 | INFO | `recovery timeout elapsed. Half-open circuit.` ← legitimate, untouched |

After this PR, a multi-hour outage produces ~5–10 lines of log instead of hundreds, while the meaningful signals (trip/recovery state transitions and the actual upstream failures) are preserved.

## Out of scope

The half-open re-trip path double-logs `Circuit OPEN` each time a half-open probe fails. That's a separate, smaller issue (4 redundant lines in the 3-day window vs. 151 from this PR's fix) — would need a `HALF_OPEN` state flag in `CircuitBreaker` to distinguish first-trip from re-trip-after-probe. Happy to follow up if desired.

## Test plan
- [x] One-line change: WARNING → DEBUG; no behavior change beyond log severity
- [x] CHANGELOG `[Unreleased]` entry added
- [ ] CI green