### PR TITLE
fix: use upload-artifact@v4 in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
             --cov-report=term-missing --cov-report=xml -v
       - name: Upload coverage artifact
         if: always() && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
           path: coverage.xml


### PR DESCRIPTION
Aligns the coverage XML upload in tests.yml to @v4, matching docker-publish.yml after #396. The @v7 tag was never a real release; it was silently passing because nothing downloads this artifact.