### PR TITLE
fix: use upload-artifact@v4 and download-artifact@v4 in docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v4
         with:
           name: digests-${{ strategy.job-index }}
           path: /tmp/digests/*
@@ -83,7 +83,7 @@ jobs:
       contents: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
           pattern: digests-*


### PR DESCRIPTION
PR #394 bumped upload-artifact from @v7 to @v8 to 'align' with download-artifact@v8, but neither v7 nor v8 are real release tags for these actions. This broke the docker-publish workflow on the v5.28.0 tag push. Setting both to @v4, the actual current release.