### PR TITLE
ci: use persistent local disk cache for ARM64 docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,8 +16,12 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
+            cache-from: type=gha,scope=build-linux/amd64
+            cache-to: type=gha,mode=max,scope=build-linux/amd64
           - platform: linux/arm64
             runner: [self-hosted, Linux, ARM64]
+            cache-from: type=local,src=/var/cache/buildx/spc-bot
+            cache-to: type=local,dest=/var/cache/buildx/spc-bot-new,mode=max
     runs-on: ${{ matrix.runner }}
     permissions:
       packages: write
@@ -48,8 +52,14 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=build-${{ matrix.platform }}
+          cache-from: ${{ matrix.cache-from }}
+          cache-to: ${{ matrix.cache-to }}
+
+      - name: Rotate local build cache (ARM64 only)
+        if: matrix.platform == 'linux/arm64'
+        run: |
+          rm -rf /var/cache/buildx/spc-bot
+          mv /var/cache/buildx/spc-bot-new /var/cache/buildx/spc-bot
 
       - name: Export digest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,6 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: ${{ matrix.platform }}
           push: false
           load: true
           tags: spc-bot:ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,16 +87,23 @@ jobs:
       # behind an optional feature so `cargo test --no-default-features` works.
 
   docker-build:
-    # Verify the image builds on all pushes and PRs; pre-warms GHA layer cache
-    # for both platforms so docker-publish release builds hit cache, not scratch.
+    # Verify the image builds on all pushes and PRs.
+    # ARM64 uses a persistent local disk cache on the self-hosted runner so
+    # Cartopy/arm-pyart wheel compilation is skipped on every run after the
+    # first. amd64 uses the GHA layer cache (ephemeral runner has no local disk
+    # to persist across jobs).
     needs: [test, mypy, rust]
     strategy:
       matrix:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
+            cache-from: type=gha,scope=build-linux/amd64
+            cache-to: type=gha,mode=max,scope=build-linux/amd64
           - platform: linux/arm64
             runner: [self-hosted, Linux, ARM64]
+            cache-from: type=local,src=/var/cache/buildx/spc-bot
+            cache-to: type=local,dest=/var/cache/buildx/spc-bot-new,mode=max
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -109,8 +116,13 @@ jobs:
           push: false
           load: true
           tags: spc-bot:ci
-          cache-from: type=gha,scope=build-${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=build-${{ matrix.platform }}
+          cache-from: ${{ matrix.cache-from }}
+          cache-to: ${{ matrix.cache-to }}
+      - name: Rotate local build cache (ARM64 only)
+        if: matrix.platform == 'linux/arm64'
+        run: |
+          rm -rf /var/cache/buildx/spc-bot
+          mv /var/cache/buildx/spc-bot-new /var/cache/buildx/spc-bot
       - name: Smoke test — image imports main.py
         env:
           DISCORD_TOKEN: ci-smoke-token


### PR DESCRIPTION
## Summary

- Switches ARM64 Docker builds (both CI `docker-build` and release `docker-publish`) from `type=gha` to `type=local` pointing at `/var/cache/buildx/spc-bot` on the `honk` self-hosted runner
- Adds a cache rotation step after each build to prevent unbounded disk growth
- `amd64` (ephemeral `ubuntu-latest`) keeps `type=gha` unchanged

## Why

The GHA layer cache doesn't reliably carry the expensive builder stage across squash merges and branch boundaries. Cartopy (~20s) and arm-pyart (~120s) were recompiling from source on every run. Since `honk` is a persistent self-hosted runner, its local disk survives between jobs — after the first warm run, these layers are always cached regardless of commit hash or GHA cache eviction policy.

## Test plan
- [ ] Confirm ARM64 `docker-build` CI leg passes
- [ ] Confirm first run populates `/var/cache/buildx/spc-bot` on `honk`
- [ ] On next run, confirm Cartopy/arm-pyart show as `CACHED` in build output