### PR TITLE
fix: preserve LRU order on cache hydration and drain executors on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ version numbers follow [SemVer](https://semver.org/).
 
 ### Fixed
 - **Circuit Breaker Log Noise.** Demoted the per-request "Circuit open for {host}, failing fast" log from WARNING to DEBUG. The breaker fast-failing is the desired behavior — the actual state transition is still logged at WARNING (`reached N failures. Circuit OPEN`) and INFO (`recovered. Closing circuit`). A single upstream outage was producing 20× amplification (one trip warning + tens of fast-fail warnings until recovery).
+- **LRU Hydration Order.** `hydrate_validators_from_store` now inserts entries via `_validators_set` instead of `OrderedDict.update`. The bulk `.update` bypassed move-to-end and the max-size eviction path, so a large persisted store could silently exceed `_VALIDATORS_CACHE_MAX` and leave the LRU order undefined for items loaded at startup.
+- **Executor Drain on Shutdown.** `shutdown_executors` now passes `wait=True, cancel_futures=True` to both `ProcessPoolExecutor.shutdown` calls. The previous `wait=False` caused in-flight hodo/sounding renders to be abandoned mid-write on SIGTERM, risking partial image files and silent result loss.
 
 ## [5.24.0] — 2026-05-11
 

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -66,7 +66,8 @@ async def hydrate_validators_from_store() -> int:
         return len(_validators_cache)
     stored = await get_all_validators()
     if stored:
-        _validators_cache.update(stored)
+        for k, v in stored.items():
+            _validators_set(k, v)
     _validators_hydrated = True
     logger.info(f"Hydrated {len(_validators_cache)} HTTP validators from store")
     return len(_validators_cache)

--- a/utils/worker_pool.py
+++ b/utils/worker_pool.py
@@ -90,10 +90,10 @@ def shutdown_executors():
     """Cleanly shut down all worker pools."""
     global _HODO_EXECUTOR, _SOUNDING_EXECUTOR
     if _HODO_EXECUTOR is not None:
-        _HODO_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+        _HODO_EXECUTOR.shutdown(wait=True, cancel_futures=True)
         _HODO_EXECUTOR = None
     if _SOUNDING_EXECUTOR is not None:
-        _SOUNDING_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+        _SOUNDING_EXECUTOR.shutdown(wait=True, cancel_futures=True)
         _SOUNDING_EXECUTOR = None
 
 


### PR DESCRIPTION
Both fixes are in `utils/`.

**Item A — LRU hydration order (`utils/cache.py`)**

`hydrate_validators_from_store` was calling `_validators_cache.update(stored)` to load the persisted validator store at startup. `_validators_cache` is an `OrderedDict` with LRU eviction via `_validators_set` (which calls `move_to_end` and enforces the 2048-entry cap). The bulk `.update` bypassed both: entries landed in arbitrary dict iteration order with no eviction, so a store larger than `_VALIDATORS_CACHE_MAX` silently exceeded the cap. Fixed by iterating and calling `_validators_set(k, v)` for each entry.

**Item B — Graceful executor drain (`utils/worker_pool.py`)**

`shutdown_executors` passed `wait=False, cancel_futures=True` to both `ProcessPoolExecutor.shutdown` calls. `wait=False` returns immediately, abandoning in-flight tasks — a hodo or sounding render mid-write on SIGTERM would produce a partial/corrupt image file. Changed to `wait=True, cancel_futures=True`: running tasks finish, queued-but-not-started tasks are cancelled. This is the correct SIGTERM drain semantic per the Python docs.

**Tests:** `pytest -x -k "cache or worker"` cannot run in this environment (missing `aiohttp`/`discord` runtime deps); the pre-push hook has the same `python` vs `python3` issue. Both changes are mechanical one-liners with no logic branching.