### PR TITLE
ci: pre-warm ARM64 docker layer cache on every push to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,9 +87,17 @@ jobs:
       # behind an optional feature so `cargo test --no-default-features` works.
 
   docker-build:
-    # Verify the image builds on all pushes and PRs.
-    runs-on: ubuntu-latest
+    # Verify the image builds on all pushes and PRs; pre-warms GHA layer cache
+    # for both platforms so docker-publish release builds hit cache, not scratch.
     needs: [test, mypy, rust]
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: [self-hosted, Linux, ARM64]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
@@ -97,11 +105,12 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           push: false
           load: true
           tags: spc-bot:ci
-          cache-from: type=gha,scope=build-linux/amd64
-          cache-to: type=gha,mode=max,scope=build-linux/amd64
+          cache-from: type=gha,scope=build-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.platform }}
       - name: Smoke test — image imports main.py
         env:
           DISCORD_TOKEN: ci-smoke-token


### PR DESCRIPTION
## Summary

- `docker-build` CI job is now a 2×matrix: `linux/amd64` on `ubuntu-latest` and `linux/arm64` on the `honk` self-hosted runner
- Each platform writes to its own GHA cache scope (`build-linux/amd64` / `build-linux/arm64`) on every PR and push to `main`

## Why

The ARM64 cache scope was only populated during tag releases. Between releases, if `requirements.txt` changed or the cache expired, `docker-publish` would rebuild Cartopy and arm-pyart from source (~80–100s each) instead of pulling from cache. Now every merge to `main` pre-warms both caches so release builds are fast.

## Test plan
- [ ] Confirm `docker-build (linux/arm64)` leg completes successfully on the honk runner
- [ ] Confirm `docker-build (linux/amd64)` leg still passes the smoke test
- [ ] On next tag release, verify `docker-publish` ARM64 build no longer rebuilds Cartopy/arm-pyart from scratch