### PR TITLE
fix: snapshot posted_warnings in to_dict; remove dead upstash alias

### DIFF
--- a/utils/state.py
+++ b/utils/state.py
@@ -198,7 +198,7 @@ class BotState:
             "manual_cache": self.manual_cache,
             "posted_mds": list(self.posted_mds),
             "posted_watches": list(self.posted_watches),
-            "posted_warnings": self.posted_warnings,
+            "posted_warnings": dict(self.posted_warnings),
             "posted_reports": list(self.posted_reports),
             "posted_product_ids": list(self.posted_product_ids),
             "csu_posted": list(self.csu_posted),

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -871,9 +871,6 @@ async def resync_to_redis(force_full: bool = False) -> Dict[str, int]:
     return {"dirty": len(ids_to_delete)}
 
 
-# Backward-compat alias — callers in failover.py use this name.
-resync_to_upstash = resync_to_redis
-
 
 async def mirror_to_sqlite() -> None:
     """Pull authoritative state from Redis and update the local SQLite mirror.


### PR DESCRIPTION
## Summary

- **`to_dict()` iteration race**: `posted_warnings` was iterated directly in `to_dict()` with no snapshot. A concurrent NWWS ingest adding to the dict could cause `RuntimeError: dictionary changed size during iteration` during failover state serialization. Fixed with `dict(self.posted_warnings)` before returning.
- **Dead `resync_to_upstash` alias**: the backward-compat alias in `state_store.py` had no callers — it was left over from the Upstash → Redis migration. Removed.

## Changes

- `utils/state.py`: `dict()` snapshot in `to_dict()`
- `utils/state_store.py`: removed `resync_to_upstash = resync_to_redis` alias and its comment

## Test plan

- [ ] 422/422 tests passing