### PR TITLE
fix: add Rust toolchain setup to test job in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,10 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
       - name: Build Rust extensions
         run: maturin build --release --out dist && pip install dist/*.whl
       - name: Run tests with coverage


### PR DESCRIPTION
## Summary

Fixes the CI `test` job failure introduced in #369.

The CI container (`Dockerfile.ci`) has rustup installed, but GitHub Actions overrides `HOME` and environment variables when spinning up a container, so the pre-baked toolchain path isn't reachable. `maturin build` then fails with `no default toolchain configured`.

Fix: add `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` before the build step, matching the pattern already used in the `rust` job. This ensures the toolchain is set up correctly regardless of the container environment.