### PR TITLE
Add Upstash quota stats to /status

### DIFF
--- a/cogs/status.py
+++ b/cogs/status.py
@@ -11,6 +11,7 @@ import discord
 from discord.ext import commands, tasks
 
 import utils.http as _http
+from utils.state_store import get_upstash_stats
 from cogs.mesoscale import (
     clean_md_text_for_discord,
     extract_md_body,
@@ -338,6 +339,26 @@ class StatusView(discord.ui.View):
                 inline=False,
             )
             embed.color = discord.Color.red()
+
+        # Upstash quota
+        try:
+            upstash = await get_upstash_stats()
+            cmds = upstash["commands_today"]
+            budget = upstash["budget"]
+            dirty = upstash["dirty_count"]
+            pct = (cmds / budget * 100) if budget else 0
+            health = "🟢" if pct < 80 else ("🟡" if pct < 100 else "🔴")
+            upstash_val = (
+                f"**Commands today:** {health} `{cmds:,} / {budget:,}` ({pct:.1f}%)\n"
+                f"**Dirty queue:** `{dirty}`"
+            )
+            embed.add_field(name="📊 Upstash", value=upstash_val, inline=True)
+            if pct >= 100:
+                embed.color = discord.Color.red()
+            elif pct >= 80 and embed.color != discord.Color.red():
+                embed.color = discord.Color.gold()
+        except Exception as e:
+            logger.debug(f"Failed to fetch Upstash stats: {e}")
 
         # Recent activity (condensed)
         recent_lines = []

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -906,6 +906,24 @@ async def set_validators(url: str, etag: str, last_modified: str) -> None:
     await sqlite_backend.set_validators(url, etag, last_modified)
 
 
+# ── Upstash stats (for /status dashboard) ────────────────────────────────────
+
+async def get_upstash_stats() -> dict:
+    """Return daily command usage and dirty-write queue depth.
+
+    Returns dict with keys: commands_today, budget, soft_quota, dirty_count.
+    Used by /status to surface quota health to the user.
+    """
+    usage = await sqlite_backend.get_upstash_commands_today()
+    dirty = await sqlite_backend.get_dirty_writes()
+    return {
+        "commands_today": usage,
+        "budget": _UPSTASH_DAILY_BUDGET,
+        "soft_quota": _UPSTASH_SOFT_QUOTA,
+        "dirty_count": len(dirty),
+    }
+
+
 # ── Startup resync ───────────────────────────────────────────────────────────
 
 async def resync_to_upstash(force_full: bool = False) -> Dict[str, int]:


### PR DESCRIPTION
## Summary
- Display daily Upstash command usage (commands today / 10,000 budget) in the `/status` embed
- Show dirty write queue depth (pending Upstash reconciliation operations)
- Color-coded health indicator: 🟢 <80% | 🟡 80-100% | 🔴 ≥100%
- Field refreshes automatically with the existing 5-second auto-update loop

## Problem
The bot tracks daily Upstash usage but never surfaced it in `/status`, making quota exhaustion invisible without checking logs. Especially critical now that monthly usage is at 474k/500k (free tier limit).

## Test plan
- [ ] Run `/status` locally; confirm new "📊 Upstash" field appears with realistic command count
- [ ] Manually verify color-coded logic: mock `get_upstash_commands_today` returns 8500 (yellow) and 10000 (red)
- [ ] Confirm field updates every 5 seconds during live-refresh loop
- [ ] Test on deployed instance to see actual usage patterns

## Files changed
- `cogs/status.py` — add import and Upstash field to `build_embeds()`
- `utils/state_store.py` — add `get_upstash_stats()` helper