### PR TITLE
chore: release v5.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ version numbers follow [SemVer](https://semver.org/).
 - **LRU Hydration Order.** `hydrate_validators_from_store` now inserts entries via `_validators_set` instead of `OrderedDict.update`. The bulk `.update` bypassed move-to-end and the max-size eviction path, so a large persisted store could silently exceed `_VALIDATORS_CACHE_MAX` and leave the LRU order undefined for items loaded at startup.
 - **Executor Drain on Shutdown.** `shutdown_executors` now passes `wait=True, cancel_futures=True` to both `ProcessPoolExecutor.shutdown` calls. The previous `wait=False` caused in-flight hodo/sounding renders to be abandoned mid-write on SIGTERM, risking partial image files and silent result loss.
 
+### Rust
+- **Phase 7 — VAD Plotter Math.** Ported `compute_shear_mag`, `compute_sr_flow`, and `clip_profile` from `lib/vad_plotter/params.py` to Rust. Includes a vectorized `linspace` helper and a `_interp_linear` implementation that matches NumPy's `left=nan, right=nan` boundary behavior. Verified at `1e-9` tolerance against the Python implementations using the `test.vwp` fixture.
+- **Phase 8 — Batch Spatial Joins.** Added `find_nearest_stations_batch`, `points_in_polygon_counts`, and `points_in_polygon_lookup` to the Rust core (`utils/geo`). Refactored `find_nearest_stations` in `cogs/sounding_utils.py` to use the Rust `find_nearest_indices` fast-path, replacing a row-wise Pandas `nsmallest`. Parity and integration tests in `tests/test_rust_phase8.py`.
+
+### Fixed
+- **International Sounding Availability.** `filter_stations_with_data` now falls back to a direct Wyoming/GSL archive probe when IEM returns empty results for non-CONUS stations (e.g. SBSM/Santa Maria). Previously these stations incorrectly showed "no recent data" despite full profiles being available in the Wyoming archive. Rolled into a unified `get_available_sounding_times` helper in the follow-up fix so the Wyoming probe applies consistently across all availability checks.
+- **Sounding Theme Toggle.** Label changed to "Switch to Dark/Light Mode" for clarity, emojis standardized, and button row indexing fixed to prevent UI collisions with other sounding controls.
+- **Upstash Daily Quota Guard.** Added a local daily command counter in `utils/db.py` and a soft-quota guard in `_upstash_cmd`. Logs a `WARNING` when usage reaches 8,000 (80% of the 10,000-command free tier) and raises `_UpstashUnavailable` to fall back to SQLite at the hard limit. The warning is emitted once per process per day to avoid log spam.
+- **NWWS Ping Loop Leak.** `NWWSClient.disconnect` now explicitly cancels and clears `_ping_task`, preventing the keep-alive loop from outliving the XMPP session across reconnects.
+
 ### CI
 - **Parallel test execution.** Added `pytest-xdist` to `requirements-dev.txt` and enabled `-n auto` in the CI test step, distributing tests across all available CPU cores. `pytest.ini` addopts unchanged so local runs stay serial.
 - **Docker layer cache efficiency.** Reordered the runtime `Dockerfile` so the `apt-get install` layer appears before `COPY --from=builder /wheels`; code-only changes no longer invalidate the OS package layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.25.0] — 2026-05-13
+
 ### Performance
 - **Tenacity Retry Decorator Hoisted.** `http_get_bytes_conditional` and `http_get_json` previously reconstructed a `tenacity.retry(...)` decorator object on every invocation, paying the full strategy-compilation cost per HTTP call. Decorators are now built once at module load and cached by attempt-count in `_RETRY_CACHE`; the common cases (1–4 attempts) are pre-populated at import time. Non-default counts are lazily memoized on first use.
 - **Vectorized Station Coordinate Transform.** Replaced two `df.apply(lambda row: ...)` calls in `_fetch_stations` with column-wise `np.where` expressions. The old approach iterated row-by-row in Python (~900 iterations per startup fetch); the new approach evaluates the hemisphere-sign conversion in a single vectorized pass over the entire column.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,10 @@ The bot implements two cleanup paths. `utils/cache_utils.py` runs once after sta
 
 The `/sounding` command geocodes the location, finds nearby RAOB stations that have verified data in the Wyoming archive, and presents an interactive station and time picker. Plots are generated headlessly via SounderPy and posted to the channel where the command was used. Per-user dark mode preference is persisted to the local SQLite database. Auto-posting of soundings is active in three modes: (1) **proactive pre-warming** when the MD cog detects a mesoscale discussion with ≥80% watch issuance probability; (2) **immediately on watch issuance**, using the most recent IEM-available sounding time (any hour); (3) **at 00z/12z** for all active watches. Up to 3 RAOB stations and 2 ACARS profiles per watch. At 00z/12z, Wyoming and IEM are raced simultaneously — whichever returns data first wins.
 
+**Disk caching**: generated sounding plots are cached to disk using a hash-based key so identical requests skip re-rendering. **Queue management**: concurrent plot requests are governed by an `asyncio.Semaphore`; users see a "Plot Queued (Position X)..." message while waiting so the interaction does not time out.
+
+**Worker pool split**: sounding generation runs in a dedicated "Heavy Sounding" `ProcessPoolExecutor` (isolated from the "Fast Hodo" pool used for hodograph/VAD rendering) to prevent long SounderPy renders from blocking time-sensitive hodo requests.
+
 ### CSU-MLP and NCAR WxNext2
 
 Both poll once daily around model update time. State is persisted via `state_store` (Upstash + SQLite) so restarts and failovers don't cause duplicate posts.
@@ -270,6 +274,8 @@ Same tables as historical `utils/db.py`: `image_hashes`, `posted_mds`, `posted_w
 
 Projected ~8.2 k commands/day across both nodes (primary heartbeat writes, standby heartbeat reads, periodic bulk refreshes, state mutations) against the 10 k/day free-tier ceiling. Hot reads are served from the in-process cache, not billed.
 
+**Soft-quota guard**: `state_store` tracks the rolling daily Upstash command count. At **8 k/day** a warning is logged; at **10 k/day** the store automatically falls back to SQLite for all reads and writes for the remainder of the UTC day, preventing hard rate-limit errors.
+
 ---
 
 ## Running Tests
@@ -296,6 +302,18 @@ Lint (same selection CI uses):
 ```bash
 ruff check --select=E9,F63,F7,F82,F401 --exclude=venv,lib,cache .
 ```
+
+### CI pipeline
+
+The GitHub Actions workflow runs three jobs on every push and pull request:
+
+| Job | What it checks |
+|---|---|
+| **pytest** | Full test suite via `pytest -n auto` (pytest-xdist parallel execution) with coverage |
+| **mypy** | Static type check on `utils/` (`mypy utils/`) |
+| **rust** | `cargo fmt --check` and `cargo clippy -- -D warnings` on `src_rust/` |
+
+All three jobs must pass before a PR can be merged.
 
 ---
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -33,7 +33,7 @@ spc-bot/
 │   ├── spc_urls.py          # SPC outlook URL resolution
 │   ├── spc_outlook.py       # SPC Day 1 categorical polygon (MDT/HIGH) with geodesic buffer
 ├── backoff.py           # Exponential backoff tracker for task loops
-├── worker_pool.py       # Shared ProcessPoolExecutor for background rendering
+├── worker_pool.py       # Two separate ProcessPoolExecutors: "Fast Hodo" (hodograph/VAD rendering) and "Heavy Sounding" (SounderPy plot generation)
 └── db.py                # Async SQLite backend used internally by state_store as the durable mirror; also home of http_validators
 
 ├── cogs/
@@ -52,8 +52,8 @@ spc-bot/
 │   ├── scp.py               # NIU/Gensini SCP graphics, twice daily
 │   ├── csu_mlp.py           # CSU-MLP consolidated /csu command with Choice dropdown
 │   ├── ncar.py              # NCAR WxNext2 AI severe weather forecast
-│   ├── sounding.py          # RAOB+ACARS sounding plots; auto-posts near active watches
-│   ├── sounding_utils.py    # Location resolution, IEM fetch (all hours), ACARS fetch, plot generation
+│   ├── sounding.py          # RAOB+ACARS sounding plots; auto-posts near active watches; asyncio.Semaphore queue with position feedback
+│   ├── sounding_utils.py    # Location resolution, IEM fetch (all hours), ACARS fetch, plot generation; disk-caches plots with hash-based dedup
 │   ├── sounding_views.py    # Discord UI: CombinedSoundingView, IEMTimeSelectionView, ACARS views
 │   ├── hodograph.py         # VWP hodograph generation via /hodograph
 │   ├── failover.py          # Leader election via an Upstash lease (no HTTP tunnel — v5+)
@@ -125,6 +125,8 @@ High-performance Rust core via PyO3 with Python fallback for all operations:
 - **NWWS Product ID Normalizer** (Phase 4): ISO8601 timestamp conversion and product ID deduplication
 - **Haversine Distance Calculator** (Phase 5): Geospatial queries for station lookups
 - **Comprehensive Unit Tests** (Phase 6): 30+ tests covering all Rust internals
+- **VAD Storm-Mode Math** (Phase 7): `compute_shear_mag`, `compute_sr_flow`, `clip_profile` from `lib/vad_plotter/params.py` now Rust-backed
+- **Batch Spatial Joins** (Phase 8): `find_nearest_stations_batch`, `points_in_polygon_counts`, `points_in_polygon_lookup` in `utils/geo`; `find_nearest_stations` uses Rust fast-path via rstar R*-tree
 
 All Rust functions maintain pure-Python fallback implementations. FFI detection at runtime gracefully downgrades to Python if Rust extension is unavailable.
 
@@ -169,13 +171,13 @@ The test suite has **382 tests** covering:
 - Failover scenarios and race conditions
 - HTTP caching and retry logic
 - Forecasting model parsing
-- **Rust FFI tests** (Phases 1–6): SRH/Bunkers, VTEC parser, image cache validator, product ID normalizer, haversine distance, with Python fallback verification
+- **Rust FFI tests** (Phases 1–8): SRH/Bunkers, VTEC parser, image cache validator, product ID normalizer, haversine distance, VAD storm-mode math, batch spatial joins — with Python fallback verification
 
 Run tests with:
 ```bash
 pip install -r requirements-dev.txt
 VIRTUAL_ENV=venv maturin develop --release  # Build Rust extension
-python -m pytest tests/ -v
+python -m pytest tests/ -n auto -v          # pytest-xdist parallel execution
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md#running-tests) for coverage reports and lint checks.
+CI additionally runs a **mypy gate** on `utils/` and a **Rust clippy/fmt** job on every push. See [CONTRIBUTING.md](CONTRIBUTING.md#running-tests) for coverage reports and lint checks.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NWWS-OI fast path, IEMBot fallback, NWS API polling, SPC watch alerts with dedup
 
 **Scientific Tools:** Interactive RAOB/ACARS sounding plots (auto-posted near active watches and MDT/HIGH risk areas), VWP hodographs, searchable tornado forensics archive, NEXRAD Level 2 downloader, and IEM-based tornado analytics.
 
-**System:** Real-time `/status` dashboard, owner-only `/taskmgr` and `/logs` monitoring, dual-endpoint watchdog, leader-election failover with Upstash Redis, SQLite durability, optional Syncthing event archive replication, and an optional Rust hybrid core.
+**System:** Real-time `/status` dashboard, owner-only `/taskmgr` and `/logs` monitoring, dual-endpoint watchdog, leader-election failover with Upstash Redis, SQLite durability, optional Syncthing event archive replication, and a Rust hybrid core (Phases 1–8) that accelerates VAD hodograph math, VTEC parsing, XXH3 image hashing, NWWS product ID normalization, haversine distance queries, VAD storm-mode calculations (`shear_mag`, `sr_flow`, `clip_profile`), and batch spatial joins (`find_nearest_stations_batch`, `points_in_polygon_counts`). All Rust paths fall back to pure Python if the extension is unavailable.
 
 ## Quick Start
 

--- a/wiki/pages/Alerting-Authority-&-NWWS-OI.md
+++ b/wiki/pages/Alerting-Authority-&-NWWS-OI.md
@@ -23,6 +23,36 @@ Traditional polling via the NWS API (`api.weather.gov`) and `spc.noaa.gov`.
 - **Role:** Used for "Aggressive Checking" during Moderate/High risk days and for rehydrating state at startup.
 - **Persistence:** ETag and Last-Modified headers are used to minimize bandwidth and detect updates efficiently.
 
+## 📢 Per-Type Warning Channels
+
+Warning products can be routed to dedicated Discord channels based on event type, rather than a single shared channel.
+
+### Channel Environment Variables
+
+| Variable | Warning Type |
+|---|---|
+| `TOR_CHANNEL_ID` | Tornado Warnings |
+| `SVR_CHANNEL_ID` | Severe Thunderstorm Warnings |
+| `FFW_CHANNEL_ID` | Flash Flood Warnings |
+| `SPS_CHANNEL_ID` | Special Weather Statements |
+
+### Routing Fallback Chain
+
+For each warning type, the bot resolves the destination channel in this order:
+1. Per-type channel (e.g., `TOR_CHANNEL_ID`) — if set and enabled
+2. `WARNINGS_CHANNEL_ID` — general warnings channel
+3. `SPC_CHANNEL_ID` — catch-all SPC channel
+
+### Runtime Configuration
+
+Per-type channel routing can be adjusted at runtime without a restart:
+
+| Command | Description |
+|---|---|
+| `/enablewarnings` | Enable warning posting for the current channel (or a specified channel). Setting persists to the state store. |
+| `/disablewarnings` | Disable warning posting for the configured channel. |
+| `/displaysetup` | Show the current per-type channel routing configuration, including which env vars are active and which channels are enabled. |
+
 ## 🛡️ Circuit Breakers & Resilience
 
 SPCBot implements **Circuit Breakers** for all upstream HTTP endpoints.

--- a/wiki/pages/Configuration-Guide.md
+++ b/wiki/pages/Configuration-Guide.md
@@ -20,9 +20,15 @@ SPCBot is configured via a `.env` file in the project root. Below is a comprehen
 | `NWWS_PASSWORD` | NWWS-OI XMPP password. | (empty) |
 | `NWWS_SERVER` | NWWS-OI XMPP server address. | `nwws-oi.weather.gov` |
 | `WARNINGS_CHANNEL_ID` | Channel for TOR/SVR/FFW alerts. | `SPC_CHANNEL_ID` |
+| `TOR_CHANNEL_ID` | Dedicated channel for Tornado Warning (TOR) posts. | `WARNINGS_CHANNEL_ID` |
+| `SVR_CHANNEL_ID` | Dedicated channel for Severe Thunderstorm Warning (SVR) posts. | `WARNINGS_CHANNEL_ID` |
+| `FFW_CHANNEL_ID` | Dedicated channel for Flash Flood Warning (FFW) posts. | `WARNINGS_CHANNEL_ID` |
+| `SPS_CHANNEL_ID` | Dedicated channel for Special Weather Statement (SPS) posts. | `WARNINGS_CHANNEL_ID` |
 | `HEALTH_CHANNEL_ID` | Channel for health alerts and watchdog notifications. | `SPC_CHANNEL_ID` |
 | `SOUNDING_CHANNEL_ID` | Channel for automated sounding posts. | `SPC_CHANNEL_ID` |
 | `DEV_CHANNEL_ID` | Channel for developer/admin operational alerts. | `HEALTH_CHANNEL_ID`, then `SPC_CHANNEL_ID` |
+
+**Warning-type channel fallback chain:** For each warning type the bot resolves the destination as: type-specific ID (`TOR_CHANNEL_ID`, `SVR_CHANNEL_ID`, `FFW_CHANNEL_ID`, `SPS_CHANNEL_ID`) → `WARNINGS_CHANNEL_ID` → `SPC_CHANNEL_ID`. These IDs can also be changed at runtime without a restart via `/enablewarnings`, `/disablewarnings`, and `/displaysetup`.
 
 ## 🔄 High Availability (Failover)
 

--- a/wiki/pages/High-Availability-&-Failover.md
+++ b/wiki/pages/High-Availability-&-Failover.md
@@ -34,6 +34,16 @@ While the failover manages *who* posts, the state must remain consistent.
 - **SQLite Mirror:** A local `bot_state.db` provides a durable mirror and handles outage survival if Upstash is unreachable.
 - **Syncthing:** Replicates the historical `events.db` archive cross-node, ensuring the Standby has the full record if it promotes.
 
+### Upstash Quota Exhaustion
+
+The bot enforces a daily command quota guard against the Upstash free-tier limit (10,000 commands/day):
+
+- **At 8,000 commands:** A one-time `WARNING` is logged (`Upstash daily quota warning: X/10000`). Upstash remains fully active.
+- **At 10,000 commands:** The bot raises `_UpstashUnavailable` and silently falls back to SQLite for all state operations — posting, deduplication, and HA heartbeats all continue via the local mirror. **The node does not crash or demote itself.**
+- **Reset:** The counter resets at UTC midnight. Upstash operations resume automatically on the next call after reset.
+
+Quota exhaustion is operationally transparent: from Discord's perspective the bot continues to post and deduplicate correctly. The only observable effect is that Upstash-sourced cross-node state (e.g., lease renewal) relies on the last synced SQLite snapshot until midnight.
+
 ## ⚙️ Environment Checklist
 
 Set these on both nodes:

--- a/wiki/pages/Maintenance-&-Operations.md
+++ b/wiki/pages/Maintenance-&-Operations.md
@@ -74,6 +74,16 @@ Symptoms: failover lease warnings, dirty-write reconciliation logs, or standby u
 3. Let SQLite mirror continue local durability; dirty writes are replayed when Upstash returns.
 4. Avoid manual role swaps until the lease store recovers unless the current primary is clearly down.
 
+### Upstash Quota Warning
+Symptom: `/logs` shows `WARNING Upstash daily quota warning: X/10000`.
+
+The bot tracks daily Upstash command usage and enforces a soft quota guard:
+- **At 8,000 commands (80%):** A single `WARNING` is logged. The bot continues using Upstash normally — no action is required unless the server is handling an unusually high alert volume.
+- **At 10,000 commands (hard limit):** The bot raises an internal `_UpstashUnavailable` and automatically falls back to SQLite for all state operations. HA heartbeats continue via SQLite — the node does not crash or stop posting.
+- **Reset:** The counter resets daily at UTC midnight. Normal operation resumes automatically on the next Upstash call after midnight.
+
+If quota exhaustion is a recurring pattern, consider whether a runaway loop or unusual traffic spike is inflating command counts.
+
 ### Split-Brain Suspicion
 Symptoms: both nodes appear to post or both report `PRIMARY`.
 
@@ -89,6 +99,11 @@ Symptoms: slash commands are missing, stale, or return interaction errors.
 2. Check `/logs` for Discord HTTP errors or permission failures.
 3. Confirm the bot is invited with `applications.commands` scope.
 4. Restart only the primary if command sync failed during startup.
+
+### Sounding Queue Saturation
+Symptom: users see `Plot Queued (Position X)...` instead of an immediate sounding image.
+
+The sounding renderer uses a dedicated `Heavy Sounding` worker pool (separate from the `Fast Hodo` radar pool). When all workers are busy, new requests are queued and users receive a position message. The queue auto-clears as workers finish — no operator action is needed. A 60-second render timeout prevents deadlock; requests that exceed the timeout are discarded and the user sees an error. If queuing is persistent, the server may be under unusually high sounding load.
 
 ### Cache Disk Pressure
 Symptoms: large `cache/`, slow image/radar commands, or filesystem warnings.

--- a/wiki/pages/Slash-Command-Reference.md
+++ b/wiki/pages/Slash-Command-Reference.md
@@ -34,6 +34,13 @@ SPCBot uses Discord Slash Commands for all user interactions. Commands are organ
 
 Some analytics commands expose experimental IEM Autoplot workflows and are still being hardened for production use.
 
+## 🔔 Warning Channel Management
+| Command | Description | Parameters |
+|---|---|---|
+| `/enablewarnings` | Enable warning posting for the current channel (or a specified channel). Setting persists to the state store. | `channel` (optional) |
+| `/disablewarnings` | Disable warning posting for the current channel. | None |
+| `/displaysetup` | Show the current per-type channel routing configuration (TOR/SVR/FFW/SPS channel assignments and enabled state). | None |
+
 ## 🧪 Models & System
 | Command | Description | Parameters |
 |---|---|---|

--- a/wiki/pages/Soundings-&-Hodographs.md
+++ b/wiki/pages/Soundings-&-Hodographs.md
@@ -8,8 +8,16 @@ The `/sounding` command plots RAOB (weather balloon) and ACARS (aircraft) data u
 - **Location Support:** Accepts 3-letter site IDs (e.g., `OUN`), 4-letter ICAO codes (`KOUN`), or city names (`Norman, OK`).
 - **Data Sources:** Automatically tries **IEM**, **Wyoming**, and **GSL** (FSL) in a prioritized hierarchy with circuit-breaker logic.
 - **Interactive UI:** Users can select specific times (e.g., `00z`, `12z`) or recent special releases (e.g., `18z`, `20z`) via a dropdown menu.
-- **Performance:** As of v5.20.0, the initial "Checking Station Availability..." step is optimized with concurrent request limiting (max 5 simultaneous), reducing lookup time from 10–30s to 1–3s.
-- **Dark Mode:** Toggle between light and dark plot themes using the built-in mode switch button (preserves station data on mode change).
+- **Performance:** The initial "Checking Station Availability..." step is optimized with concurrent request limiting, reducing lookup time from 10–30s to 1–3s.
+- **International Stations:** For stations not listed in the IEM station inventory (e.g., `SBSM`/Santa Maria), availability is confirmed via a Wyoming archive fallback probe, ensuring non-CONUS stations show correctly.
+- **Dark Mode:** Toggle between light and dark plot themes using the **Switch to Dark/Light Mode** button (preserves station data on mode change).
+
+### Queue Management & Caching
+
+Sounding renders run in a dedicated **Heavy Sounding** executor, isolated from hodograph requests so that a slow or queued sounding plot never delays a hodograph update.
+
+- **Queue position feedback:** When all sounding workers are busy, the bot replies with "Plot Queued (Position X)…" and updates the message as the request advances through the queue. An `asyncio.Semaphore` controls concurrency.
+- **Disk caching with hash dedup:** Rendered sounding images are cached to disk keyed by a hash of location + time + theme. Repeated requests for the same combination return the cached image immediately without re-rendering.
 
 ## 🌪️ Watch-Triggered Soundings
 
@@ -24,7 +32,7 @@ The `/hodograph` command generates a Vertical Wind Profile (VWP) hodograph for a
 - **High-Availability:** Uses **AWS S3** as a primary data source with automatic fallback to **TGFTP**, ensuring reliability during NWS server outages.
 - **Real-time Surface Wind:** Automatically fetches the latest ASOS surface observation near the radar to provide an accurate surface-to-1km profile.
 - **Parameter Table:** Includes a comprehensive storm-parameter table (Bunkers motion, SRH, Shear) rendered alongside the plot.
-- **Performance (v5.20.0+):** Hodograph storm-parameter calculations (Bunkers displacement, Storm-Relative Helicity, Critical Angle) are accelerated using Rust with Python fallback, reducing computation time for large profiles.
+- **Performance:** Hodograph storm-parameter calculations (Bunkers displacement, Storm-Relative Helicity, Critical Angle) are accelerated using Rust with Python fallback, reducing computation time for large profiles. Hodographs run in a dedicated **Fast Hodo** executor and are never blocked by concurrent sounding renders.
 
 ## 🎥 VAD Forensics
 
@@ -32,6 +40,15 @@ Introduced in **v5.14.0**, the bot automatically records the wind environment du
 - **Trigger:** Any Tornado Warning with an `OBSERVED` tag starts a **2.5-hour mission**.
 - **Evolution GIFs:** Captures a 1-hour lookback and a 90-minute follow-up window, stitching them into an animated evolution of the vertical wind profile.
 - **Permanent Record:** Calculates the **Peak 0-1km SRH** during the event and archives it in `events.db` along with the GIF.
+
+## ⚙️ Rust-Accelerated VAD Math (Phase 7)
+
+Key VAD math routines in `vad_plotter/params.py` are now backed by compiled Rust via try-Rust → fallback-to-Python wrappers:
+- `compute_shear_mag` — bulk shear magnitude between two pressure levels
+- `compute_sr_flow` — storm-relative flow vectors
+- `clip_profile` — profile clipping to a depth layer
+
+If the Rust extension is unavailable (e.g., unsupported platform), each function transparently falls back to the pure-Python implementation with no user-visible change.
 
 ## 🔬 Scientific Stack
 

--- a/wiki/pages/Tornado-Dashboard-&-DAT-Integration.md
+++ b/wiki/pages/Tornado-Dashboard-&-DAT-Integration.md
@@ -26,7 +26,7 @@ The bot is deeply integrated with the NWS DAT for high-resolution post-storm dat
 
 The bot uses a **geographic and temporal matching engine** to link real-time warnings to post-storm surveys:
 1. **LSR Linkage:** Links "Confirmed Tornado" reports to the warning that covered them.
-2. **Survey Linkage:** Uses a haversine distance search (50km radius) to link DAT tracks to the original "Significant Events" logged in the bot's `events.db`.
+2. **Survey Linkage:** Uses a haversine distance search (50km radius) to link DAT tracks to the original "Significant Events" logged in the bot's `events.db`. This search is Rust-accelerated via batch haversine (Phase 5 of the Rust integration), replacing what was previously a ~900-iteration Python loop.
 
 ## 💾 The `events.db` Archive
 


### PR DESCRIPTION
Prepares the v5.25.0 release.

## Changes
- Promotes `[Unreleased]` CHANGELOG block to `[5.25.0] — 2026-05-13`
- Cherry-picks docs commit: CHANGELOG entries for PRs #349–#353, wiki updates (Soundings, Alerting Authority, Slash Command Reference, Maintenance, HA/Failover, Configuration Guide, Tornado Dashboard), in-repo doc updates (PROJECT_STRUCTURE, CONTRIBUTING, README)

## PRs included since v5.24.0
- #342 fix: circuit breaker log noise
- #343 fix: mesoscale MD index state race
- #344 ci: pytest-xdist + Docker layer cache
- #345 perf: hoist tenacity retry decorator
- #346 perf: vectorize sounding station lookup
- #347 fix: LRU cache hydration + executor drain on SIGTERM
- #348 ci: enable parallel tests (-n auto)
- #349 feat: Rust Phase 7 — vad_plotter math
- #350 fix: P2 hardening (Upstash quota guard, NWWS ping loop)
- #351 feat: Rust Phase 8 — batch spatial joins and station rank/filter
- #352 fix: sounding availability + theme toggle
- #353 fix: unified sounding availability (Wyoming fallback)