### PR TITLE
fix: roll back active_warnings on send failure; replace crude dedup clear with deque

### DIFF
--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -241,7 +241,7 @@ class WarningsCog(commands.Cog):
                 vtec_to_use = vtec or self.bot.state.active_warnings.get(vtec_id)
                 await self._handle_cancellation(vtec_id, reason=reason, vtec=vtec_to_use)
                 self.bot.state.active_warnings.pop(vtec_id, None)
-                self.bot.state.posted_product_ids.add(product_id)
+                self.bot.state.posted_product_ids.append(product_id)
             return
 
         # ── Pipeline fast-path for updates (CON, EXT, EXA) ─────────────────────
@@ -274,7 +274,7 @@ class WarningsCog(commands.Cog):
             # Claim the dedup key BEFORE any awaits so concurrent tasks
             # hitting the same path see the state immediately.
             # For updates, we don't overwrite the dict yet, but we mark the product.
-            self.bot.state.posted_product_ids.add(product_id)
+            self.bot.state.posted_product_ids.append(product_id)
             if not is_update:
                 self.bot.state.posted_warnings[vtec_id] = {}  # placeholder
 
@@ -338,18 +338,24 @@ class WarningsCog(commands.Cog):
                 }
             except discord.Forbidden as e:
                 await self._notify_channel_error(channel, ["send_messages (403 Forbidden)"])
-                if product_id in self.bot.state.posted_product_ids:
-                    self.bot.state.posted_product_ids.discard(product_id)
+                try:
+                    self.bot.state.posted_product_ids.remove(product_id)
+                except ValueError:
+                    pass
                 if not is_update and vtec_id in self.bot.state.posted_warnings:
                     del self.bot.state.posted_warnings[vtec_id]
+                self.bot.state.active_warnings.pop(vtec_id, None)
                 logger.error(f"iembot send forbidden for {vtec_id} in channel {channel.id}: {e}")
                 return
             except discord.HTTPException as e:
                 # Roll back the dedup claim on a hard send failure
-                if product_id in self.bot.state.posted_product_ids:
-                    self.bot.state.posted_product_ids.discard(product_id)
+                try:
+                    self.bot.state.posted_product_ids.remove(product_id)
+                except ValueError:
+                    pass
                 if not is_update and vtec_id in self.bot.state.posted_warnings:
                     del self.bot.state.posted_warnings[vtec_id]
+                self.bot.state.active_warnings.pop(vtec_id, None)
                 logger.exception(
                     f"iembot send failed for {vtec_id}: {e}"
                 )
@@ -366,10 +372,6 @@ class WarningsCog(commands.Cog):
                     tornado_confidence=tornado_confidence,
                     tornado_severity=tornado_severity,
                 )
-                # Keep product IDs pruned to today's set (roughly)
-                if len(self.bot.state.posted_product_ids) > 1000:
-                    # Very crude pruning — ideally we'd use a TTL but this is in-memory
-                    self.bot.state.posted_product_ids.clear()
                 await prune_posted_warnings()
             except Exception as e:
                 logger.warning(f"Failed to persist {vtec_id}: {e}")

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -4,6 +4,7 @@ _tick poll path (disappeared detection, CON area updates, initial discovery)."""
 
 import asyncio
 import json
+from collections import deque
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
@@ -189,7 +190,7 @@ def _make_cog(posted: dict | None = None) -> WarningsCog:
     cog.bot.state.is_primary = True
     cog.bot.state.posted_warnings = posted if posted is not None else {}
     cog.bot.state.active_warnings = {}
-    cog.bot.state.posted_product_ids = set()
+    cog.bot.state.posted_product_ids = deque(maxlen=1000)
     channel = MagicMock()
     channel.send = AsyncMock()
     cog.bot.get_channel = MagicMock(return_value=channel)

--- a/utils/state.py
+++ b/utils/state.py
@@ -84,7 +84,7 @@ class PostingLog:
         # Currently-active VTEC IDs mapping to their latest vtec metadata dict
         self.active_warnings: Dict[str, dict] = {}
         self.posted_reports: Set[str] = set()
-        self.posted_product_ids: Set[str] = set()
+        self.posted_product_ids: deque = deque(maxlen=1000)
 
 
 class TimingTracker:


### PR DESCRIPTION
## Summary

Two related bugs in the warning posting pipeline:

- **Incomplete rollback on send failure**: on `discord.Forbidden` or `discord.HTTPException`, the rollback blocks restored `posted_product_ids` and `posted_warnings` but left `active_warnings[vtec_id]` populated. The stale entry caused a spurious expiry notification on the next 30s poll cycle when the warning no longer appeared in the NWS API response.
- **Blunt dedup clear**: `posted_product_ids` was cleared entirely when it reached 1000 entries, wiping dedup history for ongoing events and causing previously-posted warnings to be reposted. Replaced the plain `set` with `deque(maxlen=1000)` in `PostingLog` so oldest entries evict automatically via FIFO.

## Changes

- `utils/state.py`: `posted_product_ids` changed from `Set[str]` to `deque(maxlen=1000)`
- `cogs/warnings.py`: `.add()` → `.append()` at claim sites; `.discard()` → `try/remove` at rollback sites; `active_warnings.pop(vtec_id, None)` added to both rollback blocks; clear block removed
- `tests/test_warnings.py`: fixture updated to initialize with `deque(maxlen=1000)`

## Test plan

- [ ] 422/422 tests passing
- [ ] Confirm no double-post on concurrent NWWS + IEMBot for same VTEC
- [ ] Confirm no spurious expiry messages after a Discord send error