### PR TITLE
chore: CI/CD pipeline improvements

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,10 +1,6 @@
 name: Build and Push CI Image
 
 on:
-  schedule:
-    # Build daily (7am Pacific Time / 2pm UTC) to keep deps current
-    # Scheduled for minimal disruption during active coding hours
-    - cron: '2 14 * * *'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,39 +10,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  verify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
-      - name: System build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libgeos-dev libproj-dev proj-bin libgdal-dev libhdf5-dev libnetcdf-dev
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-      - name: Install Rust toolchain
-        run: |
-          if ! command -v cargo &>/dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
-          fi
-          . "$HOME/.cargo/env" || . "/root/.cargo/env"
-      - name: Build and install Rust extension
-        run: |
-          . "$HOME/.cargo/env" || . "/root/.cargo/env"
-          pip install maturin
-          maturin build --release --out dist
-          pip install dist/*.whl
-      - name: Run tests
-        run: python -m pytest tests/ -q
-
   build:
     strategy:
       matrix:
@@ -52,7 +19,6 @@ jobs:
           - platform: linux/arm64
             runner: [self-hosted, Linux, ARM64]
     runs-on: ${{ matrix.runner }}
-    needs: verify
     permissions:
       packages: write
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,13 @@ jobs:
           python-version: '3.13'
           cache: pip
           cache-dependency-path: requirements-dev.txt
-      - run: pip install ruff
+      - run: pip install -r requirements-dev.txt
       - name: Ruff (syntax, undefined-name, unused imports)
         run: ruff check --select=E9,F63,F7,F82,F401 --exclude=venv,lib,cache .
 
   test:
     runs-on: ubuntu-latest
+    needs: [lint]
     container:
       image: ghcr.io/${{ github.repository }}/ci:latest
       credentials:
@@ -34,20 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build Rust extensions
-        run: |
-          # 1. Ensure Rust is in PATH
-          export PATH="$HOME/.cargo/bin:/root/.cargo/bin:$PATH"
-          
-          # 2. Install Rust if missing
-          if ! command -v cargo &> /dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
-            . "$HOME/.cargo/env" || . "/root/.cargo/env"
-          fi
-          
-          # 3. Build and install extension
-          pip install maturin
-          maturin build --release --out dist
-          pip install dist/*.whl
+        run: maturin build --release --out dist && pip install dist/*.whl
       - name: Run tests with coverage
         run: |
           python -m pytest tests/ -n auto \
@@ -70,12 +58,10 @@ jobs:
           python-version: '3.13'
           cache: pip
           cache-dependency-path: requirements-dev.txt
-      - name: Install mypy
-        run: pip install mypy
-      - name: mypy (utils — lenient, ignore-missing-imports)
-        # Scope limited to utils/ where types are cleanest. Expand scope
-        # incrementally as annotations are added to other modules.
-        run: mypy --ignore-missing-imports --follow-imports=silent utils/
+      - run: pip install -r requirements-dev.txt
+      - name: mypy (utils + lib/vtec_parser — lenient, ignore-missing-imports)
+        # lib/vtec_parser.py added in v5.25.2; expand to cogs/ incrementally as annotations mature
+        run: mypy --ignore-missing-imports --follow-imports=silent utils/ lib/vtec_parser.py
 
   rust:
     runs-on: ubuntu-latest
@@ -97,10 +83,9 @@ jobs:
       # behind an optional feature so `cargo test --no-default-features` works.
 
   docker-build:
-    # Verify the image builds on main branch and tags. Skip on PRs to save CI time.
+    # Verify the image builds on all pushes and PRs.
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4

--- a/lib/vtec_parser.py
+++ b/lib/vtec_parser.py
@@ -110,9 +110,9 @@ def parse_warning_polygon(
     # Try Rust optimized parser first
     if RUST_AVAILABLE:
         try:
-            coords = spc_rust_core.extract_latlon_coords(raw_coords_str)
-            if coords:
-                return coords
+            rust_coords = spc_rust_core.extract_latlon_coords(raw_coords_str)
+            if rust_coords:
+                return rust_coords
         except Exception as e:
             logger.debug(f"Rust extract_latlon_coords failed: {e}. Falling back to Python.")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-cov>=7.1.0,<8.0
 pytest-xdist>=3.8.0,<4.0
 ruff>=0.15.12,<0.16.0
 maturin>=1.13,<2.0
+mypy>=1.10,<2.0

--- a/utils/map_utils.py
+++ b/utils/map_utils.py
@@ -65,13 +65,13 @@ def render_tornado_track(paths: List[List[Tuple[float, float]]], output_path: st
 
     # Set extent with 30% margin
     margin = 0.3
-    ax.set_extent([min_lon - (lon_span * margin), max_lon + (lon_span * margin),
+    ax.set_extent([min_lon - (lon_span * margin), max_lon + (lon_span * margin),  # type: ignore[attr-defined]
                    min_lat - (lat_span * margin), max_lat + (lat_span * margin)],
                   crs=data_proj)
 
     # 3. Add Tiles and Features
     # Zoom level 11 is a good balance for tornado tracks
-    ax.add_image(request, 11)
+    ax.add_image(request, 11)  # type: ignore[attr-defined,arg-type,call-arg]
 
     # Add County lines (High Detail)
     counties = cfeature.NaturalEarthFeature(
@@ -80,8 +80,8 @@ def render_tornado_track(paths: List[List[Tuple[float, float]]], output_path: st
         scale='10m',
         facecolor='none'
     )
-    ax.add_feature(counties, edgecolor='#555555', linewidth=0.6, linestyle=':')
-    ax.add_feature(cfeature.STATES, edgecolor='black', linewidth=1.0)
+    ax.add_feature(counties, edgecolor='#555555', linewidth=0.6, linestyle=':')  # type: ignore[attr-defined]
+    ax.add_feature(cfeature.STATES, edgecolor='black', linewidth=1.0)  # type: ignore[attr-defined]
 
     # 4. Plot paths
     for path in paths:


### PR DESCRIPTION
## Summary

Seven targeted improvements to the CI/CD pipeline — no behavior changes to the bot itself.

- **Pin ruff + mypy via `requirements-dev.txt`** — `lint` and `mypy` jobs previously did bare `pip install ruff` / `pip install mypy` with no version pin. Both jobs now install from the pinned requirements file, ensuring CI uses the same versions as local dev.
- **Add `mypy` to `requirements-dev.txt`** (`mypy>=1.10,<2.0`)
- **Simplify `test` job Rust build step** — Rust and maturin are already baked into the CI image (`Dockerfile.ci`); the per-run `if ! command -v cargo` check + curl-based Rust install was fragile dead weight. Step is now a single line.
- **Fail-fast: `test` now `needs: [lint]`** — if ruff fails in 30 s, the 2-minute test run no longer burns runner time pointlessly.
- **`docker-build` now runs on PRs** — previously skipped with `if: github.event_name != 'pull_request'`, meaning a broken `Dockerfile` would only be caught after merging to main.
- **Drop `verify` job from `docker-publish`** — the full test suite + fresh system/Rust install was re-running redundantly on every tag push. Tests already passed on the release PR before the tag was cut.
- **Drop daily schedule from `ci-image`** — the image only needs rebuilding when `Dockerfile.ci` or `requirements-dev.txt` change; the `paths` trigger covers that. Daily rebuilds of an unchanged image served no purpose.
- **Expand mypy scope to `lib/vtec_parser.py`** — fixed a `no-redef` error uncovered by the check (`coords` variable renamed to `rust_coords` in the Rust fast-path branch). Added `# type: ignore` annotations for cartopy `GeoAxes` false positives in `utils/map_utils.py`.

## Test plan

- [ ] `lint` job passes
- [ ] `test` job passes (and is skipped if lint fails)
- [ ] `mypy` job passes with expanded scope
- [ ] `rust` job passes
- [ ] `docker-build` job runs on this PR and passes