### PR TITLE
fix: guard int() casts in hydration; prune stale watchdog state

### DIFF
--- a/main.py
+++ b/main.py
@@ -450,9 +450,10 @@ async def watchdog_task():
 
     # Prune stale task names from watchdog state (cog reloads can change task names)
     current_names = {name for _, name in current_managed_tasks}
-    _task_alerted &= current_names
-    _task_seen_running &= current_names
-    _task_fail_counts = {k: v for k, v in _task_fail_counts.items() if k in current_names}
+    _task_alerted.intersection_update(current_names)
+    _task_seen_running.intersection_update(current_names)
+    for stale in set(_task_fail_counts) - current_names:
+        del _task_fail_counts[stale]
 
     for task, name in current_managed_tasks:
         if task.is_running():

--- a/main.py
+++ b/main.py
@@ -96,16 +96,22 @@ async def _hydrate_state():
     db_auto, db_manual, db_mds, db_watches, db_reports, csu_raw, d1_urls, d2_urls, d3_urls, last_seq, last_botstalk, db_warnings = results
 
     if isinstance(last_botstalk, str):
-        bot.state.iembot_botstalk_last_seqnum = int(last_botstalk)
-        logger.debug(f"[DB] Restored last botstalk seqnum {last_botstalk}")
+        try:
+            bot.state.iembot_botstalk_last_seqnum = int(last_botstalk)
+            logger.debug(f"[DB] Restored last botstalk seqnum {last_botstalk}")
+        except ValueError:
+            logger.warning(f"[DB] Invalid botstalk seqnum {last_botstalk!r}, resetting to 0")
 
     if isinstance(db_warnings, dict):
         bot.state.posted_warnings.update(db_warnings)
         logger.debug(f"[DB] Restored {len(db_warnings)} posted warnings into cache")
 
     if isinstance(last_seq, str):
-        bot.state.iembot_last_seqnum = int(last_seq)
-        logger.debug(f"[DB] Restored last seqnum {last_seq}")
+        try:
+            bot.state.iembot_last_seqnum = int(last_seq)
+            logger.debug(f"[DB] Restored last seqnum {last_seq}")
+        except ValueError:
+            logger.warning(f"[DB] Invalid iembot seqnum {last_seq!r}, resetting to 0")
 
     if isinstance(db_auto, dict):
         bot.state.auto_cache.update(db_auto)
@@ -441,6 +447,12 @@ async def watchdog_task():
                 task = getattr(cog, task_attr, None)
                 if task and isinstance(task, tasks.Loop):
                     current_managed_tasks.append((task, display_name))
+
+    # Prune stale task names from watchdog state (cog reloads can change task names)
+    current_names = {name for _, name in current_managed_tasks}
+    _task_alerted &= current_names
+    _task_seen_running &= current_names
+    _task_fail_counts = {k: v for k, v in _task_fail_counts.items() if k in current_names}
 
     for task, name in current_managed_tasks:
         if task.is_running():


### PR DESCRIPTION
## Summary

Two defensive hardening fixes in `main.py`:

- **Unguarded `int()` casts** (`_hydrate_state`): bare `int(last_botstalk)` and `int(last_seq)` on DB-sourced strings would raise `ValueError` on any corrupted row, aborting the entire startup hydration sequence before the bot connects to Discord. Wrapped both in `try/except ValueError` with a `logger.warning` and fallback to 0.

- **Watchdog module-level sets grow unbounded**: `_task_alerted`, `_task_seen_running`, and `_task_fail_counts` accumulated task names forever across cog reloads, never pruning stale entries. Added `intersection_update` / key deletion at the top of each watchdog tick to keep them bounded to currently-loaded tasks.

## Changes

- `main.py`: two `try/except ValueError` guards around seqnum casts; four-line prune block after `current_managed_tasks` is built each tick

## Test plan

- [ ] 422/422 tests passing
- [ ] Bot starts clean after restart with valid DB
- [ ] Bot survives startup with a simulated corrupted seqnum value