### PR TITLE
ci: re-enable parallel testing with pytest-xdist

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
           pip install dist/*.whl
       - name: Run tests with coverage
         run: |
-          python -m pytest tests/ \
+          python -m pytest tests/ -n auto \
             --cov=cogs --cov=utils --cov=config --cov=main \
             --cov-report=term-missing --cov-report=xml -v
       - name: Upload coverage artifact


### PR DESCRIPTION
Restores parallel testing with `pytest-xdist` using the `-n auto` flag. This follows the merge of #344, which added the dependency and triggered the CI image rebuild.

Parallelization should reduce test time from ~100s to ~40s in CI.