### PR TITLE
chore: release v5.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.28.1] — 2026-05-19
+
+### Fixed
+- **`add_significant_event` received a tuple instead of `event_id` string.** Two call sites passed the raw `find_matching_tornado` return value (an `(event_id, vtec_id)` tuple) directly as `event_id`, causing SQLite to fail with `type 'tuple' is not supported` on every matched tornado warning and LSR. Significant events were still posted to Discord; only database logging was broken. (#410)
+- **`posted_warnings` not snapshotted in `to_dict`.** State serialization omitted `posted_warnings`, so any warnings posted since the last Redis sync were lost across restarts or failover. (#400)
+- **Dead `upstash` alias removed from state store.** Leftover `upstash` import alias was referenced nowhere and caused a lint warning. (#400)
+- **`_promote`/`_demote` not serialized under a lock.** Concurrent promotion and demotion calls could race on shared state. Both methods now acquire the failover lock before executing. (#398)
+- **Unhandled `SystemExit` on cog unload failure.** A failing cog unload previously swallowed the exit, leaving the process in a degraded state. Now calls `os._exit(1)` to force a clean restart. (#398)
+- **RwLock `.unwrap()` panics in Rust extension.** Several `RwLock` acquire sites used `.unwrap()`, which could panic on a poisoned lock and kill the process. Replaced with proper `PyErr` conversion so Python sees a recoverable exception. (#399)
+- **`upload-artifact` version mismatch in `tests.yml`.** CI used `upload-artifact@v4` in `tests.yml` while `docker-publish.yml` had been aligned to `@v8`; aligned to `@v4` across both files. (#397)
+
 ## [5.28.0] — 2026-05-18
 
 ### Fixed

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ log_cli = false
 log_level = WARNING
 markers =
     real_create_task: opt out of global asyncio.create_task suppression (for tests that exercise internal task-based concurrency like fetch_md_details)
+addopts = --ignore-glob=*sync-conflict*
 filterwarnings =
     ignore::DeprecationWarning:discord.*
     ignore::DeprecationWarning:aiohttp.*

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,7 +4,7 @@
 line-length = 100
 
 # lib/vad_plotter is vendored third-party code. Not ours, not linted.
-extend-exclude = ["lib", "venv", ".venv", "docs"]
+extend-exclude = ["lib", "venv", ".venv", "docs", "*sync-conflict*"]
 
 [lint]
 # Per-iteration try/except in loops is deliberate error isolation


### PR DESCRIPTION
Bump CHANGELOG for v5.28.1 and exclude Syncthing conflict files from ruff/pytest.

## What's in this release

- fix: unpack find_matching_tornado tuple before using as event_id (#410)
- fix: snapshot posted_warnings in to_dict; remove dead upstash alias (#400)
- fix: serialize _promote/_demote with a lock; force exit on unload failure (#398)
- fix: replace RwLock .unwrap() with PyErr on poisoned lock (#399)
- fix: use upload-artifact@v4 in tests.yml (#397)
- chore: exclude Syncthing conflict files from ruff and pytest