### PR TITLE
docs: purge Upstash references from wiki, update to local Redis

### DIFF
--- a/wiki/pages/Getting-Started.md
+++ b/wiki/pages/Getting-Started.md
@@ -7,7 +7,7 @@ SPCBot is designed for flexibility, supporting both containerized and native Lin
 - **Python 3.13+** (matches current production stack).
 - **Discord Bot Token**: Create one at the [Discord Developer Portal](https://discord.com/developers/applications).
 - **Discord Channel IDs**: At minimum, one SPC channel and one model channel.
-- **Upstash Redis** (Optional): Required only for High Availability (Failover).
+- **Redis** (Optional): Required only for High Availability (Failover). A local Redis instance on each node is recommended; no external service is needed.
 - **Syncthing** (Optional): Required for cross-node `events.db` replication.
 
 ## 🐳 Docker Deployment (Recommended)
@@ -60,7 +60,7 @@ Optional production features:
 |---|---|
 | Warning channel split | `WARNINGS_CHANNEL_ID`, `HEALTH_CHANNEL_ID`, `SOUNDING_CHANNEL_ID`, `DEV_CHANNEL_ID` |
 | NWWS-OI fast path | `NWWS_USER`, `NWWS_PASSWORD`, `NWWS_SERVER` |
-| High availability | `IS_PRIMARY`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `ADMIN_USER_ID` |
+| High availability | `IS_PRIMARY`, `ELECTION_REDIS_URL`, `ADMIN_USER_ID` |
 | Events DB sync | `EVENTS_DB_PATH`, `EVENTS_SYNC_DIR`, `SYNCTHING_API_KEY`, `SYNCTHING_FOLDER_ID` |
 | Off-server GIF backups | `RCLONE_REMOTE`, `RCLONE_DEST_DIR` |
 

--- a/wiki/pages/Maintenance-&-Operations.md
+++ b/wiki/pages/Maintenance-&-Operations.md
@@ -46,7 +46,7 @@ Finalized GIFs are uploaded asynchronously after each recording mission. Local f
 
 ### Failover Manual Swap
 If you need to perform maintenance on the Primary node, use `/failover`.
-- The command opens an interactive selector listing active nodes from the Upstash node registry.
+- The command opens an interactive selector listing active nodes from the local Redis node registry.
 - Choosing a node stores a manual primary override for that hostname.
 - Clearing the override returns the pair to automatic lease-based failover.
 
@@ -66,23 +66,14 @@ Symptoms: `/status` shows NWWS disconnected or stale ping/throughput.
 3. Confirm `NWWS_USER`, `NWWS_PASSWORD`, and `NWWS_SERVER` are set correctly.
 4. Keep IEMBot/API polling online as fallback; do not restart both HA nodes at once during active weather.
 
-### Upstash Unavailable
-Symptoms: failover lease warnings, dirty-write reconciliation logs, or standby uncertainty.
+### Redis Unavailable
+Symptoms: failover lease warnings or standby uncertainty in `/logs`.
 
 1. Check `/status` on both nodes and identify which node is posting.
-2. Verify `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`.
-3. Let SQLite mirror continue local durability; dirty writes are replayed when Upstash returns.
-4. Avoid manual role swaps until the lease store recovers unless the current primary is clearly down.
-
-### Upstash Quota Warning
-Symptom: `/logs` shows `WARNING Upstash daily quota warning: X/10000`.
-
-The bot tracks daily Upstash command usage and enforces a soft quota guard:
-- **At 8,000 commands (80%):** A single `WARNING` is logged. The bot continues using Upstash normally — no action is required unless the server is handling an unusually high alert volume.
-- **At 10,000 commands (hard limit):** The bot raises an internal `_UpstashUnavailable` and automatically falls back to SQLite for all state operations. HA heartbeats continue via SQLite — the node does not crash or stop posting.
-- **Reset:** The counter resets daily at UTC midnight. Normal operation resumes automatically on the next Upstash call after midnight.
-
-If quota exhaustion is a recurring pattern, consider whether a runaway loop or unusual traffic spike is inflating command counts.
+2. Verify `ELECTION_REDIS_URL` points to a reachable Redis instance.
+3. Confirm Redis is running: `systemctl status redis` (or `redis-cli ping`).
+4. SQLite continues local durability while Redis is down — the node will not crash or stop posting.
+5. Avoid manual role swaps unless the current primary is clearly down.
 
 ### Split-Brain Suspicion
 Symptoms: both nodes appear to post or both report `PRIMARY`.
@@ -117,7 +108,7 @@ Symptoms: large `cache/`, slow image/radar commands, or filesystem warnings.
 Symptoms: integrity check failures or startup messages about recreating `bot_state.db`.
 
 1. Preserve the `.corrupted` database file for inspection.
-2. Confirm the replacement DB starts and rehydrates from Upstash where available.
+2. Confirm the replacement DB starts cleanly and that Redis replication is still in sync on standby.
 3. For HA setups, verify `events.db` replication before promoting a standby.
 4. If duplicate posts appear, reconcile posted MD/watch/warning state before resuming automation.
 
@@ -125,7 +116,7 @@ Symptoms: integrity check failures or startup messages about recreating `bot_sta
 
 | Path | Purpose | Backup Priority | Safe to Delete? |
 |---|---|---|---|
-| `cache/bot_state.db` | Operational dedupe and bot state mirror. | Medium; Upstash can rehydrate some state. | No, unless intentionally resetting state. |
+| `cache/bot_state.db` | Operational dedupe and bot state mirror. | Medium; Redis replication keeps standby in sync. | No, unless intentionally resetting state. |
 | `cache/events.db` | Historical confirmed tornado and forensics archive. | High. | No. |
 | `cache/event_archive/` | VAD evolution GIF archive. | High if not backed up remotely. | Only after backup/retention decision. |
 | `cache/vad_recordings/` | Temporary active recording missions. | Low after mission finalization. | Old orphaned dirs are pruned automatically. |


### PR DESCRIPTION
## Summary

- **Getting-Started.md**: Updated HA prerequisite from "Upstash Redis" to local Redis; replaced `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` with `ELECTION_REDIS_URL` in the config table
- **Maintenance-&-Operations.md**: Replaced "Upstash node registry" with "local Redis node registry" in the failover section; replaced the "Upstash Unavailable" and "Upstash Quota Warning" runbooks with a single "Redis Unavailable" runbook; removed two stray Upstash references in the SQLite corruption runbook and cache table

## Test plan

- [ ] Verify no `upstash` references remain in wiki pages
- [ ] Confirm `ELECTION_REDIS_URL` is accurate per `.env.example`