### PR TITLE
fix: surface silent failures in state_store and db migrations

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -214,18 +214,16 @@ async def _create_tables(db: aiosqlite.Connection):
     """)
 
     # Migrations: add columns if they don't exist
-    try:
-        await db.execute("ALTER TABLE posted_warnings ADD COLUMN area TEXT")
-    except Exception:
-        pass  # already exists
-    try:
-        await db.execute("ALTER TABLE posted_warnings ADD COLUMN tornado_confidence TEXT")
-    except Exception:
-        pass  # already exists
-    try:
-        await db.execute("ALTER TABLE posted_warnings ADD COLUMN tornado_severity TEXT")
-    except Exception:
-        pass  # already exists
+    for col_def in (
+        "ALTER TABLE posted_warnings ADD COLUMN area TEXT",
+        "ALTER TABLE posted_warnings ADD COLUMN tornado_confidence TEXT",
+        "ALTER TABLE posted_warnings ADD COLUMN tornado_severity TEXT",
+    ):
+        try:
+            await db.execute(col_def)
+        except Exception as e:
+            if "duplicate column" not in str(e).lower() and "already exists" not in str(e).lower():
+                logger.error(f"[DB] Migration failed — {col_def!r}: {e}")
 
 
 async def close_db():

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -610,7 +610,8 @@ async def get_all_posted_warnings() -> Dict[str, dict]:
             for vtec_id, json_str in result.items():
                 try:
                     mapping[vtec_id] = json.loads(json_str)
-                except (json.JSONDecodeError, TypeError):
+                except (json.JSONDecodeError, TypeError) as e:
+                    logger.warning(f"[STATE] Corrupt posted_warning entry dropped {vtec_id!r}: {e}")
                     continue
         _cache_set(cache_key, mapping)
         return dict(mapping)
@@ -856,6 +857,8 @@ async def resync_to_redis(force_full: bool = False) -> Dict[str, int]:
             await _replay(item["op"], tuple(item["args"]))
             ids_to_delete.append(item["id"])
         except _RedisUnavailable:
+            remaining = len(pending) - len(ids_to_delete)
+            logger.warning(f"[STATE] Resync paused — Redis unavailable with {remaining} write(s) still pending")
             break
         except Exception as e:
             logger.exception(f"[STATE] Resync dropped {item['op']}: {e}")


### PR DESCRIPTION
## Summary

Three observability fixes that turn silent failures into visible log entries:

- **Corrupt VTEC entry in Redis**: `get_all_posted_warnings()` was silently dropping entries that failed JSON decode with no log output. Now logs at WARNING so Redis memory errors become visible.
- **Resync loop aborts silently**: when `resync_to_redis()` hits `_RedisUnavailable` and breaks, there was no indication of how many writes remained unsynced. Now logs the remaining count before breaking.
- **DB migration swallows all exceptions**: `ALTER TABLE ... ADD COLUMN` was catching all exceptions including real failures. Now only silences "already exists" errors; any other exception is logged at ERROR.

## Changes

- `utils/state_store.py`: `logger.warning` in JSON decode except block; remaining-count log before resync break
- `utils/db.py`: migration loop refactored to distinguish "column already exists" from real errors

## Test plan

- [ ] 422/422 tests passing