### PR TITLE
fix: unpack find_matching_tornado tuple before using as event_id

### DIFF
--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -530,7 +530,7 @@ class ReportsCog(commands.Cog):
                         match_id = await find_matching_tornado(office, ts, location, window_hours=1.0)
                         if match_id:
                             await add_significant_event(
-                                event_id=match_id,
+                                event_id=match_id[0],
                                 event_type="Tornado",
                                 location=location,
                                 magnitude=magnitude,

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -418,7 +418,7 @@ class WarningsCog(commands.Cog):
                 source=office,
                 raw_text=raw_text
             )
-            logger.info(f"Logged confirmed tornado for {vtec_id} (match: {match_id is not None})")
+            logger.info(f"Logged confirmed tornado for {vtec_id} (match: {match is not None})")
 
             # 2. Trigger VAD Recorder mission
             try:

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -404,9 +404,9 @@ class WarningsCog(commands.Cog):
 
             office = vtec.get("office", "NWS")
             from utils.state_store import find_matching_tornado
-            match_id = await find_matching_tornado(office, time.time(), location, window_hours=1.0)
+            match = await find_matching_tornado(office, time.time(), location, window_hours=1.0)
 
-            event_id = match_id if match_id else f"NWS:WARN:{vtec_id}"
+            event_id = match[0] if match else f"NWS:WARN:{vtec_id}"
 
             await add_significant_event(
                 event_id=event_id,


### PR DESCRIPTION
## Summary

- `find_matching_tornado` returns `Optional[Tuple[str, Optional[str]]]` — an `(event_id, vtec_id)` pair
- Two call sites were passing the whole tuple as `event_id` to `add_significant_event`, causing SQLite to fail with `type 'tuple' is not supported` on every matched tornado/LSR
- Significant events were still posted to Discord; only database logging was silently broken

## Affected sites

- `cogs/warnings.py` — confirmed tornado handler after NWS warning match
- `cogs/reports.py` — GeoJSON LSR fast-path dedup handler

`cogs/reports.py:151-153` already unpacks correctly and was not touched.

## Test plan

- [x] All 422 tests pass (verified via pre-push hook)
- [ ] Verify no `add_significant_event(...) failed: type 'tuple' is not supported` warnings in logs during next active warning event