### PR TITLE
ci: build Rust extension before tests in docker-publish verify job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+      - name: Install Rust toolchain
+        run: |
+          if ! command -v cargo &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+          fi
+          . "$HOME/.cargo/env" || . "/root/.cargo/env"
+      - name: Build and install Rust extension
+        run: |
+          . "$HOME/.cargo/env" || . "/root/.cargo/env"
+          pip install maturin
+          maturin build --release --out dist
+          pip install dist/*.whl
       - name: Run tests
         run: python -m pytest tests/ -q
 


### PR DESCRIPTION
The `verify` job in `docker-publish.yml` runs `pytest` without first building and installing the `spc_rust_core` extension. The main CI workflow (`tests.yml`) does this explicitly via `maturin build --release` + `pip install dist/*.whl`, but the docker-publish workflow was missing those steps.

This was a silent pre-existing gap that became fatal with Rust Phases 7 and 8, whose test files (`test_rust_phase8.py`, `test_rust_vad_params.py`) import `spc_rust_core` at module level, causing collection errors when the extension isn't present.

Fix: add Rust toolchain install + `maturin build` + `pip install dist/*.whl` to the verify job, matching the pattern in `tests.yml`.