### PR TITLE
feat: show per-type warning breakdown on /status

### DIFF
--- a/cogs/status.py
+++ b/cogs/status.py
@@ -302,10 +302,24 @@ class StatusView(discord.ui.View):
         )
         if active_high_risk:
             env_val += "*(Sounding Sweep Armed)*\n"
+        active_warnings = self.bot.state.active_warnings
+        warn_total = len(active_warnings)
+        if warn_total:
+            _phenom_label = {"TO": "🌪️ TOR", "SV": "⛈️ SVR", "FF": "🌊 FFW", "MA": "🚢 MAR"}
+            counts: dict[str, int] = {}
+            for vtec in active_warnings.values():
+                p = vtec.get("phenom", "?") if isinstance(vtec, dict) else "?"
+                counts[p] = counts.get(p, 0) + 1
+            warn_detail = " | ".join(
+                f"{_phenom_label.get(p, p)} `{n}`" for p, n in sorted(counts.items())
+            )
+            warn_line = f"**Active Warnings:** `{warn_total}` — {warn_detail}"
+        else:
+            warn_line = f"**Active Warnings:** `0`"
         env_val += (
             f"**Active MDs:** `{len(self.bot.state.active_mds)}`\n"
             f"**Active Watches:** `{len(self.bot.state.active_watches)}`\n"
-            f"**Active Warnings:** `{len(self.bot.state.active_warnings)}`"
+            + warn_line
         )
         embed.add_field(name="🌩️ Environment", value=env_val, inline=True)
 


### PR DESCRIPTION
When warnings are active, the **Active Warnings** line in the Environment field now breaks down counts by phenomenon type instead of showing just a total:

**Before:**
```
Active Warnings: `8`
```

**After:**
```
Active Warnings: `8` — 🌪️ TOR `2` | ⛈️ SVR `5` | 🌊 FFW `1`
```

When no warnings are active the line stays as `Active Warnings: \`0\``.

Reads from `bot.state.active_warnings` (already populated by the warnings cog), uses the existing `phenom` key on each vtec dict (`TO`/`SV`/`FF`/`MA`). No new state, no new I/O.