### PR TITLE
fix: close sounding dedup race in post_soundings_for_watch

### DIFF
--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -698,14 +698,17 @@ class SoundingCog(commands.Cog):
             pkey = f"raob:{sid}:{tkey}"
             if pkey in self._posted_watch_soundings:
                 return None
+            # Claim synchronously before returning so a concurrent task that runs
+            # during the gather's yield points cannot grab the same key.
+            self._posted_watch_soundings.add(pkey)
             return station, sid, y, mo, d, h, tkey, pkey
 
         avail_results = await asyncio.gather(*[_check_avail(s) for s in verified[:3]])
         to_fetch = [r for r in avail_results if r]
 
-        # Claim post keys before launching parallel fetches to prevent double-posts.
+        # Persist keys already claimed in-memory by _check_avail.
         for *_, pkey in to_fetch:
-            await self._mark_sounding_posted(pkey)
+            await add_posted_sounding(pkey)
 
         # ── Phase 1: fetch all sounding data concurrently ─────────────────
         async def _fetch_raob(station, sid, y, mo, d, h, tkey, pkey):


### PR DESCRIPTION
## Summary

`post_soundings_for_watch` used an inner `_check_avail` coroutine that checked whether a pkey was already in `_posted_watch_soundings` but returned the pkey *without claiming it*. All availability checks ran concurrently in `asyncio.gather`, after which pkeys were claimed in a separate loop. A concurrent task (`monitor_special_soundings` or `monitor_high_risk_soundings`) could claim the same pkey during the gather's yield window, but `post_soundings_for_watch` would still post because the pkey was already in `to_fetch`.

The other check-and-claim sites in this file use `await self._mark_sounding_posted()` directly after the check with no intervening yield — those are safe because `_mark_sounding_posted` adds to the set synchronously before its first `await`.

## Changes

- `cogs/sounding.py`: claim `_posted_watch_soundings.add(pkey)` synchronously inside `_check_avail` before returning, closing the race window. Post-gather loop changed to persist-only (`add_posted_sounding`) since the in-memory claim already happened.

## Test plan

- [ ] 422/422 tests passing
- [ ] No duplicate sounding posts during concurrent high-risk + active-watch scenarios