### PR TITLE
fix: handle ReadOnlyError on Redis replica (failover standby node)

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -165,6 +165,7 @@ class FailoverCog(commands.Cog):
         except (
             redis.exceptions.ConnectionError,
             redis.exceptions.TimeoutError,
+            redis.exceptions.ReadOnlyError,
             OSError,
         ) as e:
             logger.warning(f"[FAILOVER] Redis error: {e!r}")
@@ -187,6 +188,7 @@ class FailoverCog(commands.Cog):
         except (
             redis.exceptions.ConnectionError,
             redis.exceptions.TimeoutError,
+            redis.exceptions.ReadOnlyError,
             OSError,
         ) as e:
             logger.warning(f"[FAILOVER] Renew lease error: {e!r}")
@@ -206,6 +208,7 @@ class FailoverCog(commands.Cog):
         except (
             redis.exceptions.ConnectionError,
             redis.exceptions.TimeoutError,
+            redis.exceptions.ReadOnlyError,
             OSError,
         ) as e:
             logger.warning(f"[FAILOVER] Release lease error: {e!r}")

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -181,6 +181,7 @@ async def _redis_cmd(*args: Any) -> Any:
         redis_exc.ConnectionError,
         redis_exc.TimeoutError,
         redis_exc.BusyLoadingError,
+        redis_exc.ReadOnlyError,
         OSError,
         asyncio.TimeoutError,
     ) as e:
@@ -201,6 +202,7 @@ async def _scan_all_keys(pattern: str) -> List[str]:
     except (
         redis_exc.ConnectionError,
         redis_exc.TimeoutError,
+        redis_exc.ReadOnlyError,
         OSError,
     ) as e:
         raise _RedisUnavailable(f"Redis SCAN unavailable: {e}") from e


### PR DESCRIPTION
## Summary

- `redis.exceptions.ReadOnlyError` added to exception handlers in `cogs/failover.py` (`_exec`, `_renew_lease`, `_release_lease`) and `utils/state_store.py` (`_redis_cmd`, `_scan_all_keys`)
- The failover standby node on multivortex runs a Redis replica (`slave_read_only:1`), causing every write attempt to raise `ReadOnlyError` — previously uncaught, crashing the failover cog on startup
- Write failures on the replica now degrade gracefully: failover cog stays in standby mode, state_store falls back to SQLite as intended

## Test plan

- [ ] CI passes (lint, test, mypy, rust, docker-build)
- [ ] After merge: deploy to multivortex standby and confirm no `ReadOnlyError` in logs
- [ ] Confirm standby boots cleanly in standby mode