### PR TITLE
fix: ruff hygiene sweep + mypy real-bug fixes

### DIFF
--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import discord
@@ -32,20 +32,20 @@ class AnalyticsCog(commands.Cog):
         app_commands.Choice(name="Severe Thunderstorm", value="SV"),
     ])
     async def top_stats(
-        self, 
-        interaction: discord.Interaction, 
-        by: str = "state", 
+        self,
+        interaction: discord.Interaction,
+        by: str = "state",
         year: Optional[int] = None,
         source: str = "109",
         phenomenon: str = "TO"
     ):
         await interaction.response.defer()
-        
+
         current_year = datetime.now(timezone.utc).year
         year = year or current_year
-        
+
         from urllib.parse import quote
-        
+
         # Build URL for IEM Autoplot
         if source == "109":
             # #109: WFO/State VTEC Event Counts
@@ -63,7 +63,7 @@ class AnalyticsCog(commands.Cog):
             sdate = quote(f"{year}/01/01 0000")
             edate = quote(f"{year}/12/31 2359")
             url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/163/filter:{lsr_filter}::by:{by}::sdate:{sdate}::edate:{edate}.png"
-        
+
         phenom_label = "Tornado" if phenomenon == "TO" else "Severe Thunderstorm"
         embed = discord.Embed(
             title=f"📊 Top {phenom_label} {'Warnings' if source == '109' else 'Reports'} by {by.upper()} ({year})",
@@ -72,7 +72,7 @@ class AnalyticsCog(commands.Cog):
         )
         embed.set_image(url=url)
         embed.set_footer(text=f"Data provided by IEM Autoplot #{source}")
-        
+
         await interaction.followup.send(embed=embed)
 
     @app_commands.command(name="dayssince", description="Show the streak since the last Tornado Warning (IEM Autoplot 92)")
@@ -81,17 +81,17 @@ class AnalyticsCog(commands.Cog):
         state="2-letter State code (e.g. OK, used if WFO is blank)"
     )
     async def days_since(
-        self, 
-        interaction: discord.Interaction, 
+        self,
+        interaction: discord.Interaction,
         wfo: Optional[str] = None,
         state: Optional[str] = None
     ):
         await interaction.response.defer()
-        
+
         # #92: Days since Last Watch/Warning/Advisory by WFO
         # phenomena: TO, significance: W
         url = "https://mesonet.agron.iastate.edu/plotting/auto/plot/92/phenomena:TO::significance:W.png"
-        
+
         embed = discord.Embed(
             title="⏳ Days Since Last Tornado Warning",
             color=discord.Color.green(),
@@ -99,20 +99,20 @@ class AnalyticsCog(commands.Cog):
         )
         embed.set_image(url=url)
         embed.set_footer(text="Data provided by IEM Autoplot #92")
-        
+
         await interaction.followup.send(embed=embed)
 
     @app_commands.command(name="dailyrecap", description="Visual summary of all tornado warning polygons for a day (IEM Autoplot 203)")
     @app_commands.describe(date="Date in YYYY-MM-DD format (default: yesterday)")
     async def daily_recap(self, interaction: discord.Interaction, date: Optional[str] = None):
         await interaction.response.defer()
-        
+
         if not date:
             yesterday = datetime.now(timezone.utc) - timedelta(days=1)
             date = yesterday.strftime("%Y-%m-%d")
-            
+
         url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/203/date:{date}::typ:W.png"
-        
+
         embed = discord.Embed(
             title=f"🗺️ Tornado Warning Recap: {date}",
             color=discord.Color.red(),
@@ -120,7 +120,7 @@ class AnalyticsCog(commands.Cog):
         )
         embed.set_image(url=url)
         embed.set_footer(text="Data provided by IEM Autoplot #203")
-        
+
         await interaction.followup.send(embed=embed)
 
     @app_commands.command(name="tornadoheatmap", description="Generate a density map of tornado reports (IEM Autoplot 163)")
@@ -130,19 +130,19 @@ class AnalyticsCog(commands.Cog):
     )
     async def tornado_heatmap(self, interaction: discord.Interaction, days: int = 30, state: Optional[str] = None):
         await interaction.response.defer()
-        
+
         from urllib.parse import quote
         now = datetime.now(timezone.utc)
         sdate = quote((now - timedelta(days=days)).strftime("%Y/%m/%d 0000"))
         edate = quote(now.strftime("%Y/%m/%d 2359"))
-        
+
         by_param = "state" if state else "wfo"
         state_param = f"::csector:{state.upper()}" if state else ""
-        
+
         # #163: Local Storm Reports Issued by WFO/State [map]
         # var: count, filter: TORNADO
         url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/163/var:count::filter:TORNADO::by:{by_param}::sdate:{sdate}::edate:{edate}{state_param}.png"
-        
+
         embed = discord.Embed(
             title=f"🔥 Tornado Report Heatmap (Last {days} Days)",
             color=discord.Color.orange(),
@@ -150,7 +150,7 @@ class AnalyticsCog(commands.Cog):
         )
         embed.set_image(url=url)
         embed.set_footer(text="Data provided by IEM Autoplot #163")
-        
+
         await interaction.followup.send(embed=embed)
 
     @app_commands.command(name="riskmap", description="Visualize historical SPC Day 1 outlook risk frequency (IEM Autoplot 200)")
@@ -166,33 +166,33 @@ class AnalyticsCog(commands.Cog):
         app_commands.Choice(name="High Risk", value="CATEGORICAL.HIGH"),
     ])
     async def risk_map(
-        self, 
-        interaction: discord.Interaction, 
-        threshold: str = "CATEGORICAL.SLGT", 
+        self,
+        interaction: discord.Interaction,
+        threshold: str = "CATEGORICAL.SLGT",
         state: Optional[str] = None,
         years: int = 10
     ):
         await interaction.response.defer()
-        
+
         from urllib.parse import quote
         now = datetime.now(timezone.utc)
         sdate = quote((now - timedelta(days=365 * years)).strftime("%Y-%m-%d"))
         edate = quote(now.strftime("%Y-%m-%d"))
-        
+
         # #200: SPC + WPC Outlook Heatmap
         # p: 1.C.A (Day 1 Convective All Issuances), level: (threshold), t: (state/cwa)
         t_param = "state" if state else "cwa"
         state_param = f"::csector:{state.upper()}" if state else ""
         url = f"https://mesonet.agron.iastate.edu/plotting/auto/plot/200/p:1.C.A::level:{threshold}::t:{t_param}::sdate:{sdate}::edate:{edate}{state_param}.png"
-        
+
         embed = discord.Embed(
-            title=f"📈 Historical {threshold.split('.')[-1]} Risk Frequency (Last {years} Years)",
+            title=f"📈 Historical {threshold.rsplit('.', maxsplit=1)[-1]} Risk Frequency (Last {years} Years)",
             color=discord.Color.dark_green(),
             timestamp=datetime.now(timezone.utc)
         )
         embed.set_image(url=url)
         embed.set_footer(text="Data provided by IEM Autoplot #200")
-        
+
         await interaction.followup.send(embed=embed)
 
     @app_commands.command(name="verify", description="Storm-based warning verification metrics via IEM Cow")
@@ -207,60 +207,60 @@ class AnalyticsCog(commands.Cog):
         app_commands.Choice(name="Flash Flood (FF)", value="FF"),
     ])
     async def verify(
-        self, 
-        interaction: discord.Interaction, 
-        wfo: str, 
+        self,
+        interaction: discord.Interaction,
+        wfo: str,
         days: int = 30,
         phenomena: str = "TO"
     ):
         await interaction.response.defer()
-        
+
         wfo = wfo.upper()
         if wfo.startswith("K") and len(wfo) == 4:
             wfo = wfo[1:]
-            
+
         now = datetime.now(timezone.utc)
         sts = (now - timedelta(days=days)).strftime("%Y-%m-%dT00:00Z")
         ets = now.strftime("%Y-%m-%dT23:59Z")
-        
+
         # IEM Cow API
         url = (
             f"https://mesonet.agron.iastate.edu/api/1/cow.json"
             f"?wfo={wfo}&begints={sts}&endts={ets}&phenomena={phenomena}&lsrtype={phenomena}"
         )
-        
+
         from utils.http import http_get_json
         data = await http_get_json(url)
         if not data or "stats" not in data:
             await interaction.followup.send(f"Could not fetch verification data for {wfo}.")
             return
-            
+
         stats = data["stats"]
-        
+
         embed = discord.Embed(
             title=f"🐄 IEM Cow Verification: {wfo} ({phenomena})",
             description=f"Verification metrics for the last {days} days.",
             color=discord.Color.blue(),
             timestamp=datetime.now(timezone.utc)
         )
-        
+
         # POD (Probability of Detection)
         pod = stats.get("POD[1]", 0.0)
         # FAR (False Alarm Ratio)
         far = stats.get("FAR[1]", 0.0)
         # Lead Time
         avg_lt = stats.get("avg_leadtime[min]")
-        
+
         embed.add_field(name="POD (Detection)", value=f"{pod:.2f}", inline=True)
         embed.add_field(name="FAR (False Alarm)", value=f"{far:.2f}", inline=True)
         embed.add_field(name="CSI (Success Index)", value=f"{stats.get('CSI[1]', 0.0):.2f}", inline=True)
-        
+
         if avg_lt is not None:
             embed.add_field(name="Avg Lead Time", value=f"{avg_lt:.1f} min", inline=True)
-            
+
         embed.add_field(name="Warnings", value=f"{stats.get('events_total', 0)}", inline=True)
         embed.add_field(name="Verified", value=f"{stats.get('events_verified', 0)}", inline=True)
-        
+
         embed.set_footer(text=f"IEM Cow | Interval: {sts} to {ets}")
         await interaction.followup.send(embed=embed)
 

--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -10,11 +10,11 @@ from discord.app_commands import Choice
 from discord.ext import commands, tasks
 
 from config import MANUAL_CACHE_FILE, MODELS_CHANNEL_ID
-from utils.http import ensure_session
-from utils.state_store import get_state, set_state
 from utils.cache import (
     download_single_image,
 )
+from utils.http import ensure_session
+from utils.state_store import get_state, set_state
 
 logger = logging.getLogger("spc_bot.csu_mlp")
 
@@ -52,7 +52,7 @@ async def _resolve_panel_url(product: str, allow_yesterday: bool = False) -> tup
     """
     now_utc = datetime.now(timezone.utc)
     today = now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
-    
+
     dates = [(today, "00z")]
     if allow_yesterday:
         dates.append((today - timedelta(days=1), "yesterday 00z"))
@@ -292,12 +292,12 @@ class CSUMLPCog(commands.Cog):
 
         # Use the first available missing day to determine the best init hour
         # for the current batch (either 12z or 00z).
-        # 
+        #
         # NOTE: We do NOT use allow_yesterday=True here. The auto-poll only
         # cares about fresh data for the current operational day. Manual
         # commands are more lenient to handle requests after midnight UTC.
         current_init_hour = None
-        
+
         for day in range(1, 9):
             if str(day) in self.bot.state.csu_posted:
                 continue
@@ -306,7 +306,7 @@ class CSUMLPCog(commands.Cog):
             url, label = await _resolve_best_url(day, force_hour=current_init_hour)
             if not url:
                 continue
-            
+
             # Lock in the init hour for this poll cycle based on the first success
             if current_init_hour is None and "z" in label:
                 current_init_hour = label.replace("z", "")
@@ -349,7 +349,7 @@ class CSUMLPCog(commands.Cog):
                 await _save_posted_today(self.bot.state.csu_posted)
                 self.bot.state.last_post_times[f"csu_day{day}"] = now_utc
                 logger.info(f"Auto-posted Day {day} ({label})")
-                
+
                 # Small pause to avoid hammering Discord API/local networking stack
                 await asyncio.sleep(1.0)
             except Exception as e:
@@ -395,7 +395,7 @@ class CSUMLPCog(commands.Cog):
                 await _save_posted_today(self.bot.state.csu_posted)
                 self.bot.state.last_post_times[f"csu_{state_key}"] = now_utc
                 logger.info(f"Auto-posted {label_name} ({label})")
-                
+
                 # Small pause to avoid hammering Discord API/local networking stack
                 await asyncio.sleep(1.0)
             except Exception as e:

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -239,7 +239,8 @@ class FailoverCog(commands.Cog):
         )
 
     async def _read_lease_holder(self) -> str | None:
-        return await self._upstash("GET", LEASE_KEY)
+        result = await self._upstash("GET", LEASE_KEY)
+        return str(result) if result is not None else None
 
     async def _release_lease(self) -> None:
         # Only release if it's still ours — otherwise we'd clobber a
@@ -262,7 +263,7 @@ class FailoverCog(commands.Cog):
 
             # 2. Check for manual override
             manual_primary = await self._upstash("GET", "spcbot:manual_primary")
-            
+
             if manual_primary:
                 if self._is_our_node(manual_primary):
                     # We are the designated primary
@@ -566,7 +567,7 @@ class FailoverView(discord.ui.View):
     ):
         super().__init__(timeout=60)
         self.cog = cog
-        
+
         options = []
         for node in nodes:
             label = node
@@ -574,14 +575,14 @@ class FailoverView(discord.ui.View):
                 label += " (Active Primary)"
             if node == cog._identity:
                 label += " (This Node)"
-            
+
             options.append(discord.SelectOption(
                 label=label,
                 value=node,
                 description=f"Force {node} to be Primary",
                 default=(node == current_manual)
             ))
-        
+
         options.append(discord.SelectOption(
             label="❌ Clear Manual Override",
             value="CLEAR",

--- a/cogs/iembot.py
+++ b/cogs/iembot.py
@@ -19,12 +19,9 @@ from typing import Optional
 
 from discord.ext import commands, tasks
 
-from config import IEMBOT_BOTSTALK_URL, IEMBOT_FEED_URL, IEM_NWSTEXT_URL
-from utils.state_store import (
-    get_state, set_state, 
-    get_product_cache, set_product_cache
-)
+from config import IEM_NWSTEXT_URL, IEMBOT_BOTSTALK_URL, IEMBOT_FEED_URL
 from utils.http import http_get_bytes
+from utils.state_store import get_product_cache, get_state, set_product_cache, set_state
 
 logger = logging.getLogger("spc_bot.iembot")
 
@@ -167,10 +164,11 @@ class IEMBotCog(commands.Cog):
                 product_id = msg.get("product_id", "")
                 if not product_id:
                     continue
-                
+
                 # Track IEMBot wire latency
                 try:
-                    from datetime import datetime as dt_class, timezone as tz_class
+                    from datetime import datetime as dt_class
+                    from datetime import timezone as tz_class
                     now = dt_class.now(tz_class.utc)
                     start_time = self.bot.state.bot_start_time
                     if isinstance(start_time, dt_class):
@@ -345,10 +343,11 @@ class IEMBotCog(commands.Cog):
                 product_id = msg.get("product_id", "")
                 if not product_id:
                     continue
-                
+
                 # Track IEMBot wire latency
                 try:
-                    from datetime import datetime as dt_class, timezone as tz_class
+                    from datetime import datetime as dt_class
+                    from datetime import timezone as tz_class
                     now = dt_class.now(tz_class.utc)
                     start_time = self.bot.state.bot_start_time
                     if isinstance(start_time, dt_class):

--- a/cogs/maintenance.py
+++ b/cogs/maintenance.py
@@ -1,10 +1,12 @@
 import asyncio
 import logging
 import os
-import time
 import shutil
+import time
+
 from discord.ext import commands, tasks
-from config import CACHE_DIR, RECORDING_DIR, ARCHIVE_DIR
+
+from config import ARCHIVE_DIR, CACHE_DIR, RECORDING_DIR
 
 logger = logging.getLogger("spc_bot.maintenance")
 
@@ -21,17 +23,17 @@ class MaintenanceCog(commands.Cog):
     @tasks.loop(hours=24)
     async def cleanup_cache_loop(self):
         await self.bot.wait_until_ready()
-        
+
         # Only the primary node performs cleanup to prevent race conditions on shared storage
         if getattr(self.bot.state, "is_primary", False) is False:
             return
 
         logger.info("[MAINTENANCE] Starting routine cache cleanup")
-        
+
         now = time.time()
         # 48 hours in seconds
         cutoff = now - (48 * 3600)
-        
+
         try:
             loop = asyncio.get_running_loop()
             deleted_count, total_size_freed = await loop.run_in_executor(
@@ -45,33 +47,33 @@ class MaintenanceCog(commands.Cog):
                 logger.info("[MAINTENANCE] Cleanup complete. No files needed deletion.")
 
             # Prune significant_events older than 365 days
-            from utils.events_db import prune_old_significant_events, backfill_dat_guids
+            from utils.events_db import backfill_dat_guids, prune_old_significant_events
             await prune_old_significant_events(days=365)
-            
+
             # Backfill missing DAT GUIDs via geographic matching
             await backfill_dat_guids(days=30)
-                
+
         except Exception as e:
             logger.exception(f"[MAINTENANCE] Error during cache cleanup: {e}")
 
     def _run_cleanup_worker(self, now, cutoff):
         deleted_count = 0
         total_size_freed = 0
-        
+
         if not os.path.exists(CACHE_DIR):
             return 0, 0
 
         extensions_to_prune = (".png", ".gif", ".jpg", ".jpeg", ".tmp", ".has")
-        
+
         # 1. Prune root cache files
         for filename in os.listdir(CACHE_DIR):
             if not filename.lower().endswith(extensions_to_prune):
                 continue
-                
+
             filepath = os.path.join(CACHE_DIR, filename)
             if not os.path.isfile(filepath):
                 continue
-                
+
             try:
                 file_stat = os.stat(filepath)
                 if file_stat.st_mtime < cutoff:
@@ -105,10 +107,10 @@ class MaintenanceCog(commands.Cog):
                         gif_files.append((entry.path, entry.stat()))
                     except OSError:
                         continue
-            
+
             # Sort by mtime (oldest first)
             gif_files.sort(key=lambda x: x[1].st_mtime)
-            
+
             total_archive_size = sum(f[1].st_size for f in gif_files)
             if (total_archive_size / (1024*1024)) > ARCHIVE_BUDGET_MB:
                 logger.info(f"[MAINTENANCE] Event archive ({total_archive_size/(1024*1024):.1f}MB) exceeds budget ({ARCHIVE_BUDGET_MB}MB). Pruning oldest...")

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -1,7 +1,7 @@
 # cogs/mesoscale.py
 import asyncio
-import json as _json
 import html as _html
+import json as _json
 import logging
 import os
 import re
@@ -232,10 +232,10 @@ async def fetch_md_details(
     if not html:
         fallback_url = f"https://www.spc.noaa.gov/products/md/mcd{md_number}.png"
         cached_path = get_cache_path_for_url(fallback_url)
-        
+
         # Check iembot cache for text as a last resort
         cached_text = await get_cached_md_text(md_number)
-        
+
         if os.path.exists(cached_path):
             logger.info(f"SPC unreachable for #{md_number}, serving image from cache")
             return fallback_url, None, True, cached_text
@@ -244,7 +244,7 @@ async def fetch_md_details(
             if iem_img:
                 logger.info(f"Got MD #{md_number} from IEM")
                 return iem_img, iem_summary, True, iem_raw or cached_text
-        
+
         if cached_text:
             logger.info(f"SPC/IEM unreachable for #{md_number}, but found text in iembot cache")
             return None, None, False, cached_text
@@ -303,7 +303,7 @@ def extract_md_body(raw_text: Optional[str]) -> Optional[str]:
     """
     if not raw_text:
         return None
-    
+
     # 1. Extraction from HTML if needed
     clean = None
     lowered_raw = raw_text.lower()
@@ -357,24 +357,24 @@ def clean_md_text_for_discord(text: str) -> str:
     """
     if not text:
         return ""
-    
+
     # 1. Clean existing double-asterisks to prevent formatting bugs
     text = text.replace("**", "")
-    
+
     # Standard SPC labels
     top_headers = ["Areas affected", "Concerning", "Valid", "Probability"]
     para_headers = ["SUMMARY", "DISCUSSION"]
     all_headers = top_headers + para_headers
-    
+
     # Filter out empty lines and redundant whitespace
     lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
     cleaned = []
-    
+
     i = 0
     while i < len(lines):
         ln = lines[i]
         ln_lower = ln.lower()
-        
+
         # A. Check for paragraph labels (SUMMARY, DISCUSSION)
         para_label = next((h for h in para_headers if ln_lower.startswith(h.lower())), None)
         if para_label:
@@ -390,7 +390,7 @@ def clean_md_text_for_discord(text: str) -> str:
                         break
                     body_parts.append(lines[j])
                     j += 1
-                
+
                 body_text = " ".join(p for p in body_parts if p).strip()
                 cleaned.append(f"**{lbl.strip()}** {body_text}".strip())
                 i = j
@@ -424,7 +424,7 @@ def clean_md_text_for_discord(text: str) -> str:
         # C. Regular status lines (e.g., "The severe threat continues") or signatures
         cleaned.append(ln)
         i += 1
-        
+
     return "\n".join(cleaned)
 
 
@@ -534,12 +534,12 @@ class MesoscaleCog(commands.Cog):
         """Parse probability of watch issuance and signal SoundingCog if high."""
         if not raw_text:
             return
-        
+
         # Look for "PROBABILITY OF WATCH ISSUANCE...80 PERCENT" etc.
         m = re.search(r"PROBABILITY OF WATCH ISSUANCE\s*\.\.\.\s*(\d+)\s*PERCENT", raw_text, re.IGNORECASE)
         if not m:
             return
-        
+
         try:
             prob = int(m.group(1))
             if prob >= 80:
@@ -653,14 +653,14 @@ class MesoscaleCog(commands.Cog):
             if md_numbers is None:
                 # Both SPC and IEM failed - skip this cycle to avoid false cancellations
                 return
-            
+
             current_mds = set(md_numbers)
             # -1 sentinel disables lag-protection when the index is empty
             # (nothing to compare against, so all active MDs can be cancelled).
             current_max = max((int(m) for m in current_mds), default=-1)
 
             # ── MD cancellations ─────────────────────────────────────────────
-            # Run only when NOT in fallback mode. The authoritative source for 
+            # Run only when NOT in fallback mode. The authoritative source for
             # cancellations is the primary SPC index.
             if not is_fallback:
                 diff = self.bot.state.active_mds - current_mds

--- a/cogs/ncar.py
+++ b/cogs/ncar.py
@@ -4,6 +4,7 @@ import json
 import logging
 from datetime import datetime, timedelta, timezone
 
+import aiohttp
 import discord
 from discord.ext import commands, tasks
 
@@ -14,10 +15,8 @@ from utils.cache import (
     get_cache_path_for_url,
     is_placeholder_image,
 )
-from utils.state_store import delete_state, get_state, set_hash, set_state
 from utils.http import ensure_session
-
-import aiohttp
+from utils.state_store import delete_state, get_state, set_hash, set_state
 
 logger = logging.getLogger("spc_bot")
 

--- a/cogs/nwws.py
+++ b/cogs/nwws.py
@@ -24,7 +24,7 @@ from slixmpp import ClientXMPP, Message
 from slixmpp.exceptions import IqError, IqTimeout
 from slixmpp.xmlstream import ElementBase, register_stanza_plugin
 
-from config import NWWS_USER, NWWS_PASSWORD, NWWS_SERVER, NWWS_FIREHOSE_LOG
+from config import NWWS_FIREHOSE_LOG, NWWS_PASSWORD, NWWS_SERVER, NWWS_USER
 
 logger = logging.getLogger("spc_bot")
 
@@ -69,7 +69,7 @@ firehose_logger.propagate = False
 # Only add the handler once
 if not firehose_logger.handlers:
     fh = RotatingFileHandler(
-        NWWS_FIREHOSE_LOG, 
+        NWWS_FIREHOSE_LOG,
         maxBytes=10*1024*1024, # 10MB
         backupCount=1
     )
@@ -94,7 +94,7 @@ class NWWSClient(ClientXMPP):
         # Room is 'nwws' on the conference server
         self.room = f"nwws@conference.{NWWS_SERVER}"
         self.nick = jid.split('@')[0]
-        
+
         # Register the MUC plugin and our custom payload
         self.register_plugin('xep_0045') # Multi-User Chat
         self.register_plugin('xep_0199') # XMPP Ping
@@ -103,7 +103,7 @@ class NWWSClient(ClientXMPP):
         self.add_event_handler("session_start", self.session_start)
         self.add_event_handler("message", self.message)
         self.add_event_handler("disconnected", self.on_disconnect)
-        
+
         # Start ping task on session start
         self.add_event_handler("session_start", self._start_ping_task)
         self._ping_task: Optional[asyncio.Task] = None
@@ -126,7 +126,7 @@ class NWWSClient(ClientXMPP):
                 await asyncio.sleep(30)
         except asyncio.CancelledError:
             logger.debug("NWWS ping loop cancelled")
-        
+
         # Enable auto-reconnect at the slixmpp level
         self.reconnect = True
         self.use_ipv6 = False
@@ -144,7 +144,7 @@ class NWWSClient(ClientXMPP):
             await self.get_roster()
         except (IqError, IqTimeout):
             logger.error("Error fetching roster")
-        
+
         # Join the NWWS-OI Multi-User Chat
         logger.info(f"Joining room {self.room} as {self.nick}...")
         self.plugin['xep_0045'].join_muc(self.room, self.nick)
@@ -185,7 +185,8 @@ class NWWSClient(ClientXMPP):
 
         # Check for archived message (XEP-0203 delay element).
         # Real-time messages have delay stamps very close to now; archived messages are older.
-        from datetime import datetime as dt_class, timezone as tz_class
+        from datetime import datetime as dt_class
+        from datetime import timezone as tz_class
         is_archived = False
         try:
             delay_elem = msg.get('delay')
@@ -206,7 +207,8 @@ class NWWSClient(ClientXMPP):
 
         # Track NWWS message throughput for real-time messages
         if not is_archived:
-            from datetime import datetime as dt_class, timezone as tz_class
+            from datetime import datetime as dt_class
+            from datetime import timezone as tz_class
             now = dt_class.now(tz_class.utc)
             self.bot.state.nwws_msg_count += 1
 
@@ -236,7 +238,8 @@ class NWWSClient(ClientXMPP):
             logger.debug(f"Skipping archived message ({payload['awipsid']})")
 
         # Capture receive timestamp for accurate wire latency measurement
-        from datetime import datetime as dt_class, timezone as tz_class
+        from datetime import datetime as dt_class
+        from datetime import timezone as tz_class
         received_at = dt_class.now(tz_class.utc)
 
         # Route to processing
@@ -260,7 +263,8 @@ class NWWSClient(ClientXMPP):
             if not is_archived:
                 issue_val = payload['issue'] or issue_str
                 try:
-                    from datetime import datetime as dt_class, timezone as tz_class
+                    from datetime import datetime as dt_class
+                    from datetime import timezone as tz_class
                     start_time = self.bot.state.bot_start_time
 
                     # Only track latency if we have a valid start time and 60s has passed
@@ -285,7 +289,7 @@ class NWWSClient(ClientXMPP):
                     logger.debug(f"Latency calculation failed ({issue_val}): {e}")
 
             # 2. Routing Logic
-            
+
             # WATCHES (SEL products)
             if "SEL" in afos_pil:
                 m = re.search(r"(?:Tornado|Severe Thunderstorm)\s+Watch\s+Number\s+(\d+)", raw_text, re.IGNORECASE)
@@ -298,7 +302,7 @@ class NWWSClient(ClientXMPP):
                         if text:
                             from utils.state_store import set_product_cache
                             await set_product_cache(f"watch_{watch_num}", text, ttl=600)
-                        
+
                         wtype = "TORNADO" if "Tornado Watch" in raw_text else "SVR"
                         await watches_cog.post_watch_now(watch_num, {"type": wtype, "expires": None, "affected_zones": []})
                         logger.info(f"Triggered Watch {watch_num} via XMPP")
@@ -364,7 +368,7 @@ class NWWSCog(commands.Cog):
         if not all([NWWS_USER, NWWS_PASSWORD]):
             logger.warning("Credentials missing, NWWS cog disabled")
             return
-        
+
         self._should_be_connected = True
         self.monitor_connection.start()
 
@@ -380,7 +384,7 @@ class NWWSCog(commands.Cog):
             self._should_be_connected = True
             if not self.monitor_connection.is_running():
                 self.monitor_connection.start()
-        
+
         await self.monitor_connection()
 
     @tasks.loop(seconds=30)
@@ -396,7 +400,7 @@ class NWWSCog(commands.Cog):
         if self.xmpp_client is not None:
             if self.xmpp_client.is_connected:
                 return
-            
+
             if self.xmpp_client.transport is not None:
                 # Still in flight
                 return
@@ -408,7 +412,7 @@ class NWWSCog(commands.Cog):
         logger.info(f"Connecting to {NWWS_SERVER}...")
         jid = f"{NWWS_USER}@{NWWS_SERVER}"
         self.xmpp_client = NWWSClient(jid, NWWS_PASSWORD, self.bot)
-        
+
         try:
             self.xmpp_client.connect((NWWS_SERVER, 5222))
         except Exception as e:

--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -8,12 +8,12 @@ from discord.ext import commands, tasks
 
 from config import AUTO_CACHE_FILE, SPC_CHANNEL_ID, SPC_URLS, SPC_URLS_FALLBACK
 from utils.backoff import TaskBackoff
-from utils.state_store import set_posted_urls
 from utils.cache import (
     check_partial_updates_parallel,
     save_downloaded_images,
 )
 from utils.spc_urls import get_spc_urls
+from utils.state_store import set_posted_urls
 
 logger = logging.getLogger("spc_bot.outlooks")
 
@@ -25,11 +25,11 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
     posting whatever is available.
     """
     day_key = f"day{day}"
-    
+
     # Locking: prevent concurrent checks for the same day (auto_post vs aggressive_check)
     if day_key in state.hashes._in_flight:
         return
-    
+
     state.hashes._in_flight.add(day_key)
     try:
         urls = await get_spc_urls(day)
@@ -80,7 +80,7 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
                 )
                 if day == 1:
                     return # Start waiting cycle for Day 1
-            
+
             # Now we know it's in the state
             elapsed = (
                 datetime.now(timezone.utc) - state.partial_update_state[day_key]["start_time"]

--- a/cogs/radar/__init__.py
+++ b/cogs/radar/__init__.py
@@ -10,7 +10,7 @@ import discord
 from discord.app_commands import Choice
 from discord.ext import commands, tasks
 
-from cogs.radar.downloads import cleanup_old_files, run_download, OUTPUT_DIR, CLEANUP_AGE_THRESHOLD
+from cogs.radar.downloads import CLEANUP_AGE_THRESHOLD, OUTPUT_DIR, cleanup_old_files, run_download
 from cogs.radar.s3 import _s3
 from cogs.radar.views import StartView, TimeRangeView
 

--- a/cogs/radar/downloads.py
+++ b/cogs/radar/downloads.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import discord
 
-from cogs.radar.s3 import s3_download_file, list_files
+from cogs.radar.s3 import list_files, s3_download_file
 
 logger = logging.getLogger("spc_bot")
 
@@ -207,12 +207,12 @@ async def split_and_zip_files(
             for site, site_files in by_site.items()
             if site_files
         ]
-        
+
         all_zip_paths = []
         results = await asyncio.gather(*tasks)
         for result in results:
             all_zip_paths.extend(result)
-            
+
         return all_zip_paths
     except Exception as e:
         logger.exception(f"[RADAR] ZIP creation failed: {e}")
@@ -373,7 +373,7 @@ async def download_and_zip(
         description=f"Starting download of {total_files} files...\n",
         color=discord.Color.blue(),
     )
-    message = await interaction.followup.send(embed=embed)
+    message = await interaction.followup.send(embed=embed, wait=True)
     messages_to_delete.append(message)
 
     try:

--- a/cogs/recorder.py
+++ b/cogs/recorder.py
@@ -1,17 +1,17 @@
 import asyncio
-import logging
 import json
-from datetime import datetime, timezone
-from typing import Dict, Set, Optional
+import logging
 import os
-from PIL import Image
+from datetime import datetime, timezone
+from typing import Dict, Optional, Set
 
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
+from PIL import Image
 
+from config import ARCHIVE_DIR, RECORDING_DIR
 from lib.vad_plotter.vad_reader import download_vad, find_file_times
-from config import RECORDING_DIR, ARCHIVE_DIR
 from utils.state_store import get_state, set_state
 from utils.worker_pool import get_executor
 
@@ -27,7 +27,7 @@ class VADRecordingMission:
         self.start_ts = trigger_ts - (60 * 60) # 1h lookback
         self.end_ts = trigger_ts + (90 * 60)   # 90m follow-up
         self.processed_timestamps: Set[float] = set()
-        
+
         # Create storage directory
         self.dir = os.path.join(RECORDING_DIR, f"{site_id}_{int(trigger_ts)}")
         os.makedirs(self.dir, exist_ok=True)
@@ -62,11 +62,11 @@ class RecorderCog(commands.Cog):
         self.bot = bot
         self.active_missions: Dict[str, VADRecordingMission] = {}
         self.executor = get_executor()
-        
+
         # Ensure directories exist
         os.makedirs(RECORDING_DIR, exist_ok=True)
         os.makedirs(ARCHIVE_DIR, exist_ok=True)
-        
+
         self.recorder_loop.start()
 
     def cog_unload(self):
@@ -99,7 +99,7 @@ class RecorderCog(commands.Cog):
         else:
             self.active_missions[site_id] = VADRecordingMission(site_id, trigger_ts, {event_id} if event_id else None)
             logger.info(f"Started NEW mission for {site_id} (Initial Event: {event_id})")
-        
+
         await self._persist_missions()
 
     @tasks.loop(minutes=5)
@@ -111,12 +111,12 @@ class RecorderCog(commands.Cog):
                 return
 
         now = datetime.now(timezone.utc).timestamp()
-        
+
         # 1. Fetch data for all active missions
         tasks_list = []
         for site_id, mission in self.active_missions.items():
             tasks_list.append(self._record_step(mission))
-            
+
         if tasks_list:
             await asyncio.gather(*tasks_list, return_exceptions=True)
             await self._persist_missions() # Save progress (processed_timestamps)
@@ -138,14 +138,14 @@ class RecorderCog(commands.Cog):
         """Fetch available VAD scans for the mission window."""
         try:
             available_times = await find_file_times(mission.site_id)
-            
+
             mission_start = datetime.fromtimestamp(mission.start_ts, timezone.utc)
             mission_end = datetime.fromtimestamp(mission.end_ts, timezone.utc)
-            
+
             for fn, dt in available_times:
                 dt_utc = dt.replace(tzinfo=timezone.utc) if not dt.tzinfo else dt
                 ts = dt_utc.timestamp()
-                
+
                 if mission_start <= dt_utc <= mission_end and ts not in mission.processed_timestamps:
                     try:
                         await download_vad(mission.site_id, time=dt_utc, cache_path=mission.dir)
@@ -153,7 +153,7 @@ class RecorderCog(commands.Cog):
                         logger.debug(f"Saved scan for {mission.site_id} @ {dt_utc}")
                     except Exception as e:
                         logger.warning(f"Failed to fetch {mission.site_id} @ {dt_utc}: {e}")
-                        
+
         except Exception as e:
             logger.error(f"Step failed for {mission.site_id}: {e}")
 
@@ -267,9 +267,9 @@ class RecorderCog(commands.Cog):
 
     @staticmethod
     def _render_frame_worker(input_path, output_path, rid):
-        from lib.vad_plotter.vad_reader import VADFile
-        from lib.vad_plotter.plot import plot_hodograph
         from lib.vad_plotter.params import compute_parameters
+        from lib.vad_plotter.plot import plot_hodograph
+        from lib.vad_plotter.vad_reader import VADFile
         try:
             with open(input_path, 'rb') as f:
                 vad = VADFile(f)
@@ -292,8 +292,9 @@ class RecorderCog(commands.Cog):
     @staticmethod
     def _calc_srh_worker(mission_dir, files):
         import numpy as np
-        from lib.vad_plotter.vad_reader import VADFile
+
         from lib.vad_plotter.params import compute_bunkers, compute_srh
+        from lib.vad_plotter.vad_reader import VADFile
         srh_max = 0.0
         for filename in files:
             p = os.path.join(mission_dir, filename)
@@ -304,11 +305,11 @@ class RecorderCog(commands.Cog):
                     vad = VADFile(f)
                 if len(vad['wind_dir']) < 2:
                     continue
-                
+
                 # compute_bunkers returns (right, left, mean) vectors in (dir, spd)
                 brm, _, _ = compute_bunkers(vad)
                 srh = compute_srh(vad, brm, 1.0) # 1km SRH
-                
+
                 if not np.isnan(srh):
                     srh_max = max(srh_max, srh)
             except Exception:

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -12,11 +12,11 @@ from config import WARNINGS_CHANNEL_ID
 from utils.http import http_get_bytes
 from utils.state_store import (
     add_posted_report,
-    add_posted_survey, 
+    add_posted_survey,
     add_significant_event,
-    get_posted_surveys, 
+    get_posted_surveys,
     prune_posted_reports,
-    prune_posted_surveys
+    prune_posted_surveys,
 )
 
 logger = logging.getLogger("spc_bot")
@@ -73,7 +73,7 @@ class ReportsCog(commands.Cog):
         """Handle LSR or PNS damage survey posts."""
         if product_id in self.bot.state.posted_reports:
             return
-        
+
         if pil == "LSR":
             await self._handle_lsr(product_id, raw_text)
         elif pil == "PNS":
@@ -81,13 +81,13 @@ class ReportsCog(commands.Cog):
 
     async def _handle_lsr(self, product_id: str, raw_text: str):
         # Local Storm Report parsing
-        # Usually multiple reports can be in one LSR product, but IEMbot usually 
+        # Usually multiple reports can be in one LSR product, but IEMbot usually
         # sends them individually or as a small block.
         # Format: TIME...EVENT...CITY...LAT/LON etc.
-        
+
         # Split by the standard LSR separator if multiple
         reports = re.split(r"\n\n(?=\d{4}\s+[A-Z])", raw_text)
-        
+
         channel = self.bot.get_channel(WARNINGS_CHANNEL_ID)
         if not channel:
             return
@@ -95,7 +95,7 @@ class ReportsCog(commands.Cog):
         for r in reports:
             if "LOCAL STORM REPORT" not in r and "EVENT" not in r:
                 continue
-            
+
             # Match Line 1: 0131 AM     TSTM WND DMG     DICKSON                 36.03N 87.39W
             m_l1 = re.search(r"^(\d{4}\s+[AP]M)\s+(.{16})\s+(.{24})\s+(\d+\.\d+N\s+\d+\.\d+W)", r, re.M)
             if not m_l1:
@@ -124,7 +124,7 @@ class ReportsCog(commands.Cog):
             # Specialized logic for automated stations (ASOS, AWOS, MTR)
             source_upper = source.upper()
             is_automated = any(x in source_upper for x in ("ASOS", "AWOS", "MTR"))
-            
+
             peak_wind_summary = ""
             if is_automated:
                 # Extract Peak Wind: PK WND 27045/2220 -> 45kt
@@ -139,7 +139,7 @@ class ReportsCog(commands.Cog):
 
             office = product_id.split("-")[1] if "-" in product_id else "NWS"
             lsr_url = f"https://mesonet.agron.iastate.edu/p.php?pid={product_id}"
-            
+
             # Approx timestamp for LSR
             lsr_ts = datetime.now(timezone.utc).timestamp()
             if product_id and len(product_id) >= 12:
@@ -147,16 +147,16 @@ class ReportsCog(commands.Cog):
                     lsr_ts = datetime.strptime(product_id[:12], "%Y%m%d%H%M").replace(tzinfo=timezone.utc).timestamp()
                 except Exception:
                     logger.debug("LSR timestamp parse failed for product_id %r, falling back to now()", product_id)
-            
+
             # Dedup check for Tornadoes (Discord side)
             if "TORNADO" in event_type.upper():
-                from utils.state_store import find_matching_tornado
                 from utils.db import get_posted_warning_timestamp
+                from utils.state_store import find_matching_tornado
                 match = await find_matching_tornado(office, lsr_ts, location, window_hours=1.0)
                 if match:
                     event_id, vtec_id = match
                     logger.info(f"[REPORTS] Skipping Discord post for Tornado LSR {product_id}, matches {event_id}")
-                    
+
                     # Calculate Lead Time if we have a vtec_id
                     if vtec_id:
                         warn_ts = await get_posted_warning_timestamp(vtec_id)
@@ -197,7 +197,7 @@ class ReportsCog(commands.Cog):
                 timestamp=datetime.now(timezone.utc)
             )
             embed.set_footer(text=f"{office} LSR | {coords}")
-            
+
             # --- Persist State Before Sending ---
             self.bot.state.posted_reports.add(product_id)
             await add_posted_report(product_id)
@@ -226,7 +226,7 @@ class ReportsCog(commands.Cog):
         # Public Information Statement - Damage Survey
         if "DAMAGE SURVEY" not in raw_text.upper():
             return
-        
+
         channel = self.bot.get_channel(WARNINGS_CHANNEL_ID)
         if not channel:
             return
@@ -248,17 +248,17 @@ class ReportsCog(commands.Cog):
                 ef_nums.append(-1) # Unknown
             else:
                 ef_nums.append(int(r))
-        
+
         max_ef = max(ef_nums) if ef_nums else None
         rating_str = f"EF{max_ef}" if max_ef is not None and max_ef >= 0 else ("EFU" if max_ef == -1 else "N/A")
-        
+
         # 3. Location/Event Name
         m_event = re.search(r"\.\.\.(.*?)\.\.\.", raw_text)
         event_name = m_event.group(1).strip() if m_event else "NWS Damage Survey"
 
         office = product_id.split("-")[1] if "-" in product_id else "NWS"
         pns_url = f"https://mesonet.agron.iastate.edu/p.php?pid={product_id}"
-        
+
         # 4. Count total events in this product
         total_tors = len(ef_nums)
         tor_count_msg = f" ({total_tors} tornadoes)" if total_tors > 1 else ""
@@ -298,9 +298,9 @@ class ReportsCog(commands.Cog):
             timestamp=datetime.now(timezone.utc)
         )
         embed.set_footer(text=f"{office} PNS | {product_id}")
-        
+
         await channel.send(embed=embed, view=view)
-        
+
         self.bot.state.posted_reports.add(product_id)
         await add_posted_report(product_id)
         await prune_posted_reports()
@@ -310,7 +310,7 @@ class ReportsCog(commands.Cog):
         # Patterns: MM/DD/YYYY or Month DD, YYYY
         event_date = None
         event_ts = datetime.now(timezone.utc).timestamp()
-        
+
         # Numerical: 05/21/2024
         m_num = re.search(r"(\d{1,2})/(\d{1,2})/(\d{4})", raw_text)
         if m_num:
@@ -339,11 +339,11 @@ class ReportsCog(commands.Cog):
 
         from utils.state_store import find_matching_tornado
         match = await find_matching_tornado(office, event_ts, event_name)
-        
+
         # Only log to significant events if it's a Tornado survey
         # (check event_name and rating)
         is_tornado = "TORNADO" in event_name.upper() or rating_str.startswith("EF")
-        
+
         if is_tornado:
             if match:
                 event_id, vtec_id = match
@@ -396,7 +396,7 @@ class ReportsCog(commands.Cog):
                 if arg.get("id") == "datglobalid":
                     options = arg.get("options", {})
                     break
-            
+
             if not options:
                 return
 
@@ -407,7 +407,7 @@ class ReportsCog(commands.Cog):
             for guid, label in options.items():
                 if guid in self.posted_surveys:
                     continue
-                
+
                 # Format: datglobalid:{GUID}::dat:YYYY-MM-DD::cmap:gist_rainbow::_r:t::dpi:100.png
                 img_url = (
                     f"https://mesonet.agron.iastate.edu/plotting/auto/plot/253/"
@@ -418,18 +418,18 @@ class ReportsCog(commands.Cog):
                 # --- Mapping Logic: Local Render (Primary) -> IEM Autoplot (Fallback) ---
                 file_to_send = None
                 source_text = "Local DAT Render"
-                
+
                 # Try high-detail local render first
                 from utils.dat_api import fetch_dat_track_geometry  # noqa: PLC0415
                 from utils.map_utils import render_tornado_track  # noqa: PLC0415
-                
+
                 paths = await fetch_dat_track_geometry(guid)
                 if paths:
                     out_path = os.path.join("cache", f"track_{guid}.png")
                     render_tornado_track(paths, out_path)
                     if os.path.exists(out_path):
                         file_to_send = discord.File(out_path, filename=f"track_{guid}.png")
-                
+
                 # If local render failed (no geometry yet), fall back to IEM
                 if not file_to_send:
                     source_text = "IEM Autoplot 253"
@@ -438,21 +438,21 @@ class ReportsCog(commands.Cog):
                     if status != 200:
                         logger.info(f"[REPORTS] Both local and IEM maps unavailable for {guid}")
                         # We'll post without an image for now, or just use the URL and hope it populates
-                    
+
                 embed = discord.Embed(
                     title="🌪️ Tornado Track + Lead Time",
                     description=f"**Event:** {label}\n**Date:** {event_date}",
                     color=discord.Color.red(),
                     url=f"https://mesonet.agron.iastate.edu/plotting/auto/?q=253&dat={event_date.replace('-', '/')}&datglobalid={guid}"
                 )
-                
+
                 if file_to_send:
                     embed.set_image(url=f"attachment://{file_to_send.filename}")
                 else:
                     embed.set_image(url=img_url)
-                    
+
                 embed.set_footer(text=f"{source_text} | {guid}")
-                
+
                 await channel.send(embed=embed, file=file_to_send)
                 self.posted_surveys.add(guid)
                 await add_posted_survey(guid)
@@ -460,7 +460,7 @@ class ReportsCog(commands.Cog):
                 logger.info(f"[REPORTS] Posted survey map for {guid} ({label}) via {source_text}")
 
                 # Link DAT guid to tornado and cache photos
-                from utils.events_db import link_dat_guid_to_tornado, cache_dat_photos
+                from utils.events_db import cache_dat_photos, link_dat_guid_to_tornado
                 match_result = await link_dat_guid_to_tornado(event_date, guid, label)
                 if match_result:
                     event_id, location, magnitude, coords = match_result
@@ -492,14 +492,14 @@ class ReportsCog(commands.Cog):
                 pid = props.get("product_id")
                 if not pid or pid in self.bot.state.posted_reports:
                     continue
-                
+
                 # Check significance
                 is_sig = False
                 typetext = props.get("typetext", "").upper()
-                
+
                 if typetext == "TORNADO":
                     is_sig = True
-                
+
                 if is_sig:
                     # We found a significant report not seen via iembot fast-path
                     # Log it
@@ -517,7 +517,7 @@ class ReportsCog(commands.Cog):
 
                     office = props.get("wfo")
                     location = f"{props.get('city')}, {props.get('state')}"
-                    
+
                     if typetext == "TORNADO":
                         event_type = "Tornado"
                         magnitude = "Confirmed"

--- a/cogs/scp.py
+++ b/cogs/scp.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 import discord
 from discord.ext import commands, tasks
 
-from config import MANUAL_CACHE_FILE, PACIFIC, MODELS_CHANNEL_ID, SCP_IMAGE_URLS
+from config import MANUAL_CACHE_FILE, MODELS_CHANNEL_ID, PACIFIC, SCP_IMAGE_URLS
 from utils.cache import (
     download_images_parallel,
 )

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -105,7 +105,7 @@ class SoundingCog(commands.Cog):
         dropped on load."""
         self._restore_attempted = True
         logger.debug("cog_load: restoring dedup state from state_store")
-        
+
         self.auto_sounding_watches.start()
         self.monitor_special_soundings.start()
         self.monitor_high_risk_soundings.start()
@@ -118,13 +118,13 @@ class SoundingCog(commands.Cog):
                 logger.info(f"New day {today}, clearing handled watches")
                 await clear_sounding_handled_watches()
                 await set_state("sounding_handled_date", today)
-            
+
             # Prune old sounding keys
             await prune_posted_soundings(max_days=2)
 
             self._posted_watch_soundings = await get_posted_soundings()
             self._handled_watches = await get_sounding_handled_watches()
-            
+
             logger.info(
                 f"Restored {len(self._posted_watch_soundings)} "
                 f"posted-sounding keys and {len(self._handled_watches)} "
@@ -266,7 +266,7 @@ class SoundingCog(commands.Cog):
             avail = await get_available_sounding_times_iem(sid, hours_back=18, skip_cache=True)
             if not avail:
                 return None
-            
+
             # We check ALL available soundings in the window, not just the newest,
             # in case multiple special releases happened (e.g. 18z then 20z).
             # Claim each key atomically (no await between check and add) so a
@@ -283,13 +283,13 @@ class SoundingCog(commands.Cog):
         check_results = await asyncio.gather(*[
             _check_target(sid, info) for sid, info in station_targets.items()
         ])
-        
+
         # Flatten and filter
         all_to_post = []
         for res in check_results:
             if res:
                 all_to_post.extend(res)
-        
+
         if not all_to_post:
             return
 
@@ -332,11 +332,11 @@ class SoundingCog(commands.Cog):
                 png_path = opath + ".png"
                 if not success or not os.path.exists(png_path):
                     continue
-                
+
                 applicable = await self._watches_near(station["lat"], station["lon"])
                 # We know there's at least one applicable watch because that's how we found the station
                 watches_frag = self._format_watches_caption(applicable, "0000", "Watch")
-                
+
                 caption = (
                     f"**Special Sounding — {station['name']} ({sid})**\n"
                     f"Valid: {mo}-{d}-{y} {h}z | {watches_frag}"
@@ -344,7 +344,7 @@ class SoundingCog(commands.Cog):
                 qwarn = sounding_quality_warning(data)
                 if qwarn:
                     caption += f"\n{qwarn}"
-                    
+
                 try:
                     await channel.send(caption, files=[discord.File(png_path)])
                     logger.info(f"Posted special release {sid} {h}z")
@@ -352,7 +352,7 @@ class SoundingCog(commands.Cog):
                 except Exception as e:
                     logger.exception(f"Failed to post {sid}: {e}")
 
-    
+
 
     @tasks.loop(minutes=15)
     async def monitor_high_risk_soundings(self):
@@ -660,7 +660,7 @@ class SoundingCog(commands.Cog):
 
         # Use SOUNDING_CHANNEL_ID if configured, fallback to passed channel
         target_channel = self.bot.get_channel(SOUNDING_CHANNEL_ID) or channel
-        
+
         affected_zones = nws_info.get("affected_zones", []) if isinstance(nws_info, dict) else []
         if not affected_zones:
             logger.warning(f"No affected zones for watch #{watch_num} — skipping")
@@ -987,7 +987,7 @@ class SoundingCog(commands.Cog):
                 except Exception as e:
                     logger.exception(f"Failed to post ACARS: {e}")
 
-    
+
 
     @discord.app_commands.command(
         name="sounding",
@@ -1098,7 +1098,7 @@ class SoundingCog(commands.Cog):
             await post_sounding(
                 interaction, nearest[0],
                 year, month, day, hour,
-                dark_mode, followup=True,
+                dark_mode,
             )
             return
 

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -32,9 +32,14 @@ try:
 finally:
     sys.stdout = _stdout
 
+from utils.geo import find_nearest_indices, haversine  # noqa: E402
+from utils.http import (  # noqa: E402
+    CircuitOpenError,
+    circuit_breaker,
+    ensure_session,
+    http_get_json,
+)
 from utils.state_store import get_state, set_state  # noqa: E402  # follows sounderpy import
-from utils.geo import haversine, find_nearest_indices  # noqa: E402
-from utils.http import http_get_json, circuit_breaker, ensure_session, CircuitOpenError  # noqa: E402
 
 logger = logging.getLogger("spc_bot")
 
@@ -112,7 +117,7 @@ def find_nearest_stations(lat: float, lon: float, df: pd.DataFrame, n: int = 3) 
     """Return the n nearest RAOB stations as a list of dicts."""
     targets = list(zip(df["lat"], df["lon"]))
     nearest_data = find_nearest_indices(lat, lon, targets, n)
-    
+
     results = []
     for idx, dist_km in nearest_data:
         row = df.iloc[idx]
@@ -313,7 +318,7 @@ async def get_md_area_centroid(raw_text: str) -> tuple[float, float] | None:
             continue
         try:
             # Format: DDMMDDMM (LatDDMM LonDDMM)
-            # SPC lons are often 3 digits if > 100, but in this block 
+            # SPC lons are often 3 digits if > 100, but in this block
             # they are usually 4 digits (e.g. 9845 means -98.45)
             lat_raw = int(part[:4])
             lon_raw = int(part[4:])
@@ -378,7 +383,7 @@ def _iem_level_is_valid(lv: dict) -> bool:
 
 
 def _iem_to_clean_data(profile: dict, station_id: str, station_name: str,
-                        lat: float, lon: float, elev: float, valid: str) -> dict:
+                        lat: float, lon: float, elev: float, valid: str) -> dict | None:
     """
     Convert IEM RAOB profile dict to SounderPy clean_data format.
     IEM fields: pres, hght, tmpc, dwpc, drct, sknt
@@ -433,7 +438,7 @@ def _iem_to_clean_data(profile: dict, station_id: str, station_name: str,
             # Handle possible alternate formats from IEM
             dt = datetime.strptime(valid, "%Y-%m-%dT%H:%M:%S")
             dt = dt.replace(tzinfo=timezone.utc)
-            
+
         run_time = [str(dt.year), str(dt.month).zfill(2),
                     str(dt.day).zfill(2), f"{dt.hour:02d}:{dt.minute:02d}"]
     except Exception as e:
@@ -679,6 +684,7 @@ async def get_acars_profiles_in_polygon(
         return []
 
     import sounderpy as spy  # noqa: PLC0415
+
     from utils.spc_outlook import is_inside_polygon
 
     now = datetime.now(timezone.utc)
@@ -750,7 +756,7 @@ def _fsl_to_clean_data(text: str, station_id: str, station_name: str,
     """Parse GSL 'FSL' format ASCII text into SounderPy clean_data."""
     lines = text.splitlines()
     levels = []
-    
+
     # FSL format data lines (Type 4, 5, 6) have 7 fields:
     # Type, Pressure (1/10 mb), Height (m), Temp (1/10 C), Dewpt (1/10 C), Wind Dir (deg), Wind Spd (kt)
     for line in lines:
@@ -761,17 +767,17 @@ def _fsl_to_clean_data(text: str, station_id: str, station_name: str,
             ltype = int(parts[0])
             if ltype not in (4, 5, 6):
                 continue
-                
+
             p_raw = int(parts[1])
             z_raw = int(parts[2])
             t_raw = int(parts[3])
             td_raw = int(parts[4])
             wdir_raw = int(parts[5])
             wspd_raw = int(parts[6])
-            
+
             if p_raw == 99999 or z_raw == 99999:
                 continue
-                
+
             levels.append({
                 "pres": p_raw / 10.0,
                 "hght": float(z_raw),
@@ -850,7 +856,7 @@ async def fetch_gsl_sounding(station_id: str, year: str, month: str,
         "09": "SEP", "10": "OCT", "11": "NOV", "12": "DEC"
     }
     month_name = month_map.get(month, "JAN")
-    
+
     url = (
         "https://rucsoundings.noaa.gov/get_raobs.cgi?"
         f"data_source=RAOB&latest=latest&start_year={year}&"
@@ -858,13 +864,13 @@ async def fetch_gsl_sounding(station_id: str, year: str, month: str,
         f"start_hour={hour}&start_min=0&n_hrs=1.0&fcst_len=0&"
         f"select_mdstns={station_id}&fsl_data_last=yes"
     )
-    
+
     try:
         from utils.http import http_get_text
         text = await http_get_text(url, retries=1, timeout=15)
         if not text or "No data available" in text:
             return None
-            
+
         clean = _fsl_to_clean_data(
             text, station_id, station_name or station_id,
             lat, lon, elev, [year, month, day, f"{hour}:00"]
@@ -916,12 +922,12 @@ async def get_available_sounding_times(
     avail = await get_available_sounding_times_iem(station_id, hours_back, skip_cache=skip_cache)
     if avail:
         return avail
-        
+
     # 2. Try Wyoming Probe for standard hours (00z/12z)
     # This is needed for international stations like SBSM that aren't in IEM.
     # We check standard hours in the requested window.
     probe_times = get_recent_sounding_times(n=max(2, (hours_back // 12) + 1))
-    
+
     # Filter probe times to only those within hours_back
     now = datetime.now(timezone.utc)
     valid_probe_times = []
@@ -929,16 +935,16 @@ async def get_available_sounding_times(
         dt = datetime(int(y), int(mo), int(d), int(h), tzinfo=timezone.utc)
         if (now - dt).total_seconds() / 3600 <= hours_back:
             valid_probe_times.append((y, mo, d, h))
-            
+
     if not valid_probe_times:
         return []
-        
+
     # Parallel probe Wyoming/GSL
     results = await asyncio.gather(*[
         fetch_sounding(station_id, y, mo, d, h)
         for y, mo, d, h in valid_probe_times
     ])
-    
+
     return [valid_probe_times[i] for i, res in enumerate(results) if res is not None]
 
 
@@ -959,25 +965,25 @@ def validate_sounding_data(data: Optional[dict], min_levels: int = 5) -> bool:
     """Check if sounding data dict is valid and has enough levels for plotting."""
     if not data or not isinstance(data, dict):
         return False
-    
+
     # Check for required SounderPy keys
     for key in ("p", "z", "T", "Td", "u", "v"):
         if key not in data or data[key] is None:
             return False
-            
+
     # Check level count and array consistency
     try:
         p_len = len(data["p"])
         if p_len < min_levels:
             return False
-            
+
         for key in ("z", "T", "Td", "u", "v"):
             if len(data[key]) != p_len:
                 return False
     except (TypeError, KeyError) as e:
         logger.debug(f"[SOUNDING] Structural validation failed: {e}")
         return False
-        
+
     # Check for sufficient valid data (prevent crashes in SounderPy/ecape-parcel)
     try:
         # Check if we have at least SOME non-zero wind data (prevent jagged hodographs)

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -59,22 +59,22 @@ async def post_sounding(
 
     for y, mo, d, h in all_times:
         time_label = f"{mo}-{d}-{y} {h}z"
-        
+
         # ── Fast Cache Check ──────────────────────────────────────────
         # Check if the plot already exists on disk before doing any network/CPU work
         output_path = _plot_path(station_id, y, mo, d, h, dark_mode)
         png_path = output_path + ".png"
-        
+
         if os.path.exists(png_path):
             logger.info(f"[SOUNDING] Cache hit (image) for {station_id} {y}/{mo}/{d} {h}z")
             used_year, used_month, used_day, used_hour = y, mo, d, h
             if (y, mo, d, h) != (year, month, day, hour):
                 orig_label = f"{month}-{day}-{year} {hour}z"
                 fallback_note = f" (no data for {orig_label}, showing {time_label})"
-            
+
             # Post immediately!
             await _send_sounding_embed(
-                interaction, station_id, label, f"{mo}-{d}-{y} {h}z", 
+                interaction, station_id, label, f"{mo}-{d}-{y} {h}z",
                 dark_mode, png_path, fallback_note, status_msg
             )
             return
@@ -114,10 +114,10 @@ async def post_sounding(
 
     # Generate plot (only if we didn't hit the image cache above)
     time_label = f"{used_month}-{used_day}-{used_year} {used_hour}z"
-    
+
     from utils.worker_pool import get_sounding_semaphore
     sem = get_sounding_semaphore()
-    
+
     if sem.locked():
         # Pool is full, show queued status
         pos = len(sem._waiters) + 1 if hasattr(sem, '_waiters') else 1
@@ -166,7 +166,7 @@ async def post_sounding(
         return
 
     await _send_sounding_embed(
-        interaction, station_id, label, time_label, 
+        interaction, station_id, label, time_label,
         dark_mode, png_path, fallback_note, status_msg, clean_data
     )
 
@@ -199,7 +199,7 @@ async def _send_sounding_embed(
     caption = "**RAOB Sounding \u2014 {}**\nValid: {} | {} mode{}{}".format(
         label, time_label, mode_label, source_str, fallback_note
     )
-    
+
     if clean_data:
         qwarn = sounding_quality_warning(clean_data)
         if qwarn:
@@ -211,7 +211,7 @@ async def _send_sounding_embed(
                 await status_msg.delete()
             except discord.HTTPException:
                 pass
-        
+
         await interaction.channel.send(caption, files=[discord.File(png_path)])
         logger.info(f"[SOUNDING] Posted {station_id} {time_label}")
     except Exception as e:
@@ -475,7 +475,7 @@ class CombinedSoundingView(View):
 
                     from utils.worker_pool import get_sounding_semaphore
                     sem = get_sounding_semaphore()
-                    
+
                     if sem.locked():
                         pos = len(sem._waiters) + 1 if hasattr(sem, '_waiters') else 1
                         queue_embed = discord.Embed(
@@ -619,7 +619,7 @@ async def _post_from_clean_data(
     label = f"{station_name} ({station_id})"
     from utils.worker_pool import get_sounding_semaphore
     sem = get_sounding_semaphore()
-    
+
     if sem.locked():
         pos = len(sem._waiters) + 1 if hasattr(sem, '_waiters') else 1
         logger.info(f"[SOUNDING] Queueing plot for {label} (Position: {pos})")

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -10,6 +10,7 @@ import aiohttp
 import discord
 from discord.ext import commands, tasks
 
+import utils.http as _http
 from cogs.mesoscale import (
     clean_md_text_for_discord,
     extract_md_body,
@@ -17,16 +18,15 @@ from cogs.mesoscale import (
     fetch_md_details,
 )
 from config import MANUAL_CACHE_FILE, SCP_IMAGE_URLS, SPC_URLS, WPC_IMAGE_URLS, __version__
-import utils.http as _http
-from utils.db import get_write_failure_count
 from utils.cache import (
     check_all_urls_exist_parallel,
     download_images_parallel,
     download_single_image,
     format_timedelta,
 )
+from utils.db import get_write_failure_count
 from utils.discord_gateway import update_gateway_info
-from utils.spc_outlook import get_high_risk_polygon, peek_active_labels, get_current_risk_display
+from utils.spc_outlook import get_current_risk_display, get_high_risk_polygon, peek_active_labels
 from utils.spc_urls import get_spc_urls
 
 logger = logging.getLogger("spc_bot")
@@ -114,7 +114,7 @@ class MDPaginatorView(discord.ui.View):
         self.prev_btn.disabled = self.index == 0
         self.next_btn.disabled = self.index >= len(self.md_data) - 1
 
-    def build_response(self):
+    def build_response(self) -> tuple:
         """Returns (content, embeds, files) for the current MD."""
         data = self.md_data[self.index]
         md_num = data["num"]
@@ -129,7 +129,7 @@ class MDPaginatorView(discord.ui.View):
             url=md_page_url,
             color=discord.Color.dark_orange(),
         )
-        
+
         files = []
         if cache_path:
             files.append(discord.File(cache_path, filename=f"md_{md_num}.png"))
@@ -141,12 +141,12 @@ class MDPaginatorView(discord.ui.View):
             description=cleaned_text[:4090], # Stay under Discord embed limit
             color=discord.Color.dark_orange(),
         )
-        
+
         footer_text = f"MD {self.index + 1} of {len(self.md_data)}"
         if from_cache:
             footer_text = f"⚠️ SPC website unreachable — image served from cache | {footer_text}"
         text_embed.set_footer(text=footer_text)
-        
+
         return None, [img_embed, text_embed], files
 
     @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
@@ -187,7 +187,7 @@ async def is_owner(interaction: discord.Interaction) -> bool:
         return True
     if not interaction.client.application:
         await interaction.client.application_info()
-    
+
     owner = interaction.client.application.owner
     if isinstance(owner, discord.Team):
         return any(m.id == interaction.user.id for m in owner.members)
@@ -203,7 +203,7 @@ class StatusView(discord.ui.View):
         self.detailed = False
         self.should_update = True
 
-    async def build_embeds(self):
+    async def build_embeds(self) -> list:
         now = datetime.now(timezone.utc)
         hostname = socket.gethostname()
         host_ip = "unknown"
@@ -342,7 +342,7 @@ class StatusView(discord.ui.View):
 
         update_msg = " | Live Auto-refresh" if self.should_update else ""
         embed.set_footer(text=f"WXModelBot v{__version__}{update_msg}")
-        
+
         embeds = [embed]
 
         if self.detailed:
@@ -371,7 +371,7 @@ class StatusView(discord.ui.View):
                         status = "🟢" if task.is_running() else "🔴"
                         label = task_labels.get(task_name, task_name)
                         task_lines.append(f"{status} `{label}`")
-            
+
             if task_lines:
                 task_embed.description = "\n".join(task_lines)
             embeds.append(task_embed)
@@ -425,7 +425,7 @@ class TaskMgrView(discord.ui.View):
         self.message = None
         self.should_update = True
 
-    async def build_embed(self):
+    async def build_embed(self) -> discord.Embed:
         now = datetime.now(timezone.utc)
         color = discord.Color.blue()
         embed = discord.Embed(
@@ -464,7 +464,7 @@ class TaskMgrView(discord.ui.View):
                     if task.is_running() and task.next_iteration:
                         diff = task.next_iteration - now
                         next_iter = f" (next in {format_timedelta(diff)})"
-                    
+
                     task_lines.append(f"{status} `{label:<28}`{next_iter}")
 
         if task_lines:
@@ -518,14 +518,14 @@ class LogView(discord.ui.View):
         self.message = None
         self.should_update = True
 
-    def build_content(self):
+    def build_content(self) -> str:
         logs = []
         if hasattr(self.bot, "log_handler"):
             logs = self.bot.log_handler.get_logs()
-        
+
         if not logs:
             logs = ["No logs captured yet..."]
-        
+
         content = "🛰️ **SPCBot Live Console Output**\n"
         content += "```ansi\n"
         # Discord supports ANSI color codes in ```ansi blocks
@@ -798,11 +798,11 @@ class StatusCog(commands.Cog):
                 # Add a per-MD timeout to ensure one bad MD doesn't kill the whole command
                 res = await asyncio.wait_for(fetch_md_details(md_num), timeout=15.0)
                 image_url, summary, from_cache, raw_text = res
-                
+
                 # Extract the actual body text from the HTML
                 body_text = extract_md_body(raw_text)
                 logger.info(f"[/md] Fetched details for #{md_num} (body size: {len(body_text) if body_text else 0})")
-                
+
                 cache_path = None
                 if image_url:
                     logger.info(f"[/md] Downloading image for #{md_num}...")
@@ -839,7 +839,7 @@ class StatusCog(commands.Cog):
             logger.error(f"[/md] Hydration failed: {e}")
             await interaction.followup.send("Failed to load MD details.")
             return
-        
+
         if not md_data:
             await interaction.followup.send("No MD data could be retrieved.")
             return
@@ -848,10 +848,10 @@ class StatusCog(commands.Cog):
         if len(md_data) == 1:
             view.prev_btn.disabled = True
             view.next_btn.disabled = True
-        
+
         content, embeds, files = view.build_response()
         msg = await interaction.followup.send(
-            content=content, embeds=embeds, files=files, view=view
+            content=content, embeds=embeds, files=files, view=view, wait=True
         )
         view.message = msg
         logger.info("[/md] Successfully sent paginated response")
@@ -878,7 +878,7 @@ class StatusCog(commands.Cog):
 
         view = StatusView(self.bot, interaction)
         embeds = await view.build_embeds()
-        msg = await interaction.followup.send(embeds=embeds, view=view, ephemeral=True)
+        msg = await interaction.followup.send(embeds=embeds, view=view, ephemeral=True, wait=True)
         view.message = msg
         asyncio.create_task(view.start_auto_update())
 
@@ -891,7 +891,7 @@ class StatusCog(commands.Cog):
         await interaction.response.defer(ephemeral=True)
         view = TaskMgrView(self.bot, interaction)
         embed = await view.build_embed( )
-        msg = await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        msg = await interaction.followup.send(embed=embed, view=view, ephemeral=True, wait=True)
         view.message = msg
         asyncio.create_task(view.start_auto_update())
 
@@ -904,7 +904,7 @@ class StatusCog(commands.Cog):
         await interaction.response.defer(ephemeral=True)
         view = LogView(self.bot, interaction)
         content = view.build_content()
-        msg = await interaction.followup.send(content=content, view=view, ephemeral=True)
+        msg = await interaction.followup.send(content=content, view=view, ephemeral=True, wait=True)
         view.message = msg
         asyncio.create_task(view.start_auto_update())
 

--- a/cogs/warning_channels.py
+++ b/cogs/warning_channels.py
@@ -8,7 +8,13 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from config import WARNINGS_CHANNEL_ID, TOR_CHANNEL_ID, SVR_CHANNEL_ID, FFW_CHANNEL_ID, SPS_CHANNEL_ID
+from config import (
+    FFW_CHANNEL_ID,
+    SPS_CHANNEL_ID,
+    SVR_CHANNEL_ID,
+    TOR_CHANNEL_ID,
+    WARNINGS_CHANNEL_ID,
+)
 from utils.state_store import get_state, set_state
 
 logger = logging.getLogger("spc_bot.warning_channels")

--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -162,7 +162,7 @@ def iem_autoplot_url(vtec: dict, valid_time: Optional[str] = None) -> str:
 
     year = datetime.now(timezone.utc).year
     start = vtec.get("start") or ""
-    
+
     # Use provided valid_time if available (for cancellations/watermarks)
     # format should be 'YYYY-MM-DD HHMM' (UTC)
     if valid_time:
@@ -224,11 +224,11 @@ def _vtec_url(vtec: dict) -> str:
     """Build an IEM VTEC event page URL from a parsed vtec dict."""
     start = vtec.get("start", "")
     end = vtec.get("end", "")
-    
+
     # Use end time when start is missing or is the null-start sentinel (CON/EXT/CAN/EXP products)
     ref = start if (start and len(start) >= 11 and not _is_null_vtec_time(start)) \
               else (end if (end and len(end) >= 11 and not _is_null_vtec_time(end)) else "")
-              
+
     if ref:
         try:
             year = 2000 + int(ref[:2])
@@ -241,7 +241,7 @@ def _vtec_url(vtec: dict) -> str:
         now = datetime.now(timezone.utc)
         year = now.year
         iso = now.strftime("%Y-%m-%dT%H:%MZ")
-        
+
     action = vtec.get("action", "NEW")
     office = vtec.get("office", "")
     phenom = vtec["phenom"]
@@ -289,7 +289,7 @@ def _area_with_state(area_desc: str, ugc_codes: List[str], state_fallback: Optio
     # Parse county names from areaDesc - try to preserve "County, ST" pairs
     # Split by semicolon or newline first
     counties = [c.strip() for c in re.split(r'[;\n]\s*', area_desc) if c.strip()]
-    
+
     # If we only have one item and it has commas, it's likely a comma-separated list.
     # Split by comma but ONLY if not followed by a state abbreviation.
     if len(counties) == 1 and "," in counties[0]:
@@ -334,7 +334,7 @@ def _area_with_state(area_desc: str, ugc_codes: List[str], state_fallback: Optio
             r_clean = _STATE_REGEX.sub("", r.strip()).strip()
             if r_clean and (len(r_clean) > 2 or not r_clean.isupper()):
                 cleaned_remainder.append(r_clean)
-        
+
         if cleaned_remainder:
             if parts:
                 parts[-1] = parts[-1] + f", {', '.join(cleaned_remainder)}"
@@ -433,7 +433,7 @@ def build_concise_warning_text(
 
         if params.get("thunderstormDamageThreat"):
             tags.append(f"damage threat: {params['thunderstormDamageThreat'][0]}")
-            
+
         # Add "Tornado: POSSIBLE" if present in parameters
         if params.get("tornadoPossible"):
             tags.append("tornado: POSSIBLE")
@@ -454,7 +454,7 @@ def build_concise_warning_text(
             # Only add if it's high signal and NOT the name of the warning itself
             if val not in ("NONE", "FALSE"):
                 tags.append(f"tornado: {val}")
-                
+
         # Refined to catch specific magnitudes like "2.50 IN" or "GOLF BALL"
         # and ignore "HAIL THREAT...RADAR INDICATED"
         m_hail = re.search(r"(?:MAX )?HAIL(?: SIZE)?\.\.\.(?!RADAR|THREAT|NONE)(.+?)(?:\n|$)", text_to_search, re.I)
@@ -463,7 +463,7 @@ def build_concise_warning_text(
             # Skip zero-size hail — NWS emits "0.00 IN" as a default/null value
             if not re.match(r"^0+\.?0*\s+IN$", hail_val):
                 tags.append(f"hail: {hail_val}")
-            
+
         # Refined for wind
         m_wind = re.search(r"(?:MAX )?WIND(?: GUST)?\.\.\.(?!RADAR|THREAT|NONE)(.+?)(?:\n|$)", text_to_search, re.I)
         if m_wind:
@@ -480,7 +480,7 @@ def build_concise_warning_text(
         # Step A: Look for the standard "Warning for..." bullet
         # Refined regex: must NOT cross into common narrative headers or the next bullet
         m_area = re.search(r"(?:Warning for|Statement for|IMPACT)[\s.]+(.+?)(?=\n\s*\*|\n\s*At\s+|\n\s*LAT\.\.\.LON|\n\s*HAZARD\.\.\.|\n\s*SOURCE\.\.\.|\n\s*IMPACT\.\.\.|\n\s*PRECAUTIONARY|\n\s*PREPAREDNESS|$)", raw_text, re.I | re.DOTALL)
-        
+
         # Step B: Fallback to the technical header line (e.g., "CLEVELAND OK-MCCLAIN OK-")
         if not m_area:
             # Broadened to handle mixed case like "Inland Nassau FL-"
@@ -500,21 +500,21 @@ def build_concise_warning_text(
         if raw_list:
             # For raw text, we split by dots and 'AND' as well
             parts = re.split(r"\n|;|\.\.\.|\s+AND\s+", raw_list, flags=re.I)
-            
+
             # If we didn't get multiple parts, try a smart comma split
             if len(parts) <= 1:
                 parts = [c.strip() for c in re.split(r',(?!\s+[A-Z]{2}(?:\s|$|,|;))', raw_list) if c.strip()]
-                
+
             counties = []
             for p in parts:
                 c = p.strip().strip(".")
                 if not c or len(c) < 2: # Allow 2-letter state codes to be caught by filter
                     continue
-                    
+
                 # Truncate at "THROUGH" instead of skipping the whole part
                 if " THROUGH " in c.upper():
                     c = re.split(r"\s+THROUGH\s+", c, flags=re.I)[0]
-                    
+
                 # Skip if it contains garbage keywords as whole words
                 if _GEOGRAPHIC_GARBAGE_RE.search(c):
                     continue
@@ -534,7 +534,7 @@ def build_concise_warning_text(
                     if not _GEOGRAPHIC_GARBAGE_RE.search(c):
                         if c not in counties:
                             counties.append(c)
-            
+
             if counties:
                 area = ", ".join(counties)
 
@@ -542,9 +542,9 @@ def build_concise_warning_text(
         # Normalize prev_area: strip bracketed state info "[OK]" and " and " before diffing
         clean_prev = re.sub(r"\s*\[[A-Z]{2}\]", "", prev_area)
         clean_prev = clean_prev.replace(" and ", ", ")
-        
+
         prev_parts = [c.strip() for c in re.split(r'[;,]\s*', clean_prev) if c.strip()]
-        
+
         # Clean current area list: split and run through state stripper/garbage filter
         # This prevents "OK, OK" in the expands to list
         raw_curr = [c.strip() for c in re.split(r'[;,]\s*', area) if c.strip()]
@@ -581,7 +581,7 @@ def build_concise_warning_text(
                     parts.append(f"**continues** {', '.join(continuing)}")
                 if new_added:
                     parts.append(f"**expands to** {', '.join(new_added)}")
-                
+
                 area_formatted = f" ({', '.join(parts)})"
             else:
                 area_formatted = f" for {_area_with_state(area, ugc_codes or [], state_fallback=state_fallback)}"

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -19,39 +19,46 @@ import json as _json
 import logging
 import re
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
-from typing import Optional, Tuple
+from typing import Optional, Tuple, cast
 
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 
-from config import NWS_ALERTS_WARNINGS_URL, WARNINGS_CHANNEL_ID, TOR_CHANNEL_ID, SVR_CHANNEL_ID, FFW_CHANNEL_ID, SPS_CHANNEL_ID
+from cogs.warning_format import (
+    _area_with_state,
+    _download_warning_image,
+    _vtec_unix_ts,
+    _vtec_url,
+    build_concise_warning_text,
+    get_tornado_attributes,
+    get_warning_style,
+    iem_autoplot_url,
+)
+from cogs.warning_ui import (
+    EnvironmentalView,
+    TornadoDashboardView,
+)
+from config import (
+    FFW_CHANNEL_ID,
+    NWS_ALERTS_WARNINGS_URL,
+    SPS_CHANNEL_ID,
+    SVR_CHANNEL_ID,
+    TOR_CHANNEL_ID,
+    WARNINGS_CHANNEL_ID,
+)
 from lib.vad_plotter.radar_coords import get_nearest_radar
-from lib.vtec_parser import parse_vtec, parse_warning_polygon, get_polygon_centroid
+from lib.vtec_parser import get_polygon_centroid, parse_vtec, parse_warning_polygon
 from utils.backoff import TaskBackoff
 from utils.http import http_get_bytes, http_get_bytes_conditional
 from utils.state_store import (
     add_posted_warning,
     add_significant_event,
     get_recent_significant_events,
-    prune_posted_warnings,
     get_state,
-)
-from cogs.warning_format import (
-    get_warning_style,
-    get_tornado_attributes,
-    iem_autoplot_url,
-    build_concise_warning_text,
-    _vtec_url,
-    _vtec_unix_ts,
-    _area_with_state,
-    _download_warning_image,
-)
-from cogs.warning_ui import (
-    EnvironmentalView,
-    TornadoDashboardView,
+    prune_posted_warnings,
 )
 
 logger = logging.getLogger("spc_bot.warnings")
@@ -161,7 +168,7 @@ class WarningsCog(commands.Cog):
                     if missing:
                         await self._notify_channel_error(ch, missing)
                         return None
-                    return ch
+                    return cast(discord.abc.Messageable, ch)
         static_id = self._STATIC_CHANNEL_FOR_PHENOM.get(phenom, WARNINGS_CHANNEL_ID)
         logger.debug(f"[CH_RESOLVE] using static channel {static_id} for {phenom} (default fallback: {static_id == WARNINGS_CHANNEL_ID})")
         channel = self.bot.get_channel(static_id)
@@ -170,7 +177,7 @@ class WarningsCog(commands.Cog):
             if missing:
                 await self._notify_channel_error(channel, missing)
                 return None
-        return channel
+        return cast(discord.abc.Messageable, channel) if channel else None
 
     # ── iembot fast-trigger path ───────────────────────────────────────────
     #
@@ -542,7 +549,7 @@ class WarningsCog(commands.Cog):
         # Area was stored in posted_warnings when the warning was first posted.
         area = info.get("area", "")
 
-        office = (vtec or {}).get("office", vtec_id.split(".")[0])
+        office = (vtec or {}).get("office", vtec_id.split(".", maxsplit=1)[0])
         if office.startswith("K") and len(office) == 4:
             office = office[1:]
 
@@ -579,11 +586,11 @@ class WarningsCog(commands.Cog):
             # If it's an expiration, use +1 minute to definitely hit the "inactive" state
             if reason == "Expired":
                 now = now + timedelta(minutes=1)
-                
+
             valid_time = now.strftime("%Y-%m-%d %H%M")
             image_url = iem_autoplot_url(vtec, valid_time=valid_time)
             filename = f"cancel_{vtec_id.replace('.', '_')}.png"
-            
+
             # Use a retry loop for cancellations too, as IEM indexing can be slow
             logger.debug(f"[CANCEL_IMG] Requesting watermarked image: {image_url}")
             for attempt in range(5):
@@ -592,7 +599,7 @@ class WarningsCog(commands.Cog):
                     if content and status == 200:
                         files.append(discord.File(BytesIO(content), filename=filename))
                         break
-                    
+
                     if attempt < 4:
                         await asyncio.sleep(2)
                         continue

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 
 import discord
 from discord.ext import commands, tasks
-from utils.backoff import TaskBackoff
 
 from cogs.watch_fetch import (
     fetch_active_watches_nws,
@@ -20,6 +19,7 @@ from config import (
     SPC_CHANNEL_ID,
     SPC_VALID_WATCHES_URL,
 )
+from utils.backoff import TaskBackoff
 from utils.cache import (
     download_single_image,
 )
@@ -184,7 +184,7 @@ async def _execute_watches(interaction: discord.Interaction, bot: commands.Bot):
     embed = view.build_embed()
     files = view.build_files()
     msg = await interaction.followup.send(
-        embed=embed, files=files, view=view
+        embed=embed, files=files, view=view, wait=True
     )
     view.message = msg
 
@@ -222,7 +222,7 @@ class WatchesCog(commands.Cog):
             try:
                 image_url, text_summary, probs = await fetch_watch_details(watch_num)
                 has_real_probs = probs and "preliminary" not in probs
-                
+
                 cache_path = None
                 if image_url:
                     cache_path, _, _ = await download_single_image(
@@ -234,7 +234,7 @@ class WatchesCog(commands.Cog):
                     image_missing = await asyncio.to_thread(
                         lambda p=cache_path: is_placeholder_image(open(p, "rb").read())
                     )
-                
+
                 # If we have BOTH, we are fully upgraded.
                 if not image_missing and has_real_probs:
                     embed = _build_watch_embed(
@@ -253,7 +253,7 @@ class WatchesCog(commands.Cog):
                     logger.info(f"Full upgrade complete for #{watch_num}")
                     return
 
-                # If we only have Probs, or we're on the last attempt, do a 
+                # If we only have Probs, or we're on the last attempt, do a
                 # partial edit and transition to Stage 2 if needed.
                 if has_real_probs or attempt == 19:
                     embed = _build_watch_embed(
@@ -269,14 +269,14 @@ class WatchesCog(commands.Cog):
                     )
                     files = _watch_files(watch_num, cache_path) if not image_missing else []
                     await message.edit(embed=embed, attachments=files)
-                    
+
                     if not image_missing:
-                        # We have image but only preliminary probs? 
+                        # We have image but only preliminary probs?
                         # Continue fast-polling until probs are real.
                         continue
-                    
+
                     if has_real_probs:
-                        # We have real probs but still no image. 
+                        # We have real probs but still no image.
                         # Break to Stage 2 for dedicated image slow-poll.
                         logger.info(f"Probs updated for #{watch_num}; transitioning to slow-poll for image")
                         break
@@ -293,11 +293,11 @@ class WatchesCog(commands.Cog):
                 image_url, text_summary, probs = await fetch_watch_details(watch_num)
                 if not image_url:
                     continue
-                    
+
                 cache_path, _, _ = await download_single_image(
                     image_url, AUTO_CACHE_FILE, self.bot.state.auto_cache
                 )
-                
+
                 if cache_path and os.path.exists(cache_path):
                     if await asyncio.to_thread(
                         lambda p=cache_path: is_placeholder_image(open(p, "rb").read())
@@ -415,7 +415,7 @@ class WatchesCog(commands.Cog):
                 )
                 return
             now_utc = datetime.now(timezone.utc)
-            
+
             # ── Cancellations ──────────────────────────────────────────────
             for watch_num, info in list(self.bot.state.active_watches.items()):
                 wtype = info["type"] if isinstance(info, dict) else info

--- a/lib/vad_plotter/params.py
+++ b/lib/vad_plotter/params.py
@@ -1,19 +1,32 @@
 import logging
-import numpy as np
 from typing import Any, Dict, Tuple, Union
+
+import numpy as np
 
 logger = logging.getLogger("spc_bot")
 
 # Try to import Rust implementations; fall back to Python
 try:
     from spc_rust_core import (
-        compute_bunkers as _compute_bunkers_rust,
-        compute_srh as _compute_srh_rust,
-        compute_dtm as _compute_dtm_rust,
-        compute_crit_angl as _compute_crit_angl_rust,
-        compute_shear_mag as _compute_shear_mag_rust,
-        compute_sr_flow as _compute_sr_flow_rust,
         clip_profile as _clip_profile_rust,
+    )
+    from spc_rust_core import (
+        compute_bunkers as _compute_bunkers_rust,
+    )
+    from spc_rust_core import (
+        compute_crit_angl as _compute_crit_angl_rust,
+    )
+    from spc_rust_core import (
+        compute_dtm as _compute_dtm_rust,
+    )
+    from spc_rust_core import (
+        compute_shear_mag as _compute_shear_mag_rust,
+    )
+    from spc_rust_core import (
+        compute_sr_flow as _compute_sr_flow_rust,
+    )
+    from spc_rust_core import (
+        compute_srh as _compute_srh_rust,
     )
     _rust_available = True
 except ImportError:

--- a/lib/vad_plotter/plot.py
+++ b/lib/vad_plotter/plot.py
@@ -3,16 +3,16 @@ from __future__ import print_function
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional
 
 import matplotlib as mpl
 
 mpl.use("agg")
+import numpy as np
 import pylab
 from matplotlib.lines import Line2D
 from matplotlib.patches import Circle
 
-import numpy as np
 from lib.vad_plotter.params import vec2comp
 
 logger = logging.getLogger("spc_bot")

--- a/lib/vad_plotter/radar_coords.py
+++ b/lib/vad_plotter/radar_coords.py
@@ -2,7 +2,8 @@
 lib/vad_plotter/radar_coords.py - Static geographic coordinates for WSR-88D and TDWR sites.
 """
 
-from typing import Dict, Tuple, Optional
+from typing import Dict, Optional, Tuple
+
 from utils.geo import haversine
 
 RADAR_COORDS: Dict[str, Tuple[float, float]] = {

--- a/lib/vad_plotter/vad.py
+++ b/lib/vad_plotter/vad.py
@@ -1,26 +1,26 @@
 from __future__ import print_function
 
-import numpy as np
-import sys
 import os
+import sys
+
+import numpy as np
 
 # Allow running as a subprocess from any working directory
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
-from lib.vad_plotter.vad_reader import download_vad, VADFile
-from lib.vad_plotter.params import compute_parameters
-from lib.vad_plotter.plot import plot_hodograph
-from lib.vad_plotter.wsr88d import build_has_name
-from lib.vad_plotter.asos import get_asos_surface_wind
-
-import re
 import argparse
 import asyncio
-import logging
-from datetime import datetime, timedelta, timezone
-from typing import Optional, Tuple, Any
 import json
-import glob
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional, Tuple
+
+from lib.vad_plotter.asos import get_asos_surface_wind
+from lib.vad_plotter.params import compute_parameters
+from lib.vad_plotter.plot import plot_hodograph
+from lib.vad_plotter.vad_reader import VADFile, download_vad
+from lib.vad_plotter.wsr88d import build_has_name
 
 logger = logging.getLogger("spc_bot")
 
@@ -63,14 +63,14 @@ def parse_time(time_str: str) -> datetime:
 
 
 async def vad_plotter(
-    radar_id: str, 
-    storm_motion: str = 'right-mover', 
-    sfc_wind: Optional[str] = None, 
+    radar_id: str,
+    storm_motion: str = 'right-mover',
+    sfc_wind: Optional[str] = None,
     time: Optional[str] = None,
-    fname: Optional[str] = None, 
-    local_path: Optional[str] = None, 
-    cache_path: Optional[str] = None, 
-    web: bool = False, 
+    fname: Optional[str] = None,
+    local_path: Optional[str] = None,
+    cache_path: Optional[str] = None,
+    web: bool = False,
     fixed: bool = False,
     executor: Optional[Any] = None
 ) -> None:
@@ -122,11 +122,11 @@ async def vad_plotter(
         logger.info("[VAD] Storm motion: --/--")
 
     # Move CPU-bound plotting to an executor to keep the event loop free.
-    # Note: matplotlib is not thread-safe by default, but plot_hodograph 
-    # creates its own figure and closes it, which is usually okay in a 
+    # Note: matplotlib is not thread-safe by default, but plot_hodograph
+    # creates its own figure and closes it, which is usually okay in a
     # thread as long as it's not the main GUI thread.
     loop = asyncio.get_running_loop()
-    await loop.run_in_executor(executor, 
+    await loop.run_in_executor(executor,
         plot_hodograph, vad, params, fname, web, fixed, (local_path is not None), sfc_wind_str
     )
 

--- a/lib/vad_plotter/vad_reader.py
+++ b/lib/vad_plotter/vad_reader.py
@@ -1,16 +1,17 @@
 from __future__ import print_function
-import numpy as np
-import struct
-import re
+
 import logging
-import asyncio
+import re
+import struct
+import zlib
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import zlib
+import numpy as np
+
 from lib.vad_plotter.wsr88d import build_has_name
-from utils.http import http_get_bytes, http_get_text, circuit_breaker
+from utils.http import circuit_breaker, http_get_bytes, http_get_text
 
 logger = logging.getLogger("spc_bot.vad_reader")
 
@@ -44,10 +45,10 @@ def _normalize_nids_bytes(raw_bytes: bytes) -> bytes:
     # The standard structure we expect is:
     # [30 bytes WMO] [18 bytes Msg Header] [12 bytes PDB prefix] [Product Code 48]
     # Total offset to code = 30 + 18 + 12 = 60.
-    
+
     # If the file is already raw from TGFTP, it should have 48 at offset 60.
     # If it's unwrapped, it might have 48 at offset 30 (18 Msg + 12 PDB).
-    
+
     found_offset = -1
 
     # Try Rust optimized search first
@@ -71,19 +72,20 @@ def _normalize_nids_bytes(raw_bytes: bytes) -> bytes:
                         if msg_code == 48:
                             found_offset = i
                             break
-    
+
     if found_offset != -1:
         # We want the message to start 60 bytes BEFORE the PDB product code
         # (30 WMO + 18 Msg Header + 12 PDB prefix).
-        # We will strip whatever is there and prepend exactly 30 dummy bytes 
+        # We will strip whatever is there and prepend exactly 30 dummy bytes
         # so the existing _read_headers (which skips 30) works perfectly.
         nids_start = found_offset - 30 # Start of Message Header
         payload = raw_bytes[nids_start:]
         return b"A" * 30 + payload
-        
+
     return raw_bytes
 
 from collections.abc import Mapping
+
 
 class VADFile(Mapping):
     fields = ['wind_dir', 'wind_spd', 'rms_error', 'divergence', 'slant_range', 'elev_angle']
@@ -95,7 +97,7 @@ class VADFile(Mapping):
             data = file_or_bytes.read()
         else:
             data = bytes(file_or_bytes)
-            
+
         normalized = _normalize_nids_bytes(data)
         self._rpg = BytesIO(normalized)
         self._data: Optional[Dict[str, np.ndarray]] = None
@@ -289,11 +291,11 @@ class VADFile(Mapping):
             try:
                 # Seek to tabular block offset in the original stream
                 offset_tabular = self._tabular_offset if hasattr(self, '_tabular_offset') else 0
-                
+
                 # Get the raw bytes from the BytesIO object
                 self._rpg.seek(0)
                 raw_bytes = self._rpg.read()
-                
+
                 # Correct absolute offset (30 bytes WMO + NIDS relative offset)
                 abs_offset = 30 + offset_tabular
                 res = spc_rust_core.parse_vwp_tabular_data(raw_bytes, abs_offset)
@@ -368,13 +370,14 @@ import aioboto3
 import botocore
 from botocore.config import Config
 
+
 async def _list_s3_vad_times(rid: str) -> List[Tuple[str, datetime]]:
     """List recent VAD files from S3 for a site."""
     rid_upper = rid.upper()
     # The S3 bucket is alphabetical. We'll try the current day first.
     now = datetime.now(timezone.utc)
     prefix = f"{rid_upper}_NVW_{now.strftime('%Y_%m_%d')}"
-    
+
     session = aioboto3.Session()
     try:
         async with session.client(
@@ -388,10 +391,10 @@ async def _list_s3_vad_times(rid: str) -> List[Tuple[str, datetime]]:
                 yesterday = now - timedelta(days=1)
                 prefix_y = f"{rid_upper}_NVW_{yesterday.strftime('%Y_%m_%d')}"
                 response = await s3.list_objects_v2(Bucket=_S3_BUCKET, Prefix=prefix_y)
-            
+
             if "Contents" not in response:
                 return []
-            
+
             results = []
             for obj in response["Contents"]:
                 key = obj["Key"]
@@ -402,7 +405,7 @@ async def _list_s3_vad_times(rid: str) -> List[Tuple[str, datetime]]:
                     results.append((key, ts))
                 except (ValueError, IndexError):
                     continue
-            
+
             # Sort newest first
             return sorted(results, key=lambda x: x[1], reverse=True)
     except Exception as e:
@@ -411,7 +414,7 @@ async def _list_s3_vad_times(rid: str) -> List[Tuple[str, datetime]]:
 
 async def find_file_times(rid: str) -> List[Tuple[str, datetime]]:
     host = "tgftp.nws.noaa.gov"
-    
+
     # Try TGFTP if circuit is closed
     if not circuit_breaker.is_open(host):
         url = "%s/SI.%s/" % (_base_url, rid.lower())
@@ -460,7 +463,7 @@ async def download_vad(
     host = "tgftp.nws.noaa.gov"
     content = None
     status = None
-    
+
     # Attempt TGFTP if circuit is closed
     if not circuit_breaker.is_open(host):
         if time is None:
@@ -504,7 +507,7 @@ async def download_vad(
         s3_times = await _list_s3_vad_times(rid)
         if not s3_times:
             raise ValueError(f"Could not find VAD data for {rid} on TGFTP or S3")
-        
+
         target_key = None
         if time:
             time_utc = time.replace(tzinfo=timezone.utc) if not time.tzinfo else time
@@ -514,10 +517,10 @@ async def download_vad(
                     break
         else:
             target_key = s3_times[0][0] # Latest
-            
+
         if not target_key:
              raise ValueError(f"No VAD files before {time} found on S3 for {rid}")
-             
+
         session = aioboto3.Session()
         try:
             async with session.client(
@@ -538,5 +541,5 @@ async def download_vad(
             with open("%s/%s" % (cache_path, iname), 'wb') as floc:
                 floc.write(content)
         return vad
-        
+
     raise ValueError(f"VAD data unavailable for {rid}")

--- a/lib/vtec_parser.py
+++ b/lib/vtec_parser.py
@@ -7,8 +7,8 @@ geographic warning regions.
 These utilities have zero Discord dependencies and can be reused in CLI tools,
 batch processors, and other contexts.
 """
-import re
 import logging
+import re
 from typing import List, Optional, Tuple
 
 # VTEC string format (NWS Directive 10-1703):
@@ -104,7 +104,7 @@ def parse_warning_polygon(
     m = _LATLON_RE.search(text)
     if not m:
         return None
-    
+
     raw_coords_str = m.group(1)
 
     # Try Rust optimized parser first

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -16,12 +16,6 @@ from config import (
     CENTRAL,
     SPC_SCHEDULE,
 )
-from utils.state_store import (
-    set_hash,
-    set_hashes_batch,
-    get_all_validators,
-    set_validators,
-)
 from utils.change_detection import (
     calculate_hash_bytes,
     get_cache_path_for_url,
@@ -31,6 +25,12 @@ from utils.http import (
     ensure_session,
     http_get_bytes_conditional,
     http_head_ok,
+)
+from utils.state_store import (
+    get_all_validators,
+    set_hash,
+    set_hashes_batch,
+    set_validators,
 )
 
 # Per-URL HTTP validators (ETag, Last-Modified) from the most recent 200
@@ -353,7 +353,7 @@ async def save_downloaded_images(
         # Update in-memory cache first so subsequent checks in this loop see it
         for url, h in batch_updates.items():
             cache[url] = h
-            
+
         cache_type = "manual" if "manual" in cache_file_path else "auto"
         # Standardized await for DB integrity
         await set_hashes_batch(batch_updates, cache_type)
@@ -372,8 +372,8 @@ async def check_all_urls_exist_parallel(urls: List[str]) -> bool:
         )
     return ok
 async def fetch_with_validators(
-    url: str, 
-    retries: int = 3, 
+    url: str,
+    retries: int = 3,
     timeout: int = 30,
     retry_statuses: Optional[List[int]] = None
 ) -> Tuple[Optional[bytes], Optional[int]]:

--- a/utils/dat_api.py
+++ b/utils/dat_api.py
@@ -3,7 +3,8 @@ utils/dat_api.py — Interface for the NWS Damage Assessment Toolkit (DAT) ArcGI
 """
 
 import logging
-from typing import Optional, List, Tuple
+from typing import List, Optional, Tuple
+
 from utils.http import http_get_json
 
 logger = logging.getLogger("spc_bot")
@@ -25,17 +26,17 @@ async def fetch_dat_track_geometry(guid: str) -> Optional[List[List[Tuple[float,
         f"{DAT_BASE_URL}/{TRACK_LAYER_ID}/query"
         f"?where=globalid='{guid}'&outFields=*&returnGeometry=true&outSR=4326&f=json"
     )
-    
+
     try:
         data = await http_get_json(query_url, retries=1, timeout=15)
         if not data or "features" not in data:
             return None
-            
+
         features = data["features"]
         if not features:
             logger.debug(f"[DAT-API] No track geometry found for GUID {guid}")
             return None
-            
+
         # Standard ArcGIS Polyline geometry: {"paths": [[[x1, y1], [x2, y2]], ...]}
         # ArcGIS uses [lon, lat] (x, y) format.
         all_paths = []
@@ -43,17 +44,17 @@ async def fetch_dat_track_geometry(guid: str) -> Optional[List[List[Tuple[float,
             geom = feat.get("geometry")
             if not geom or "paths" not in geom:
                 continue
-                
+
             for path in geom["paths"]:
                 # Convert [lon, lat] to (lat, lon) for bot-wide consistency
                 converted_path = [(float(p[1]), float(p[0])) for p in path]
                 all_paths.append(converted_path)
-                
+
         if all_paths:
             logger.info(f"[DAT-API] Successfully fetched {len(all_paths)} path(s) for GUID {guid}")
             return all_paths
-            
+
     except Exception as e:
         logger.warning(f"[DAT-API] Error fetching track geometry for {guid}: {e}")
-        
+
     return None

--- a/utils/db.py
+++ b/utils/db.py
@@ -93,12 +93,12 @@ async def get_db() -> aiosqlite.Connection:
         # Check again inside lock in case another coroutine connected first
         if _db is None:
             _db = await _connect()
-            
+
             # Populate read pool once write connection is established
             for _ in range(_READ_POOL_SIZE):
                 conn = await _connect(read_only=True)
                 await _read_pool.put(conn)
-                
+
     return _db
 
 
@@ -107,7 +107,7 @@ async def get_read_db() -> AsyncGenerator[aiosqlite.Connection, None]:
     """Check out a read-only connection from the pool."""
     # Ensure pool is initialized (get_db ensures this)
     await get_db()
-    
+
     conn = await _read_pool.get()
     try:
         yield conn
@@ -118,7 +118,7 @@ async def get_read_db() -> AsyncGenerator[aiosqlite.Connection, None]:
 async def _connect(read_only: bool = False) -> aiosqlite.Connection:
     """Open database connection with safe settings."""
     os.makedirs(CACHE_DIR, exist_ok=True)
-    
+
     # Use URI format for read-only access
     path = f"file:{DB_PATH}?mode=ro" if read_only else DB_PATH
     db = await aiosqlite.connect(path, timeout=10, uri=read_only)

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -21,9 +21,9 @@ from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
 import aiohttp
-from utils.http import http_get_json, ensure_session
-
 import aiosqlite
+
+from utils.http import ensure_session, http_get_json
 
 logger = logging.getLogger("spc_bot")
 
@@ -189,7 +189,7 @@ async def link_dat_guid_to_tornado(date_str: str, guid: str, label: str) -> Opti
             _mark_dirty()
             logger.info(f"Linked DAT {guid} to event {best_id}")
             return (best_id, best_row["location"], best_row["magnitude"], best_row["coords"])
-            
+
     except Exception as e:
         logger.warning(f"link_dat_guid_to_tornado failed: {e}")
     return None
@@ -206,7 +206,7 @@ async def backfill_dat_guids(days: int = 30):
     # 1. Fetch recently updated tracks from DAT
     # ArcGIS uses Unix timestamps in milliseconds for date filters
     cutoff_ms = int((time.time() - (days * 86400)) * 1000)
-    
+
     url = (
         "https://services.dat.noaa.gov/arcgis/rest/services/nws_damageassessmenttoolkit/DamageViewer/FeatureServer/1/query"
         f"?where=last_edited_date >= {cutoff_ms}&outFields=event_id,event_name,efscale&returnGeometry=true&outSR=4326&f=json"
@@ -344,7 +344,7 @@ async def fetch_dat_photos(
             "https://services.dat.noaa.gov/arcgis/rest/services/nws_damageassessmenttoolkit/DamageViewer/FeatureServer/0"
             f"/queryAttachments?objectIds={ids_str}&f=json"
         )
-        
+
         urls = []
         bulk_data = await http_get_json(bulk_url, retries=1, timeout=10)
         if bulk_data and "attachmentGroups" in bulk_data:
@@ -593,7 +593,7 @@ def restore_from_sync() -> None:
     if not os.path.exists(_SYNC_PATH):
         logger.info("No sync snapshot found — starting fresh events.db")
         return
-    
+
     global _db
     if _db is not None:
         logger.warning("Cannot restore while DB is open — close it first")
@@ -605,7 +605,7 @@ def restore_from_sync() -> None:
         if os.path.getsize(_SYNC_PATH) < 4096: # Minimal SQLite file size
              logger.warning("Sync snapshot too small, skipping restore")
              return
-             
+
         shutil.copy2(_SYNC_PATH, _EVENTS_DB_PATH)
         logger.info("Restored events.db from sync snapshot")
     except Exception as e:

--- a/utils/geo.py
+++ b/utils/geo.py
@@ -64,7 +64,7 @@ def find_nearest_indices(
             return list(_find_nearest_stations_rust(lat, lon, targets, n))
         except Exception:
             pass
-    
+
     # Python fallback
     distances = [(i, haversine(lat, lon, t_lat, t_lon)) for i, (t_lat, t_lon) in enumerate(targets)]
     distances.sort(key=lambda x: x[1])
@@ -80,7 +80,7 @@ def points_in_polygon_counts(
             return list(_points_in_polygon_counts_rust(points, polygons))
         except Exception:
             pass
-            
+
     # Python fallback (minimal: just returns 0s to maintain contract if Rust fails)
     return [0] * len(polygons)
 
@@ -94,6 +94,6 @@ def points_in_polygon_lookup(
             return list(_points_in_polygon_lookup_rust(points, polygons))
         except Exception:
             pass
-            
+
     # Python fallback
     return [None] * len(points)

--- a/utils/http.py
+++ b/utils/http.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Tuple
 from urllib.parse import urlparse
 
 import aiohttp
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger("spc_bot")
 
@@ -198,7 +198,7 @@ async def http_get_bytes_conditional(
             latency = time.perf_counter() - start
             if _latency_callback:
                 _latency_callback(latency)
-            
+
             if response.status in (429, 503, 502, 504):
                 # Tenacity handles the backoff/retry; we just signal the failure
                 raise aiohttp.ClientResponseError(
@@ -207,12 +207,12 @@ async def http_get_bytes_conditional(
                     status=response.status,
                     message="Server returned retryable error"
                 )
-            
+
             if response.status == 304:
                 return None, 304, {"etag": etag or "", "last_modified": last_modified or ""}
-                
+
             response.raise_for_status() # Raise for 4xx/5xx
-            
+
             content = await response.read()
             validators = {
                 "etag": response.headers.get("ETag", ""),
@@ -254,7 +254,7 @@ async def http_head_ok(url: str, timeout: int = 20) -> bool:
     host = parsed.netloc
     if circuit_breaker.is_open(host):
         return False
-        
+
     try:
         session = await ensure_session()
         async with session.head(

--- a/utils/map_utils.py
+++ b/utils/map_utils.py
@@ -3,14 +3,16 @@ utils/map_utils.py — Local map rendering for tornado tracks and geometry.
 """
 
 import matplotlib
+
 matplotlib.use("Agg") # Headless
-import matplotlib.pyplot as plt
-import matplotlib.patheffects as patheffects
+import logging
+from typing import List, Tuple
+
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import cartopy.io.img_tiles as cimgt
-import logging
-from typing import List, Tuple
+import matplotlib.patheffects as patheffects
+import matplotlib.pyplot as plt
 
 logger = logging.getLogger("spc_bot")
 
@@ -26,13 +28,13 @@ def render_tornado_track(paths: List[List[Tuple[float, float]]], output_path: st
 
     # 1. Setup projection and tiles
     # We use OSM tiles as a reliable base
-    request = cimgt.OSM() 
+    request = cimgt.OSM()
     proj = request.crs
     data_proj = ccrs.PlateCarree()
-    
+
     fig = plt.figure(figsize=(12, 9), dpi=120)
     ax = plt.axes(projection=proj)
-    
+
     # 2. Determine Extent
     all_lats: list[float] = []
     all_lons: list[float] = []
@@ -49,10 +51,10 @@ def render_tornado_track(paths: List[List[Tuple[float, float]]], output_path: st
 
     min_lat, max_lat = min(all_lats), max(all_lats)
     min_lon, max_lon = min(all_lons), max(all_lons)
-    
+
     lat_span = max_lat - min_lat
     lon_span = max_lon - min_lon
-    
+
     # Minimum 0.1 degree span for tiny tracks
     if lat_span < 0.1:
         mid = (min_lat + max_lat) / 2
@@ -63,14 +65,14 @@ def render_tornado_track(paths: List[List[Tuple[float, float]]], output_path: st
 
     # Set extent with 30% margin
     margin = 0.3
-    ax.set_extent([min_lon - (lon_span * margin), max_lon + (lon_span * margin), 
-                   min_lat - (lat_span * margin), max_lat + (lat_span * margin)], 
+    ax.set_extent([min_lon - (lon_span * margin), max_lon + (lon_span * margin),
+                   min_lat - (lat_span * margin), max_lat + (lat_span * margin)],
                   crs=data_proj)
 
     # 3. Add Tiles and Features
     # Zoom level 11 is a good balance for tornado tracks
     ax.add_image(request, 11)
-    
+
     # Add County lines (High Detail)
     counties = cfeature.NaturalEarthFeature(
         category='cultural',
@@ -80,27 +82,27 @@ def render_tornado_track(paths: List[List[Tuple[float, float]]], output_path: st
     )
     ax.add_feature(counties, edgecolor='#555555', linewidth=0.6, linestyle=':')
     ax.add_feature(cfeature.STATES, edgecolor='black', linewidth=1.0)
-    
+
     # 4. Plot paths
     for path in paths:
         if not path:
             continue
         lats, lons = zip(*path)
         # Plot the main track with a white outline for visibility over tiles
-        ax.plot(lons, lats, color='#ff0000', linewidth=3.5, transform=data_proj, 
+        ax.plot(lons, lats, color='#ff0000', linewidth=3.5, transform=data_proj,
                 zorder=10, solid_capstyle='round', path_effects=[
                     patheffects.withStroke(linewidth=5, foreground='white')
                 ])
         # Add start/end markers
-        ax.scatter(lons[0], lats[0], color='#00ff00', s=60, edgecolors='black', 
+        ax.scatter(lons[0], lats[0], color='#00ff00', s=60, edgecolors='black',
                    transform=data_proj, zorder=15, label="Start")
-        ax.scatter(lons[-1], lats[-1], color='#000000', s=60, edgecolors='white', 
+        ax.scatter(lons[-1], lats[-1], color='#000000', s=60, edgecolors='white',
                    transform=data_proj, zorder=15, label="End")
-        
+
     # 5. Save
-    plt.title("NWS Damage Assessment Toolkit - Survey Track", 
+    plt.title("NWS Damage Assessment Toolkit - Survey Track",
               fontsize=16, fontweight='bold', pad=20, backgroundcolor='white')
-    
+
     plt.savefig(output_path, bbox_inches='tight', dpi=120)
     plt.close(fig)
     logger.info(f"[MAP] Rendered high-detail track to {output_path}")

--- a/utils/spc_outlook.py
+++ b/utils/spc_outlook.py
@@ -82,15 +82,15 @@ def _build_buffered_polygon(features: list, buffer_km: float):
     selected = []
     labels_present = set()
     max_risk_idx = 0
-    
+
     for feat in features:
         props = feat.get("properties", {}) or {}
         label = props.get("LABEL", "").strip().upper()
-        
+
         # Track overall highest risk
         if label in RISK_MAP:
             max_risk_idx = max(max_risk_idx, RISK_MAP[label])
-        
+
         if label not in HIGH_RISK_LABELS:
             continue
         geom = feat.get("geometry")

--- a/utils/spc_urls.py
+++ b/utils/spc_urls.py
@@ -1,7 +1,7 @@
 # utils/spc_urls.py
 import logging
 import re
-from typing import List, Dict, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 from config import (
     SPC_OUTLOOK_BASE,
@@ -24,18 +24,18 @@ async def get_spc_urls(day: int) -> List[str]:
     """
     fallback: List[str] = []
     page_url = f"{SPC_OUTLOOK_BASE}/day{day}otlk.html"
-    
+
     cached_etag, cached_lm, cached_urls = _OUTLOOK_CACHE.get(day, (None, None, []))
 
     try:
         content, status, new_headers = await http_get_bytes_conditional(
             page_url, etag=cached_etag, last_modified=cached_lm
         )
-        
+
         if status == 304:
             logger.debug(f"[DYN_URL] day{day} page unchanged (304 Not Modified)")
             return cached_urls
-            
+
         if not content or status != 200:
             logger.warning(
                 f"[DYN_URL] Failed to fetch day{day} page (status={status})"

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -176,7 +176,7 @@ async def _upstash_cmd(*args: Any) -> Any:
             logger.error("[STATE] Upstash daily quota (10k) EXCEEDED. Falling back to SQLite.")
             _upstash_quota_hit = True
         raise _UpstashUnavailable("Upstash daily quota exceeded")
-    
+
     if usage >= _UPSTASH_SOFT_QUOTA and not _upstash_quota_hit:
         logger.warning(f"[STATE] Upstash daily quota warning: {usage}/{_UPSTASH_DAILY_BUDGET} commands used.")
         _upstash_quota_hit = True # Log once per day per process
@@ -210,10 +210,10 @@ async def _upstash_cmd(*args: Any) -> Any:
                 # Hard failure from Redis itself — e.g. syntax error. Do
                 # not reconcile these; they're bugs, not transient.
                 raise RuntimeError(f"Upstash error: {body['error']}")
-            
+
             # Successfully executed a command
             await sqlite_backend.increment_upstash_commands(1)
-            
+
             return body.get("result")
     except asyncio.TimeoutError as e:
         raise _UpstashUnavailable(f"Upstash timeout: {e}") from e
@@ -951,26 +951,26 @@ async def mirror_to_sqlite() -> None:
     it starts taking new writes."""
     try:
         logger.info("[STATE] Mirroring Upstash → SQLite...")
-        
+
         # 1. Hashes
         for ct in ("auto", "manual"):
             h = await get_all_hashes(ct)
             if h:
                 await sqlite_backend.set_hashes_batch(h, ct)
-        
+
         # 2. Posted collections
         mds = await get_posted_mds()
         for m in mds:
             await sqlite_backend.add_posted_md(m)
-        
+
         watches = await get_posted_watches()
         for w in watches:
             await sqlite_backend.add_posted_watch(w)
-        
+
         reports = await get_posted_reports()
         for r in reports:
             await sqlite_backend.add_posted_report(r)
-        
+
         # 3. State
         states_scan = await _upstash_cmd("SCAN", 0, "MATCH", f"{_k_state('*')}")
         if states_scan and isinstance(states_scan, list) and len(states_scan) >= 2:
@@ -984,13 +984,13 @@ async def mirror_to_sqlite() -> None:
                             # Strip prefix
                             base_key = k.replace(f"{_k_state('')}", "")
                             await sqlite_backend.set_state(base_key, val)
-        
+
         # 4. Posted URLs
         for day in ("day1", "day2", "day3"):
             urls = await get_posted_urls(day)
             if urls:
                 await sqlite_backend.set_posted_urls(day, urls)
-        
+
         logger.info("[STATE] Mirroring complete")
     except Exception as e:
         logger.warning(f"[STATE] Mirroring failed: {e}")

--- a/utils/worker_pool.py
+++ b/utils/worker_pool.py
@@ -22,9 +22,9 @@ _sounding_semaphore: Optional[asyncio.Semaphore] = None
 
 def _worker_init():
     """Initialize each worker process by pre-importing heavy libraries."""
+    import io as _io
     import logging as _logging
     import sys as _sys
-    import io as _io
 
     # Silence inherited loggers to prevent double-logging to stdout
     for name in ("spc_bot", None):
@@ -35,7 +35,7 @@ def _worker_init():
 
     import matplotlib as _mpl
     _mpl.use("Agg")
-    
+
     # Silence SounderPy banner
     _stdout = _sys.stdout
     _sys.stdout = _io.StringIO()


### PR DESCRIPTION
## Ruff hygiene (371 auto-fixed violations)
Trailing/blank-line whitespace (W291/W293), import sorting (I001), redundant `str.split` (PLC0207), unused imports (F401) across 39 files.

## mypy real-bug fixes

**Silent runtime bugs:**
- `status.py`, `watches.py`, `radar/downloads.py` — added `wait=True` to `followup.send()` calls where the result is assigned to `view.message`. Without `wait=True`, followup sends return `None`, so `view.message` was `None` and all auto-update/edit paths in these views silently failed.

**Type correctness:**
- `sounding_utils.py` — `_iem_to_clean_data` return type `dict` → `dict | None` (function already returned `None` on empty profiles; annotation was lying)
- `sounding.py` — removed nonexistent `followup=True` kwarg from `post_sounding` call
- `failover.py` — `_read_lease_holder` now casts the untyped `_upstash` result to `str` before returning, satisfying the `str | None` annotation
- `warnings.py` — cast `get_channel()` result to `discord.abc.Messageable` at return sites; discord.py's union return type is broader than the method annotation requires
- `status.py` — added return type annotations to `build_response`, `build_embeds`, `build_embed`, `build_content` so mypy can verify callers