### PR TITLE
ci: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY for Python 3.13 in docker-publish verify job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,6 +35,8 @@ jobs:
           fi
           . "$HOME/.cargo/env" || . "/root/.cargo/env"
       - name: Build and install Rust extension
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
         run: |
           . "$HOME/.cargo/env" || . "/root/.cargo/env"
           pip install maturin


### PR DESCRIPTION
pyo3 0.21.2 caps Python support at 3.12. The verify job uses Python 3.13 so maturin build fails with "the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)". The main CI workflow already sets `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` to suppress this check and build via the stable ABI — this PR applies the same env var to the docker-publish verify job.