### PR TITLE
feat: state encapsulation, failover hardening, and observability metrics

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -1,0 +1,12 @@
+// Sync Claude/Gemini context files, progress.md, and project Claude config
+!progress.md
+!CLAUDE.md
+!GEMINI.md
+!.claude
+!.claude/settings.json
+!.claude/settings.local.json
+!.claude/skills
+!.claude/skills/**
+!.claude/agent-memory
+!.claude/agent-memory/**
+*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Failover & Sync Observability.** Added counters for failover transitions, lease renewals, and sync failures to `BotState`. These are now displayed in the `/status` command under the Cluster Status section to provide better visibility into the health of the high-availability mechanism.
+- **`posted_product_ids` Persistence.** The cross-feed deduplication state (`posted_product_ids`) is now persisted to Redis and SQLite. This ensures that failovers or restarts no longer reset the dedup history, preventing duplicate posts from concurrent NWWS and IEM feeds during transitions.
+
+### Fixed
+- **Unbounded Redis State Growth.** Fixed several state pruning functions (`prune_posted_warnings`, `prune_posted_mds`, etc.) to explicitly remove stale entries from Redis. Previously, these only cleaned up the local SQLite mirror, leading to indefinite memory and storage growth in the shared Redis instance.
+- **Failover Promotion Race & Partial Load.** Implemented transactional promotion in `FailoverCog`. If any extension fails to load during promotion to Primary, the bot now performs a full rollback (unloading successfully loaded cogs) and demotes itself back to Standby. This prevents the bot from entering a "partial Primary" state where only some alerting feeds are active.
+- **Concurrent Mutability in `to_dict()`.** Wrapped dictionary and set iterations in `BotState.to_dict()` with `.copy()` and `list()` to prevent `RuntimeError: dictionary changed size during iteration` when the state is serialized for metrics or failover sync while background tasks are updating it.
+- **`prune_posted_mds` Random Eviction.** Fixed a bug where MDs were being randomly evicted from Redis instead of the oldest ones. Eviction now uses the authoritative ordered list from SQLite.
+
+### Refactored
+- **State Encapsulation.** Refactored `BotState` from a passive data structure into an active state manager. Moved dual-write logic (memory + persistence) into `async` methods in `BotState` (e.g., `add_posted_warning()`). This ensures consistency and simplifies cog logic by removing the burden of manual persistence calls.
+
 ## [5.28.2] — 2026-05-19
 
 ### Changed

--- a/cogs/csu_mlp.py
+++ b/cogs/csu_mlp.py
@@ -1,6 +1,5 @@
 # cogs/csu_mlp.py
 import asyncio
-import json
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -14,7 +13,7 @@ from utils.cache import (
     download_single_image,
 )
 from utils.http import ensure_session
-from utils.state_store import get_state, set_state
+from utils.state_store import set_state
 
 logger = logging.getLogger("spc_bot.csu_mlp")
 
@@ -123,29 +122,6 @@ async def _resolve_best_url(day: int, force_hour: str | None = None, allow_yeste
     logger.warning(f"Day {day}: no recent URL available")
     return None, ""
 
-
-
-async def _load_posted_today() -> set:
-    """Load posted days for today from DB. Returns empty set if stale or missing."""
-    try:
-        raw = await get_state("csu_mlp_posted")
-        if raw:
-            data = json.loads(raw)
-            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            if data.get("date") == today:
-                return set(data.get("days", []))
-    except Exception as e:
-        logger.warning(f"[CSU-MLP] Failed to load posted state: {e}")
-    return set()
-
-async def _save_posted_today(posted: set):
-    """Persist posted days for today to DB."""
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    value = json.dumps({"date": today, "days": sorted(posted, key=str)})
-    try:
-        await set_state("csu_mlp_posted", value)
-    except Exception as e:
-        logger.warning(f"[CSU-MLP] Failed to save posted state: {e}")
 
 # Per-day first-seen timestamps; purely diagnostic.
 _availability_log: dict[int, str] = {}
@@ -262,12 +238,6 @@ class CSUMLPCog(commands.Cog):
         if not self.bot.state.is_primary:
             return
 
-        # Hydrate from DB if memory is empty
-        if not self.bot.state.csu_posted:
-            db_posted = await _load_posted_today()
-            if db_posted:
-                self.bot.state.csu_posted.update(str(d) for d in db_posted)
-
         now_utc = datetime.now(timezone.utc)
         today_str = now_utc.strftime("%Y-%m-%d")
 
@@ -278,7 +248,8 @@ class CSUMLPCog(commands.Cog):
                 logger.info("Resetting daily posted state")
                 self.bot.state.csu_posted.clear()
                 _availability_log.clear()
-                await _save_posted_today(self.bot.state.csu_posted)
+                # Use BotState method or manual persistence for reset
+                await set_state("csu_mlp_posted", "") 
             self._last_reset_date = today_str
 
         # Only poll 16-23 UTC
@@ -345,8 +316,7 @@ class CSUMLPCog(commands.Cog):
                         else:
                             raise
 
-                self.bot.state.csu_posted.add(str(day))
-                await _save_posted_today(self.bot.state.csu_posted)
+                await self.bot.state.add_csu_posted(str(day))
                 self.bot.state.last_post_times[f"csu_day{day}"] = now_utc
                 logger.info(f"Auto-posted Day {day} ({label})")
 
@@ -391,8 +361,7 @@ class CSUMLPCog(commands.Cog):
                         else:
                             raise
 
-                self.bot.state.csu_posted.add(state_key)
-                await _save_posted_today(self.bot.state.csu_posted)
+                await self.bot.state.add_csu_posted(state_key)
                 self.bot.state.last_post_times[f"csu_{state_key}"] = now_utc
                 logger.info(f"Auto-posted {label_name} ({label})")
 

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -340,7 +340,9 @@ class FailoverCog(commands.Cog):
         if holder is not None:
             # We hold the lease — renew conditionally.
             renewed = await self._renew_lease()
-            if not renewed:
+            if renewed:
+                self.bot.state.lease_renewals += 1
+            else:
                 # Lost the lease between read and renew — re-check and demote.
                 new_holder = await self._read_lease_holder()
                 if new_holder and new_holder != self._identity:
@@ -421,6 +423,7 @@ class FailoverCog(commands.Cog):
     async def _do_promote(self) -> None:
         logger.warning("[FAILOVER] !!! PROMOTING TO PRIMARY !!!")
         self.bot.state.is_primary = True
+        self.bot.state.failover_count += 1
         # Update identity so the next heartbeat HSET announces us as Primary ("P:").
         self._identity = _node_identity(True)
         await self._cleanup_own_stale_entries()
@@ -474,12 +477,25 @@ class FailoverCog(commands.Cog):
             except Exception as alert_err:
                 logger.warning(f"[FAILOVER] Could not send resync-failure alert: {alert_err}")
 
+        # ── Extension Loading (Transactional) ───────────────────────────────
+        loaded_exts = []
         for ext in ALL_EXTENSIONS:
             try:
                 await self.bot.load_extension(ext)
+                loaded_exts.append(ext)
                 logger.info(f"[FAILOVER] Loaded {ext}")
             except Exception as e:
-                logger.exception(f"[FAILOVER] Failed to load {ext}: {e}")
+                logger.exception(f"[FAILOVER] Failed to load {ext}: {e} - Rolling back promotion.")
+                # Rollback: unload what we just loaded
+                for loaded in reversed(loaded_exts):
+                    try:
+                        await self.bot.unload_extension(loaded)
+                    except Exception as rollback_err:
+                        logger.error(f"[FAILOVER] Rollback failure on {loaded}: {rollback_err}")
+                
+                # Signal demotion and exit
+                await self._demote()
+                return
 
         nwws = self.bot.get_cog("NWWSCog")
         if nwws:
@@ -498,6 +514,9 @@ class FailoverCog(commands.Cog):
         st.posted_mds = await state_store.get_posted_mds()
         st.posted_watches = await state_store.get_posted_watches()
         st.posted_reports = await state_store.get_posted_reports()
+        st.posted_product_ids.extend(await state_store.get_posted_product_ids())
+        st.posted_soundings = await state_store.get_posted_soundings()
+        st.sounding_handled_watches = await state_store.get_sounding_handled_watches()
 
         last_seq = await state_store.get_state("iembot_last_seqnum")
         if isinstance(last_seq, str) and last_seq.isdigit():

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -19,7 +19,7 @@ from utils.cache import (
 )
 from utils.change_detection import get_cache_path_for_url
 from utils.http import http_get_bytes, http_get_text, http_head_meta
-from utils.state_store import add_posted_md, get_state, prune_posted_mds, set_state
+from utils.state_store import get_state, set_state
 
 logger = logging.getLogger("spc_bot.mesoscale")
 
@@ -628,7 +628,7 @@ class MesoscaleCog(commands.Cog):
         try:
             msg = await channel.send(embeds=[img_embed, text_embed], files=files)
             self.bot.state.active_mds.add(md_num)
-            await add_posted_md(str(md_num))
+            await self.bot.state.add_posted_md(str(md_num))
             self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
             if not cache_path or not full_text:
                 t = asyncio.create_task(self._upgrade_md_message(md_num, msg, full_text))
@@ -762,9 +762,7 @@ class MesoscaleCog(commands.Cog):
                     # Track in active_mds after a successful post regardless of source —
                     # we genuinely just announced this MD and need to cancel it later.
                     self.bot.state.active_mds.add(md_num)
-                    self.bot.state.posted_mds.add(md_num)
-                    await add_posted_md(str(md_num))
-                    await prune_posted_mds()
+                    await self.bot.state.add_posted_md(str(md_num))
                     self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
                     logger.info(f"Posted MD #{md_num}")
                 except Exception as e:

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -11,12 +11,8 @@ from discord.ext import commands, tasks
 from config import WARNINGS_CHANNEL_ID
 from utils.http import http_get_bytes
 from utils.state_store import (
-    add_posted_report,
-    add_posted_survey,
     add_significant_event,
     get_posted_surveys,
-    prune_posted_reports,
-    prune_posted_surveys,
 )
 
 logger = logging.getLogger("spc_bot")
@@ -199,9 +195,7 @@ class ReportsCog(commands.Cog):
             embed.set_footer(text=f"{office} LSR | {coords}")
 
             # --- Persist State Before Sending ---
-            self.bot.state.posted_reports.add(product_id)
-            await add_posted_report(product_id)
-            await prune_posted_reports()
+            await self.bot.state.add_posted_report(product_id)
 
             # Log significant events to DB
             event_upper = event_type.upper()
@@ -301,9 +295,7 @@ class ReportsCog(commands.Cog):
 
         await channel.send(embed=embed, view=view)
 
-        self.bot.state.posted_reports.add(product_id)
-        await add_posted_report(product_id)
-        await prune_posted_reports()
+        await self.bot.state.add_posted_report(product_id)
 
         # --- DB Logging & Matching ---
         # Try to find a date in the text to poll for Autoplot 253 tracks.
@@ -454,9 +446,7 @@ class ReportsCog(commands.Cog):
                 embed.set_footer(text=f"{source_text} | {guid}")
 
                 await channel.send(embed=embed, file=file_to_send)
-                self.posted_surveys.add(guid)
-                await add_posted_survey(guid)
-                await prune_posted_surveys()
+                await self.bot.state.add_posted_survey(guid)
                 logger.info(f"[REPORTS] Posted survey map for {guid} ({label}) via {source_text}")
 
                 # Link DAT guid to tornado and cache photos
@@ -540,8 +530,7 @@ class ReportsCog(commands.Cog):
                                 raw_text=props.get("remark"),
                             )
                             logger.debug(f"[REPORTS] Updated location for {match_id} → {location!r}")
-                            self.bot.state.posted_reports.add(pid)
-                            await add_posted_report(pid)
+                            await self.bot.state.add_posted_report(pid)
                             continue
 
                         await add_significant_event(
@@ -555,9 +544,7 @@ class ReportsCog(commands.Cog):
                             raw_text=props.get("remark"),
                         )
                         # Persist dedup
-                        self.bot.state.posted_reports.add(pid)
-                        await add_posted_report(pid)
-                        await prune_posted_reports()
+                        await self.bot.state.add_posted_report(pid)
 
         except Exception as e:
             logger.warning(f"[REPORTS] LSR poll failed: {e}")

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -39,8 +39,6 @@ from config import CACHE_DIR, SOUNDING_CHANNEL_ID
 from utils.db import get_watch_centroid_cache, set_watch_centroid_cache
 from utils.spc_outlook import get_high_risk_polygon, is_inside_polygon
 from utils.state_store import (
-    add_posted_sounding,
-    add_sounding_handled_watch,
     clear_sounding_handled_watches,
     get_posted_soundings,
     get_sounding_handled_watches,
@@ -70,12 +68,6 @@ class SoundingCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        # Keys are "raob:{sid}:{time_key}" or "acars:{airport}:{time_key}" —
-        # deliberately NOT scoped by watch_num. Two geographically-overlapping
-        # watches (e.g. a TOR and SVR covering the same area) would otherwise
-        # each trigger a post of the same station at the same valid time.
-        self._posted_watch_soundings: set = set()
-        self._handled_watches: set = set()
         # Memoized watch_num → (lat, lon). Centroid resolution is an async
         # fetch over NWS zone geometry; caching avoids N re-fetches when
         # building captions that consider every active watch.
@@ -135,13 +127,11 @@ class SoundingCog(commands.Cog):
 
     async def _mark_sounding_posted(self, pkey: str):
         """Mark a sounding as posted in memory and persistent store."""
-        self._posted_watch_soundings.add(pkey)
-        await add_posted_sounding(pkey)
+        await self.bot.state.add_posted_sounding(pkey)
 
     async def _mark_watch_handled(self, watch_num: str):
         """Mark a watch as having soundings handled in memory and persistent store."""
-        self._handled_watches.add(watch_num)
-        await add_sounding_handled_watch(watch_num)
+        await self.bot.state.add_sounding_handled_watch(watch_num)
 
     async def _resolve_watch_centroid(
         self, watch_num: str, info: dict
@@ -275,7 +265,7 @@ class SoundingCog(commands.Cog):
             for y, mo, d, h in avail:
                 tkey = f"{y}-{mo}-{d}_{h}z"
                 pkey = f"raob:{sid}:{tkey}"
-                if pkey not in self._posted_watch_soundings:
+                if pkey not in self.bot.state.posted_soundings:
                     await self._mark_sounding_posted(pkey)
                     to_post.append((station_info, sid, y, mo, d, h, tkey, pkey))
             return to_post
@@ -461,7 +451,7 @@ class SoundingCog(commands.Cog):
             for y, mo, d, h in avail:
                 tkey = f"{y}-{mo}-{d}_{h}z"
                 pkey = f"raob:{sid}:{tkey}"
-                if pkey not in self._posted_watch_soundings:
+                if pkey not in self.bot.state.posted_soundings:
                     await self._mark_sounding_posted(pkey)
                     new_times.append((station, sid, y, mo, d, h, tkey, pkey))
             return new_times
@@ -542,7 +532,7 @@ class SoundingCog(commands.Cog):
         acars_to_post = []
         for p in acars_in_poly:
             pkey = p.get("pkey")
-            if pkey and pkey not in self._posted_watch_soundings:
+            if pkey and pkey not in self.bot.state.posted_soundings:
                 await self._mark_sounding_posted(pkey)
                 acars_to_post.append(p)
 
@@ -655,7 +645,7 @@ class SoundingCog(commands.Cog):
         time (any hour, not locked to 00z/12z), posts up to 3 RAOB + 2 ACARS.
         """
         await self._ensure_restored()
-        if watch_num in self._handled_watches:
+        if watch_num in self.bot.state.sounding_handled_watches:
             return
 
         # Use SOUNDING_CHANNEL_ID if configured, fallback to passed channel
@@ -696,11 +686,11 @@ class SoundingCog(commands.Cog):
             y, mo, d, h = avail[0]
             tkey = f"{y}-{mo}-{d}_{h}z"
             pkey = f"raob:{sid}:{tkey}"
-            if pkey in self._posted_watch_soundings:
+            if pkey in self.bot.state.posted_soundings:
                 return None
             # Claim synchronously before returning so a concurrent task that runs
             # during the gather's yield points cannot grab the same key.
-            self._posted_watch_soundings.add(pkey)
+            self.bot.state.posted_soundings.add(pkey)
             return station, sid, y, mo, d, h, tkey, pkey
 
         avail_results = await asyncio.gather(*[_check_avail(s) for s in verified[:3]])
@@ -708,7 +698,7 @@ class SoundingCog(commands.Cog):
 
         # Persist keys already claimed in-memory by _check_avail.
         for *_, pkey in to_fetch:
-            await add_posted_sounding(pkey)
+            await self.bot.state.add_posted_sounding(pkey)
 
         # ── Phase 1: fetch all sounding data concurrently ─────────────────
         async def _fetch_raob(station, sid, y, mo, d, h, tkey, pkey):
@@ -763,7 +753,7 @@ class SoundingCog(commands.Cog):
         acars_eligible = []
         for profile in acars_profiles[:2]:
             pkey = profile.get("pkey")
-            if pkey and pkey not in self._posted_watch_soundings:
+            if pkey and pkey not in self.bot.state.posted_soundings:
                 await self._mark_sounding_posted(pkey)
                 acars_eligible.append(profile)
 
@@ -879,10 +869,11 @@ class SoundingCog(commands.Cog):
             eligible = []
             for station in verified[:3]:
                 station_id = station.get("icao") or station.get("wmo")
-                post_key = f"raob:{station_id}:{time_key}"
-                if post_key not in self._posted_watch_soundings:
-                    await self._mark_sounding_posted(post_key)
+                pkey = f"raob:{station_id}:{time_key}"
+                if pkey not in self.bot.state.posted_soundings:
+                    await self._mark_sounding_posted(pkey)
                     eligible.append((station, station_id))
+
 
             # ── Phase 1: fetch all RAOB data concurrently ─────────────────
             async def _fetch_std(station, sid):
@@ -941,7 +932,7 @@ class SoundingCog(commands.Cog):
             acars_eligible2 = []
             for profile in acars_profiles[:2]:
                 pkey = profile.get("pkey")
-                if pkey and pkey not in self._posted_watch_soundings:
+                if pkey and pkey not in self.bot.state.posted_soundings:
                     await self._mark_sounding_posted(pkey)
                     acars_eligible2.append(profile)
 

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -251,7 +251,22 @@ class StatusView(discord.ui.View):
                 except (ValueError, IndexError):
                     lines.append(f"`{identity}` *(parse error)*")
 
-            return "\n".join(lines) if lines else "*(Unable to parse node data)*"
+            status_text = "\n".join(lines) if lines else "*(Unable to parse node data)*"
+            
+            # Add failover stats for the current node
+            st = self.bot.state
+            stats = []
+            if st.failover_count > 0:
+                stats.append(f"Failovers: `{st.failover_count}`")
+            if st.lease_renewals > 0:
+                stats.append(f"Renewals: `{st.lease_renewals}`")
+            if st.sync_failures > 0:
+                stats.append(f"Sync Errs: `{st.sync_failures}`")
+                
+            if stats:
+                status_text += "\n" + " | ".join(stats)
+                
+            return status_text
         except Exception as e:
             logger.debug(f"Could not fetch cluster status: {e}")
             return f"*(Redis unavailable)*"

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -54,11 +54,9 @@ from lib.vtec_parser import get_polygon_centroid, parse_vtec, parse_warning_poly
 from utils.backoff import TaskBackoff
 from utils.http import http_get_bytes, http_get_bytes_conditional
 from utils.state_store import (
-    add_posted_warning,
     add_significant_event,
     get_recent_significant_events,
     get_state,
-    prune_posted_warnings,
 )
 
 logger = logging.getLogger("spc_bot.warnings")
@@ -241,7 +239,7 @@ class WarningsCog(commands.Cog):
                 vtec_to_use = vtec or self.bot.state.active_warnings.get(vtec_id)
                 await self._handle_cancellation(vtec_id, reason=reason, vtec=vtec_to_use)
                 self.bot.state.active_warnings.pop(vtec_id, None)
-                self.bot.state.posted_product_ids.append(product_id)
+                await self.bot.state.add_posted_product_id(product_id)
             return
 
         # ── Pipeline fast-path for updates (CON, EXT, EXA) ─────────────────────
@@ -274,9 +272,11 @@ class WarningsCog(commands.Cog):
             # Claim the dedup key BEFORE any awaits so concurrent tasks
             # hitting the same path see the state immediately.
             # For updates, we don't overwrite the dict yet, but we mark the product.
-            self.bot.state.posted_product_ids.append(product_id)
+            await self.bot.state.add_posted_product_id(product_id)
             if not is_update:
-                self.bot.state.posted_warnings[vtec_id] = {}  # placeholder
+                # We still need a placeholder in memory to prevent concurrent races 
+                # before the message is actually sent.
+                self.bot.state.posted_warnings[vtec_id] = {} 
 
             self.bot.state.active_warnings[vtec_id] = vtec
 
@@ -331,11 +331,16 @@ class WarningsCog(commands.Cog):
                 area_m = re.search(r"for (.+?) till", concise_text)
                 area_desc = area_m.group(1) if area_m else "affected area"
 
-                self.bot.state.posted_warnings[vtec_id] = {
-                    "message_id": msg.id,
-                    "channel_id": msg.channel.id,
-                    "area": area_desc,
-                }
+                tornado_confidence, tornado_severity = get_tornado_attributes(event, raw_text)
+                await self.bot.state.add_posted_warning(
+                    vtec_id,
+                    msg.id,
+                    msg.channel.id,
+                    time.time(),
+                    area=area_desc,
+                    tornado_confidence=tornado_confidence,
+                    tornado_severity=tornado_severity,
+                )
             except discord.Forbidden as e:
                 await self._notify_channel_error(channel, ["send_messages (403 Forbidden)"])
                 try:
@@ -360,21 +365,6 @@ class WarningsCog(commands.Cog):
                     f"iembot send failed for {vtec_id}: {e}"
                 )
                 return
-
-            try:
-                tornado_confidence, tornado_severity = get_tornado_attributes(event, raw_text)
-                await add_posted_warning(
-                    vtec_id,
-                    msg.id,
-                    msg.channel.id,
-                    time.time(),
-                    area=area_desc,
-                    tornado_confidence=tornado_confidence,
-                    tornado_severity=tornado_severity,
-                )
-                await prune_posted_warnings()
-            except Exception as e:
-                logger.warning(f"Failed to persist {vtec_id}: {e}")
         finally:
             self._in_flight_vtecs.discard(vtec_id)
 
@@ -755,11 +745,10 @@ class WarningsCog(commands.Cog):
                                     logger.exception(f"Update send failed for {issuance_id}: {e}")
 
                                 # Update stored area so we don't spam updates for every poll
-                                self.bot.state.posted_warnings[issuance_id]["area"] = curr_area
                                 description = props.description or ""
                                 params = props.parameters.model_dump() if props.parameters else {}
                                 tornado_confidence, tornado_severity = get_tornado_attributes(event, description, params)
-                                await add_posted_warning(
+                                await self.bot.state.add_posted_warning(
                                     issuance_id,
                                     stored_info["message_id"],
                                     stored_info["channel_id"],
@@ -805,16 +794,11 @@ class WarningsCog(commands.Cog):
                     continue
 
                 self.bot.state.active_warnings[issuance_id] = vtec_dict
-                self.bot.state.posted_warnings[issuance_id] = {
-                    "message_id": msg.id,
-                    "channel_id": msg.channel.id,
-                    "area": area_desc,
-                }
                 try:
                     description = props.description or ""
                     params = props.parameters.model_dump() if props.parameters else {}
                     tornado_confidence, tornado_severity = get_tornado_attributes(event, description, params)
-                    await add_posted_warning(
+                    await self.bot.state.add_posted_warning(
                         issuance_id,
                         msg.id,
                         msg.channel.id,
@@ -823,7 +807,6 @@ class WarningsCog(commands.Cog):
                         tornado_confidence=tornado_confidence,
                         tornado_severity=tornado_severity,
                     )
-                    await prune_posted_warnings()
                 except Exception as e:
                     logger.warning(
                         f"Failed to persist {issuance_id}: {e}"

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -25,10 +25,6 @@ from utils.cache import (
 )
 from utils.change_detection import get_cache_path_for_url, is_placeholder_image
 from utils.http import http_get_bytes
-from utils.state_store import (
-    add_posted_watch,
-    prune_posted_watches,
-)
 
 logger = logging.getLogger("spc_bot")
 
@@ -374,9 +370,7 @@ class WatchesCog(commands.Cog):
             # populate it with real expiry/zone data on the next cycle.
             # Adding partial nws_info now causes false cancellations when
             # the NWS API hasn't indexed the watch yet.
-            self.bot.state.posted_watches.add(watch_num)
-            await add_posted_watch(str(watch_num))
-            await prune_posted_watches()
+            await self.bot.state.add_posted_watch(str(watch_num))
             self.bot.state.last_post_times["watch"] = now_utc
             logger.info(f"iembot-triggered: posted watch #{watch_num}")
             sounding_cog = self.bot.cogs.get("SoundingCog")
@@ -522,9 +516,7 @@ class WatchesCog(commands.Cog):
                 try:
                     files = _watch_files(watch_num, cache_path)
                     message = await channel.send(embed=embed, files=files)
-                    self.bot.state.posted_watches.add(watch_num)
-                    await add_posted_watch(str(watch_num))
-                    await prune_posted_watches()
+                    await self.bot.state.add_posted_watch(str(watch_num))
                     self.bot.state.last_post_times["watch"] = datetime.now(timezone.utc)
                     logger.info(f"Posted watch #{watch_num}")
                     sounding_cog = self.bot.cogs.get("SoundingCog")

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from utils.state_store import (
     check_integrity, close_db, get_db,
     get_all_hashes, get_posted_urls, get_posted_mds, get_posted_watches,
     get_posted_reports, get_all_posted_warnings,
+    get_posted_product_ids, get_posted_soundings, get_sounding_handled_watches,
     get_state,
 )
 from utils.cache import hydrate_validators_from_store
@@ -90,10 +91,25 @@ async def _hydrate_state():
         get_state("iembot_last_seqnum"),
         get_state("iembot_botstalk_last_seqnum"),
         get_all_posted_warnings(),
+        get_posted_product_ids(),
+        get_posted_soundings(),
+        get_sounding_handled_watches(),
         return_exceptions=True
     )
     
-    db_auto, db_manual, db_mds, db_watches, db_reports, csu_raw, d1_urls, d2_urls, d3_urls, last_seq, last_botstalk, db_warnings = results
+    db_auto, db_manual, db_mds, db_watches, db_reports, csu_raw, d1_urls, d2_urls, d3_urls, last_seq, last_botstalk, db_warnings, db_product_ids, db_soundings, db_handled_watches = results
+
+    if isinstance(db_product_ids, (set, list)):
+        bot.state.posted_product_ids.extend(db_product_ids)
+        logger.debug(f"[DB] Restored {len(db_product_ids)} posted product IDs")
+
+    if isinstance(db_soundings, (set, list)):
+        bot.state.posted_soundings.update(db_soundings)
+        logger.debug(f"[DB] Restored {len(db_soundings)} posted soundings")
+
+    if isinstance(db_handled_watches, (set, list)):
+        bot.state.sounding_handled_watches.update(db_handled_watches)
+        logger.debug(f"[DB] Restored {len(db_handled_watches)} sounding-handled watches")
 
     if isinstance(last_botstalk, str):
         try:

--- a/tests/test_iem_races.py
+++ b/tests/test_iem_races.py
@@ -5,6 +5,7 @@ and the watch-triggered sounding auto-post.
 """
 
 import asyncio
+from collections import deque
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -114,6 +115,13 @@ class TestPostSoundingsForWatch:
         bot = MagicMock()
         bot.state = MagicMock()
         bot.state.active_watches = {}
+        bot.state.posted_soundings = set()
+        bot.state.sounding_handled_watches = set()
+        bot.state.posted_product_ids = deque(maxlen=1000)
+        bot.state.add_posted_watch = AsyncMock()
+        bot.state.add_posted_sounding = AsyncMock()
+        bot.state.add_sounding_handled_watch = AsyncMock()
+        bot.state.add_posted_product_id = AsyncMock()
         # Use a real dict for cogs so .get() works normally
         bot.cogs = {}
         return bot
@@ -126,8 +134,8 @@ class TestPostSoundingsForWatch:
         bot = self._make_bot()
         cog = SoundingCog.__new__(SoundingCog)
         cog.bot = bot
-        cog._posted_watch_soundings = set()
-        cog._handled_watches = set()
+        cog.bot.state.posted_soundings = set()
+        cog.bot.state.sounding_handled_watches = set()
         cog._restore_attempted = True
 
         channel = AsyncMock()
@@ -144,8 +152,8 @@ class TestPostSoundingsForWatch:
         bot = self._make_bot()
         cog = SoundingCog.__new__(SoundingCog)
         cog.bot = bot
-        cog._posted_watch_soundings = set()
-        cog._handled_watches = set()
+        cog.bot.state.posted_soundings = set()
+        cog.bot.state.sounding_handled_watches = set()
         cog._restore_attempted = True
 
         channel = AsyncMock()
@@ -179,9 +187,7 @@ class TestPostSoundingsForWatch:
 
         with patch("cogs.watches.fetch_active_watches_nws", new=AsyncMock(return_value=nws_result)), \
              patch("cogs.watches.fetch_watch_details", new=AsyncMock(return_value=(None, None, None))), \
-             patch("cogs.watches.download_single_image", new=AsyncMock(return_value=(None, False, None))), \
-             patch("cogs.watches.add_posted_watch", new=AsyncMock()), \
-             patch("cogs.watches.prune_posted_watches", new=AsyncMock()):
+             patch("cogs.watches.download_single_image", new=AsyncMock(return_value=(None, False, None))):
 
             cog = WatchesCog(bot)
             cog.auto_post_watches.cancel()
@@ -211,10 +217,12 @@ class TestSoundingDedupAcrossWatches:
         from cogs.sounding import SoundingCog
         bot = MagicMock()
         bot.state = MagicMock()
+        bot.state.posted_soundings = set()
+        bot.state.sounding_handled_watches = set()
+        bot.state.add_posted_sounding = AsyncMock()
+        bot.state.add_sounding_handled_watch = AsyncMock()
         cog = SoundingCog.__new__(SoundingCog)
         cog.bot = bot
-        cog._posted_watch_soundings = set()
-        cog._handled_watches = set()
         cog._restore_attempted = True
         return cog
 
@@ -225,12 +233,12 @@ class TestSoundingDedupAcrossWatches:
 
         # Watch #0134 (TOR) processes KOAX first
         key_a = f"raob:KOAX:{time_key}"
-        assert key_a not in cog._posted_watch_soundings
-        cog._posted_watch_soundings.add(key_a)
+        assert key_a not in cog.bot.state.posted_soundings
+        cog.bot.state.posted_soundings.add(key_a)
 
         # Watch #0135 (SVR) in an overlapping region finds KOAX too
         key_b = f"raob:KOAX:{time_key}"
-        assert key_b in cog._posted_watch_soundings, (
+        assert key_b in cog.bot.state.posted_soundings, (
             "RAOB dedup key must NOT include watch_num — otherwise we re-post "
             "the same sounding once per active watch."
         )
@@ -241,10 +249,10 @@ class TestSoundingDedupAcrossWatches:
         time_key = "20260423_20z"
 
         key_a = f"acars:OMA:{time_key}"
-        cog._posted_watch_soundings.add(key_a)
+        cog.bot.state.posted_soundings.add(key_a)
 
         key_b = f"acars:OMA:{time_key}"
-        assert key_b in cog._posted_watch_soundings
+        assert key_b in cog.bot.state.posted_soundings
 
     @pytest.mark.asyncio
     async def test_cog_load_restores_todays_keys(self, monkeypatch):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,6 +40,8 @@ class TestWatchesCogIntegration:
         bot = make_mock_bot()
         bot.state.is_primary = True
         bot.get_channel = MagicMock(return_value=AsyncMock())
+        bot.state.add_posted_watch = AsyncMock()
+        bot.state.add_posted_product_id = AsyncMock()
 
         nws_result = {
             "0100": {
@@ -51,8 +53,7 @@ class TestWatchesCogIntegration:
 
         with patch("cogs.watches.fetch_active_watches_nws", new=AsyncMock(return_value=nws_result)), \
              patch("cogs.watches.fetch_watch_details", new=AsyncMock(return_value=(None, None, None))), \
-             patch("cogs.watches.download_single_image", new=AsyncMock(return_value=(None, False, None))), \
-             patch("cogs.watches.add_posted_watch", new=AsyncMock()):
+             patch("cogs.watches.download_single_image", new=AsyncMock(return_value=(None, False, None))):
 
             cog = WatchesCog(bot)
             cog.auto_post_watches.cancel()

--- a/tests/test_mesoscale.py
+++ b/tests/test_mesoscale.py
@@ -16,6 +16,7 @@ def _make_bot(posted_mds=None, active_mds=None, is_primary=True):
     bot.state.posted_mds = set(posted_mds or [])
     bot.state.active_mds = set(active_mds or [])
     bot.state.last_post_times = {}
+    bot.state.add_posted_md = AsyncMock()
     bot.wait_until_ready = AsyncMock()
     channel = AsyncMock()
     bot.get_channel.return_value = channel
@@ -190,6 +191,7 @@ def _make_bot_for_post(posted_mds=None, active_mds=None):
     bot.state.active_mds = set(active_mds or [])
     bot.state.auto_cache = {}
     bot.state.last_post_times = {}
+    bot.state.add_posted_md = AsyncMock()
     bot.cogs = {}
     bot.wait_until_ready = AsyncMock()
     channel = AsyncMock()
@@ -219,15 +221,20 @@ async def test_post_md_now_sends_and_marks_posted():
 
     # Use a dummy text to trigger upgrade task creation
     dummy_text = "SPC MD 0100"
+
+    # Configure mock state
+    async def _mock_add(md):
+        bot.state.posted_mds.add(md)
+    bot.state.add_posted_md = AsyncMock(side_effect=_mock_add)
     
     with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=("img", dummy_text, True, "/path"))), \
          patch("cogs.mesoscale.download_single_image", AsyncMock(return_value=(None, False, None))), \
          patch("cogs.mesoscale.extract_md_body", return_value="Discussion body"), \
-         patch("cogs.mesoscale.add_posted_md", AsyncMock()), \
          patch("cogs.mesoscale.clean_md_text_for_discord", return_value="Discussion body"):
         await cog.post_md_now("100")
 
     channel.send.assert_called_once()
+    bot.state.add_posted_md.assert_called_with("0100")
     assert "0100" in bot.state.posted_mds
     assert "0100" in bot.state.active_mds
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -20,6 +20,9 @@ def _make_cog(posted_reports=None):
     cog.bot.wait_until_ready = AsyncMock()
     cog.bot.state.is_primary = True
     cog.bot.state.posted_reports = set(posted_reports or [])
+    cog.bot.state.add_posted_report = AsyncMock()
+    cog.bot.state.add_posted_survey = AsyncMock()
+    cog.bot.state.add_significant_event = AsyncMock()
     cog.posted_surveys = set()
     cog._surveys_loaded = True  # skip DB load in tests
     channel = AsyncMock()
@@ -218,14 +221,17 @@ async def test_handle_pns_posts_and_records():
     """Valid damage survey PNS is posted and added to posted_reports."""
     cog, channel = _make_cog()
 
-    with patch("cogs.reports.add_posted_report", AsyncMock()), \
-         patch("cogs.reports.prune_posted_reports", AsyncMock()), \
-         patch("cogs.reports.add_significant_event", AsyncMock()), \
+    async def _mock_add_report(pid):
+        cog.bot.state.posted_reports.add(pid)
+    cog.bot.state.add_posted_report = AsyncMock(side_effect=_mock_add_report)
+
+    with patch("cogs.reports.add_significant_event", AsyncMock()), \
          patch("utils.state_store.find_matching_tornado", AsyncMock(return_value=None)), \
          patch.object(cog, "_check_for_surveys", AsyncMock()):
         await cog._handle_pns("202604292200-KOUN-PNSOUN", SAMPLE_PNS)
 
     channel.send.assert_called_once()
+    cog.bot.state.add_posted_report.assert_called_with("202604292200-KOUN-PNSOUN")
     assert "202604292200-KOUN-PNSOUN" in cog.bot.state.posted_reports
 
 
@@ -249,9 +255,7 @@ Estimated Peak Wind: 65 mph
 SUMMARY: Three tornadoes confirmed near Example City OK.
 $$
 """
-    with patch("cogs.reports.add_posted_report", AsyncMock()), \
-         patch("cogs.reports.prune_posted_reports", AsyncMock()), \
-         patch("cogs.reports.add_significant_event", AsyncMock()), \
+    with patch("cogs.reports.add_significant_event", AsyncMock()), \
          patch("utils.state_store.find_matching_tornado", AsyncMock(return_value=None)), \
          patch.object(cog, "_check_for_surveys", AsyncMock()):
         await cog._handle_pns("202604292200-KOUN-PNSOUN", multi_pns)
@@ -267,9 +271,7 @@ async def test_handle_pns_parses_numerical_date_for_survey_check():
 
     mock_check = AsyncMock()
 
-    with patch("cogs.reports.add_posted_report", AsyncMock()), \
-         patch("cogs.reports.prune_posted_reports", AsyncMock()), \
-         patch("cogs.reports.add_significant_event", AsyncMock()), \
+    with patch("cogs.reports.add_significant_event", AsyncMock()), \
          patch("utils.state_store.find_matching_tornado", AsyncMock(return_value=None)), \
          patch.object(cog, "_check_for_surveys", mock_check):
         await cog._handle_pns("202604292200-KOUN-PNSOUN", SAMPLE_PNS)
@@ -300,14 +302,16 @@ async def test_check_for_surveys_posts_track_embed():
             {"id": "datglobalid", "options": {"{GUID-XYZ}": "OUN EF2 Chickasha"}}
         ]
     }
+    cog.bot.state.add_posted_survey = AsyncMock()
+    
     with patch("cogs.reports.http_get_bytes",
                AsyncMock(return_value=(json.dumps(meta).encode(), 200))), \
-         patch("cogs.reports.add_posted_survey", AsyncMock()), \
-         patch("cogs.reports.prune_posted_surveys", AsyncMock()), \
-         patch("utils.events_db.link_dat_guid_to_tornado", AsyncMock()):
-        await cog._check_for_surveys("2026-04-29")
+         patch("utils.events_db.link_dat_guid_to_tornado", AsyncMock(return_value=("E1", "L1", "M1", "C1"))):
+         await cog._check_for_surveys("2026-04-29")
 
-    channel.send.assert_called_once()
+         channel.send.assert_called_once()
+         cog.bot.state.add_posted_survey.assert_called_with("{GUID-XYZ}")
+
     embed: discord.Embed = channel.send.call_args.kwargs["embed"]
     assert "{GUID-XYZ}" in embed.image.url
 
@@ -363,6 +367,7 @@ async def test_check_for_surveys_falls_back_to_local_render():
             {"id": "datglobalid", "options": {"{GUID-LOCAL}": "OUN EF2 Test"}}
         ]
     }
+    cog.bot.state.add_posted_survey = AsyncMock()
     
     # IEM meta call succeeds (200), but IEM image call fails (404)
     with patch("cogs.reports.http_get_bytes", side_effect=[
@@ -373,13 +378,13 @@ async def test_check_for_surveys_falls_back_to_local_render():
     patch("utils.map_utils.render_tornado_track", MagicMock()), \
     patch("os.path.exists", return_value=True), \
     patch("discord.File", return_value=MagicMock(spec=discord.File, filename="track_{GUID-LOCAL}.png")), \
-    patch("cogs.reports.add_posted_survey", AsyncMock()), \
-    patch("cogs.reports.prune_posted_surveys", AsyncMock()), \
-    patch("utils.events_db.link_dat_guid_to_tornado", AsyncMock()):
+    patch("utils.events_db.link_dat_guid_to_tornado", AsyncMock(return_value=("E2", "L2", "M2", "C2"))):
 
         await cog._check_for_surveys("2026-04-29")
 
     channel.send.assert_called_once()
+    cog.bot.state.add_posted_survey.assert_called_with("{GUID-LOCAL}")
+
     kwargs = channel.send.call_args.kwargs
     embed = kwargs["embed"]
     assert "Local DAT Render" in embed.footer.text

--- a/tests/test_state_split.py
+++ b/tests/test_state_split.py
@@ -53,7 +53,10 @@ def test_to_dict_output_shape_unchanged():
         "last_posted_urls",
         "last_post_times",
         "posted_product_ids",
-    }
+        "posted_soundings",
+        "sounding_handled_watches",
+        }
+
     assert set(d.keys()) == expected_keys
     assert d["iembot_last_seqnum"] == 7
     assert "0100" in d["posted_mds"]

--- a/tests/test_surveys.py
+++ b/tests/test_surveys.py
@@ -1,64 +1,60 @@
-import pytest
+"""Tests for DAT survey logic integration in cogs/reports.py."""
+
+import json
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from cogs.reports import ReportsCog
 
 @pytest.mark.asyncio
 async def test_pns_triggers_survey_check(isolated_events_db):
     bot = MagicMock()
     bot.get_channel.return_value = AsyncMock()
+    bot.state.posted_surveys = set()
+    bot.state.add_posted_report = AsyncMock()
+    bot.state.add_posted_survey = AsyncMock()
     cog = ReportsCog(bot)
-    
+
     # Mock state_store functions
-    with patch("cogs.reports.get_posted_surveys", return_value=AsyncMock(return_value=set())), \
-         patch("cogs.reports.add_posted_survey", return_value=AsyncMock()), \
-         patch("cogs.reports.prune_posted_surveys", return_value=AsyncMock()):
-        
-        raw_pns = """
-        ...NWS DAMAGE SURVEY FOR 05/21/2024 TORNADO EVENT...
-        RATING: EF-4
-        ESTIMATED PEAK WIND: 185 MPH
-        SUMMARY: The Greenfield tornado...
-        $$
-        """
-        
-        # Mock http_get_bytes for the metadata call
-        mock_meta = {
-            "arguments": [
-                {
-                    "id": "datglobalid",
-                    "options": {
-                        "{GUID-123}": "DMX EF4 Greenfield"
-                    }
+    raw_pns = """
+    ...NWS DAMAGE SURVEY FOR 05/21/2024 TORNADO EVENT...
+    RATING: EF-4
+    ESTIMATED PEAK WIND: 185 MPH
+    SUMMARY: The Greenfield tornado...
+    $$
+    """
+
+    # Mock http_get_bytes for the metadata call
+    mock_meta = {
+        "arguments": [
+            {
+                "id": "datglobalid",
+                "options": {
+                    "{GUID-123}": "DMX EF4 Greenfield"
                 }
-            ]
-        }
-        
-        import json
-        mock_content = json.dumps(mock_meta).encode()
-        
-        with patch("cogs.reports.http_get_bytes", side_effect=[
-            # 1. Metadata call
-            (mock_content, 200),
-            # 2. Image check call (IEM image exists)
-            (b"fake-image-data", 200)
-        ]), \
-        patch("utils.events_db.link_dat_guid_to_tornado", AsyncMock()):
-            # Use a mock for _check_for_surveys to avoid background task issues in test
-            # or just await it directly for the test
-            with patch.object(ReportsCog, "_check_for_surveys", wraps=cog._check_for_surveys) as mock_check:
-                await cog._handle_pns("20240521-KDMX-PNS", raw_pns)
-                
-                # Verify date extraction
-                assert "2024-05-21" in str(mock_check.call_args)
-                
-                # Manually await the background task if needed, or check if send was called
-                # In our code it's asyncio.create_task, so we might need to wait or mock it.
-                # For this test, let's just await the helper directly to verify it works.
-                await cog._check_for_surveys("2024-05-21")
-                
-                # Check if channel.send was called with the embed
-                bot.get_channel.return_value.send.assert_called()
-                args, kwargs = bot.get_channel.return_value.send.call_args
-                embed = kwargs.get("embed")
-                assert embed.title == "🌪️ Tornado Track + Lead Time"
-                assert "{GUID-123}" in embed.image.url
+            }
+        ]
+    }
+
+    mock_content = json.dumps(mock_meta).encode()
+
+    with patch("cogs.reports.http_get_bytes", side_effect=[
+        # 1. Metadata call
+        (mock_content, 200),
+        # 2. Image check call (IEM image exists)
+        (b"fake-image-data", 200)
+    ]), \
+    patch("utils.events_db.link_dat_guid_to_tornado", AsyncMock(return_value=("E1", "L1", "M1", "C1"))), \
+    patch.object(ReportsCog, "_check_for_surveys", AsyncMock()) as mock_check:
+        # We need to await _handle_pns, which will call _check_for_surveys in a task.
+        await cog._handle_pns("20240521-KDMX-PNS", raw_pns)
+        # Give background task a moment
+        await asyncio.sleep(0.1)
+
+    # Verify report was marked posted
+    bot.state.add_posted_report.assert_called_with("20240521-KDMX-PNS")
+    
+    # Verify _check_for_surveys was called with the date
+    mock_check.assert_called_with("2024-05-21")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -305,35 +305,6 @@ class TestCSUMLPUrls:
         url = _build_panel_url("severe_fcst_6panel", date)
         assert "severe_fcst_6panel_040812.png" in url
 
-    async def test_load_posted_today_missing_file(self):
-        from unittest.mock import AsyncMock, patch
-        with patch("cogs.csu_mlp.get_state", new=AsyncMock(return_value=None)):
-            from cogs.csu_mlp import _load_posted_today
-            result = await _load_posted_today()
-        assert result == set()
-
-    async def test_load_posted_today_stale_date(self):
-        import json
-        from unittest.mock import AsyncMock, patch
-        value = json.dumps({"date": "2020-01-01", "days": [1, 2, 3]})
-        with patch("cogs.csu_mlp.get_state", new=AsyncMock(return_value=value)):
-            from cogs.csu_mlp import _load_posted_today
-            result = await _load_posted_today()
-        assert result == set()
-
-    async def test_load_posted_today_current_date(self):
-        import json
-        from datetime import datetime, timezone
-        from unittest.mock import AsyncMock, patch
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        value = json.dumps({"date": today, "days": [1, 2, "panel12"]})
-        with patch("cogs.csu_mlp.get_state", new=AsyncMock(return_value=value)):
-            from cogs.csu_mlp import _load_posted_today
-            result = await _load_posted_today()
-        assert 1 in result
-        assert 2 in result
-        assert "panel12" in result
-
 # ── ncar tests ────────────────────────────────────────────────────────────────
 
 class TestNCARWxNext:

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -191,6 +191,9 @@ def _make_cog(posted: dict | None = None) -> WarningsCog:
     cog.bot.state.posted_warnings = posted if posted is not None else {}
     cog.bot.state.active_warnings = {}
     cog.bot.state.posted_product_ids = deque(maxlen=1000)
+    cog.bot.state.add_posted_warning = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock()
     channel = MagicMock()
     channel.send = AsyncMock()
     cog.bot.get_channel = MagicMock(return_value=channel)
@@ -205,11 +208,14 @@ async def test_post_warning_now_dedups_against_posted_set(monkeypatch):
     cog = _make_cog(posted={"KOUN.SV.W.0042": {"message_id": 1, "channel_id": 2}})
 
     # Patch the persistence helpers to no-ops so the test never touches
-    # the DB. add_posted_warning would also be skipped on the dedup
+    # the DB. bot.state.add_posted_warning would also be skipped on the dedup
     # path anyway — the assertion is that channel.send was never called.
+    async def _mock_add_product_id(pid):
+        cog.bot.state.posted_product_ids.append(pid)
+
+    cog.bot.state.add_posted_warning = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock(side_effect=_mock_add_product_id)
     import cogs.warnings as warnings_mod
-    monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
-    monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
     monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
 
@@ -229,9 +235,9 @@ async def test_post_warning_now_posts_CON_updates(monkeypatch):
     mapping = {vtec_id: {"message_id": 123, "channel_id": 456, "area": "Noble"}}
     cog = _make_cog(posted=mapping)
 
+    cog.bot.state.add_posted_warning = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock()
     import cogs.warnings as warnings_mod
-    monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
-    monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
     monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
 
     con_text = SAMPLE_RAW.replace(
@@ -281,9 +287,11 @@ async def test_post_warning_now_claims_key_before_send(monkeypatch):
     iembot path is still in-flight and double-post."""
     cog = _make_cog()
 
+    async def _mock_add_warning(vtec_id, msg_id, chan_id, *args, **kwargs):
+        cog.bot.state.posted_warnings[vtec_id] = {"message_id": msg_id, "channel_id": chan_id}
+
+    cog.bot.state.add_posted_warning = AsyncMock(side_effect=_mock_add_warning)
     import cogs.warnings as warnings_mod
-    monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
-    monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
     monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
 
@@ -313,9 +321,12 @@ async def test_post_warning_now_dedups_by_product_id(monkeypatch):
     deduplicated by product_id even if they are updates."""
     cog = _make_cog()
 
+    async def _mock_add_product_id(pid):
+        cog.bot.state.posted_product_ids.append(pid)
+
+    cog.bot.state.add_posted_warning = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock(side_effect=_mock_add_product_id)
     import cogs.warnings as warnings_mod
-    monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
-    monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
     monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
 
     # First post (e.g. from IEMBot)
@@ -344,8 +355,10 @@ async def test_post_warning_now_race_dedup(monkeypatch):
     cog = _make_cog()
 
     import cogs.warnings as warnings_mod
-    monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
-    monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
+
+    async def _mock_add_product_id(pid):
+        cog.bot.state.posted_product_ids.append(pid)
+    cog.bot.state.add_posted_product_id.side_effect = _mock_add_product_id
 
     # Mock image download to be slow to create a race window
     async def _slow_download(*args, **kwargs):
@@ -517,6 +530,9 @@ def _make_tick_cog(active=None, posted=None):
     cog.bot.state.is_primary = True
     cog.bot.state.posted_warnings = posted or {}
     cog.bot.state.active_warnings = active or {}
+    cog.bot.state.add_posted_warning = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock()
     channel = MagicMock()
     channel.id = 12345
     channel.name = "test-channel"
@@ -547,11 +563,11 @@ async def test_tick_disappeared_warning_triggers_cancellation(monkeypatch):
 
     # API returns empty features — the warning has "disappeared"
     content = _nws_response([])
+    cog.bot.state.add_posted_warning = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock()
     import cogs.warnings as warnings_mod
     monkeypatch.setattr(warnings_mod, "http_get_bytes_conditional",
                         AsyncMock(return_value=(content, 200, {})))
-    monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
-    monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
     monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
 
@@ -579,11 +595,11 @@ async def test_tick_initial_discovery_posts_active_warning_missed_at_startup(mon
     msg_mock.channel.id = 2
     channel.send.return_value = msg_mock
 
+    cog.bot.state.add_posted_warning = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock()
     import cogs.warnings as warnings_mod
     monkeypatch.setattr(warnings_mod, "http_get_bytes_conditional",
                         AsyncMock(return_value=(content, 200, {})))
-    monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
-    monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
     monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
     monkeypatch.setattr(warnings_mod, "add_significant_event", AsyncMock(), raising=False)
@@ -614,11 +630,18 @@ async def test_tick_con_area_change_posts_partial_update(monkeypatch):
     msg_mock.channel.id = 2
     channel.send.return_value = msg_mock
 
+    async def _mock_add_warning(vtec_id, msg_id, chan_id, *args, **kwargs):
+        cog.bot.state.posted_warnings[vtec_id] = {
+            "message_id": msg_id,
+            "channel_id": chan_id,
+            "area": kwargs.get("area", "")
+        }
+
+    cog.bot.state.add_posted_warning = AsyncMock(side_effect=_mock_add_warning)
+    cog.bot.state.add_posted_product_id = AsyncMock()
     import cogs.warnings as warnings_mod
     monkeypatch.setattr(warnings_mod, "http_get_bytes_conditional",
                         AsyncMock(return_value=(content, 200, {})))
-    monkeypatch.setattr(warnings_mod, "add_posted_warning", AsyncMock())
-    monkeypatch.setattr(warnings_mod, "prune_posted_warnings", AsyncMock())
     monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
     monkeypatch.setattr(warnings_mod, "add_significant_event", AsyncMock(), raising=False)

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -206,6 +206,8 @@ def _make_watch_bot(posted_watches=None):
     bot.state.last_post_times = {}
     bot.cogs = {}
     bot.wait_until_ready = AsyncMock()
+    bot.state.add_posted_watch = AsyncMock()
+    bot.state.add_posted_product_id = AsyncMock()
     channel = AsyncMock()
     bot.get_channel.return_value = channel
     return bot, channel
@@ -236,15 +238,20 @@ async def test_post_watch_now_sends_and_marks_posted():
     cog._pending_tasks = set()
     cog.bot = bot
 
+    # Configure the mock state to actually add to the set when add_posted_watch is called
+    # to maintain the behavior of the existing test assertion.
+    async def _mock_add(wn):
+        bot.state.posted_watches.add(wn)
+    bot.state.add_posted_watch = AsyncMock(side_effect=_mock_add)
+
     nws_info = {"type": "SVR", "expires": None, "affected_zones": []}
 
     with patch("cogs.watches.fetch_watch_details", AsyncMock(return_value=("http://img.png", "summary", None))), \
-         patch("cogs.watches.download_single_image", AsyncMock(return_value=(None, False, None))), \
-         patch("cogs.watches.add_posted_watch", AsyncMock()), \
-         patch("cogs.watches.prune_posted_watches", AsyncMock()):
+         patch("cogs.watches.download_single_image", AsyncMock(return_value=(None, False, None))):
         await cog.post_watch_now("0102", nws_info)
 
     channel.send.assert_called_once()
+    bot.state.add_posted_watch.assert_called_with("0102")
     assert "0102" in bot.state.posted_watches
 
 
@@ -283,9 +290,7 @@ async def test_post_watch_now_dispatches_to_sounding_cog():
     cog.bot = bot
 
     with patch("cogs.watches.fetch_watch_details", AsyncMock(return_value=(None, None, None))), \
-         patch("cogs.watches.download_single_image", AsyncMock(return_value=(None, False, None))), \
-         patch("cogs.watches.add_posted_watch", AsyncMock()), \
-         patch("cogs.watches.prune_posted_watches", AsyncMock()):
+         patch("cogs.watches.download_single_image", AsyncMock(return_value=(None, False, None))):
         await cog.post_watch_now("0102", nws_info)
 
     # post_soundings_for_watch is called to build the coroutine arg for create_task

--- a/utils/db.py
+++ b/utils/db.py
@@ -183,6 +183,11 @@ async def _create_tables(db: aiosqlite.Connection):
             watch_number TEXT PRIMARY KEY
         );
 
+        CREATE TABLE IF NOT EXISTS posted_product_ids (
+            product_id TEXT PRIMARY KEY,
+            posted_at  REAL NOT NULL DEFAULT 0
+        );
+
         CREATE TABLE IF NOT EXISTS bot_state (
             key   TEXT PRIMARY KEY,
             value TEXT NOT NULL
@@ -478,6 +483,43 @@ async def prune_posted_reports(max_size: int = 500):
            )""",
         (max_size,),
         "prune_posted_reports",
+    )
+
+
+# ── Posted product IDs (cross-feed dedup) ───────────────────────────────────
+
+async def get_posted_product_ids() -> set:
+    """Get all posted product IDs (for cross-feed deduplication)."""
+    try:
+        async with get_read_db() as db:
+            async with db.execute("SELECT product_id FROM posted_product_ids") as cursor:
+                rows = await cursor.fetchall()
+                return {row["product_id"] for row in rows}
+    except Exception as e:
+        logger.warning(f"get_posted_product_ids failed: {e}")
+        return set()
+
+
+async def add_posted_product_id(product_id: str, posted_at: float = 0.0):
+    """Mark a product ID as posted."""
+    await _write(
+        "INSERT OR IGNORE INTO posted_product_ids (product_id, posted_at) VALUES (?, ?)",
+        (product_id, posted_at or time.time()),
+        f"add_posted_product_id({product_id})",
+    )
+
+
+async def prune_posted_product_ids(max_size: int = 1000):
+    """Keep only the most recent product IDs."""
+    await _write(
+        """DELETE FROM posted_product_ids
+           WHERE product_id NOT IN (
+               SELECT product_id FROM posted_product_ids
+               ORDER BY posted_at DESC
+               LIMIT ?
+           )""",
+        (max_size,),
+        "prune_posted_product_ids",
     )
 
 

--- a/utils/state.py
+++ b/utils/state.py
@@ -22,9 +22,10 @@ new code can take an explicit dependency on the component it needs
 rather than on the whole coordinator.
 """
 
+import json
 import logging
 from collections import deque
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set
 
 
@@ -70,6 +71,8 @@ class PostingLog:
         "active_warnings",
         "posted_reports",
         "posted_product_ids",
+        "posted_soundings",
+        "sounding_handled_watches",
     )
 
     def __init__(self):
@@ -85,6 +88,8 @@ class PostingLog:
         self.active_warnings: Dict[str, dict] = {}
         self.posted_reports: Set[str] = set()
         self.posted_product_ids: deque = deque(maxlen=1000)
+        self.posted_soundings: Set[str] = set()
+        self.sounding_handled_watches: Set[str] = set()
 
 
 class TimingTracker:
@@ -140,6 +145,11 @@ class BotState:
         self.iembot_botstalk_last_seqnum: int = 0
         self.bot_start_time: Optional[datetime] = None
 
+        # Failover & Sync Stats
+        self.failover_count: int = 0
+        self.lease_renewals: int = 0
+        self.sync_failures: int = 0
+
         # Latency tracking (seconds)
         self.iembot_latency: Optional[float] = None
         self.http_latency: Optional[float] = None
@@ -170,6 +180,67 @@ class BotState:
         else:
             self.http_latency = latency
 
+    # ── State Update Methods (Encapsulation) ───────────────────────────────
+
+    async def add_posted_md(self, md_number: str) -> None:
+        from utils import state_store
+        self.posted_mds.add(md_number)
+        await state_store.add_posted_md(md_number)
+
+    async def add_posted_watch(self, watch_number: str) -> None:
+        from utils import state_store
+        self.posted_watches.add(watch_number)
+        await state_store.add_posted_watch(watch_number)
+
+    async def add_posted_report(self, product_id: str) -> None:
+        from utils import state_store
+        self.posted_reports.add(product_id)
+        await state_store.add_posted_report(product_id)
+
+    async def add_posted_product_id(self, product_id: str) -> None:
+        from utils import state_store
+        # posted_product_ids is a deque(maxlen=1000)
+        if product_id not in self.posted_product_ids:
+            self.posted_product_ids.append(product_id)
+            await state_store.add_posted_product_id(product_id)
+
+    async def add_posted_warning(
+        self,
+        vtec_id: str,
+        message_id: int,
+        channel_id: int,
+        posted_at: float = 0.0,
+        area: str = "",
+        tornado_confidence: Optional[str] = None,
+        tornado_severity: Optional[str] = None,
+    ) -> None:
+        from utils import state_store
+        self.posted_warnings[vtec_id] = {
+            "message_id": message_id,
+            "channel_id": channel_id,
+            "area": area,
+        }
+        await state_store.add_posted_warning(
+            vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity
+        )
+
+    async def add_posted_sounding(self, pkey: str) -> None:
+        from utils import state_store
+        self.posted_soundings.add(pkey)
+        await state_store.add_posted_sounding(pkey)
+
+    async def add_sounding_handled_watch(self, watch_number: str) -> None:
+        from utils import state_store
+        self.sounding_handled_watches.add(watch_number)
+        await state_store.add_sounding_handled_watch(watch_number)
+
+    async def add_csu_posted(self, day: str) -> None:
+        from utils import state_store
+        self.csu_posted.add(str(day))
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        value = json.dumps({"date": today, "days": sorted(list(self.csu_posted))})
+        await state_store.set_state("csu_mlp_posted", value)
+
     # ── Legacy attribute surface (delegated) ────────────────────────────────
     auto_cache = _delegate("hashes", "auto_cache")
     manual_cache = _delegate("hashes", "manual_cache")
@@ -184,6 +255,8 @@ class BotState:
     active_warnings = _delegate("posting", "active_warnings")
     posted_reports = _delegate("posting", "posted_reports")
     posted_product_ids = _delegate("posting", "posted_product_ids")
+    posted_soundings = _delegate("posting", "posted_soundings")
+    sounding_handled_watches = _delegate("posting", "sounding_handled_watches")
 
     last_post_times = _delegate("timing", "last_post_times")
     last_posted_urls = _delegate("timing", "last_posted_urls")
@@ -194,29 +267,30 @@ class BotState:
         endpoint). Shape is stable — the failover protocol depends on it."""
         return {
             "iembot_last_seqnum": self.iembot_last_seqnum,
-            "auto_cache": self.auto_cache,
-            "manual_cache": self.manual_cache,
+            "auto_cache": self.auto_cache.copy(),
+            "manual_cache": self.manual_cache.copy(),
             "posted_mds": list(self.posted_mds),
             "posted_watches": list(self.posted_watches),
-            "posted_warnings": dict(self.posted_warnings),
+            "posted_warnings": self.posted_warnings.copy(),
             "posted_reports": list(self.posted_reports),
             "posted_product_ids": list(self.posted_product_ids),
+            "posted_soundings": list(self.posted_soundings),
+            "sounding_handled_watches": list(self.sounding_handled_watches),
             "csu_posted": list(self.csu_posted),
             "active_mds": list(self.active_mds),
             "active_warnings": list(self.active_warnings.keys()),
             "active_watches": {
-
                 k: {
                     "type": v.get("type"),
                     "expires": v["expires"].isoformat() if v.get("expires") else None,
                     "affected_zones": v.get("affected_zones", []),
                 }
-                for k, v in self.active_watches.items()
+                for k, v in self.active_watches.copy().items()
                 if isinstance(v, dict)
             },
-            "last_posted_urls": self.last_posted_urls,
+            "last_posted_urls": self.last_posted_urls.copy(),
             "last_post_times": {
                 k: v.isoformat() if v else None
-                for k, v in self.last_post_times.items()
+                for k, v in self.last_post_times.copy().items()
             },
         }

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -117,6 +117,10 @@ def _k_posted_reports() -> str:
     return f"{_PREFIX}:posted_reports"
 
 
+def _k_posted_product_ids() -> str:
+    return f"{_PREFIX}:posted_product_ids"
+
+
 def _k_posted_warnings() -> str:
     return f"{_PREFIX}:posted_warnings"
 
@@ -271,6 +275,9 @@ async def _replay(op: str, args: tuple) -> None:
     elif op == "add_posted_report":
         (product_id,) = args
         await _redis_cmd("SADD", _k_posted_reports(), product_id)
+    elif op == "add_posted_product_id":
+        (product_id,) = args
+        await _redis_cmd("SADD", _k_posted_product_ids(), product_id)
     elif op == "add_posted_warning":
         # Handle both old (5-element) and new (7-element) formats
         vtec_id = args[0]
@@ -451,8 +458,10 @@ async def prune_posted_mds(max_size: int = 200) -> None:
     try:
         members = await _redis_cmd("SMEMBERS", _k_posted_mds())
         if members and len(members) > max_size:
-            to_remove = list(members)[max_size:]
-            await _redis_cmd("SREM", _k_posted_mds(), *to_remove)
+            sqlite_members = await sqlite_backend.get_posted_mds()
+            to_remove = [m for m in members if m not in sqlite_members]
+            if to_remove:
+                await _redis_cmd("SREM", _k_posted_mds(), *to_remove)
     except _RedisUnavailable:
         pass
 
@@ -486,9 +495,18 @@ async def add_posted_watch(watch_number: str) -> None:
         await _enqueue_dirty("add_posted_watch", (watch_number,))
 
 
-async def prune_posted_watches(max_size: int = 200) -> None:
+async def prune_posted_watches(max_size: int = 100) -> None:
     await sqlite_backend.prune_posted_watches(max_size)
     _cache_invalidate("posted_watches")
+    try:
+        members = await _redis_cmd("SMEMBERS", _k_posted_watches())
+        if members and len(members) > max_size:
+            sqlite_members = await sqlite_backend.get_posted_watches()
+            to_remove = [m for m in members if m not in sqlite_members]
+            if to_remove:
+                await _redis_cmd("SREM", _k_posted_watches(), *to_remove)
+    except _RedisUnavailable:
+        pass
 
 
 # ── Posted surveys ───────────────────────────────────────────────────────────
@@ -523,6 +541,15 @@ async def add_posted_survey(dat_guid: str) -> None:
 async def prune_posted_surveys(max_size: int = 100) -> None:
     await sqlite_backend.prune_posted_surveys(max_size)
     _cache_invalidate("posted_surveys")
+    try:
+        members = await _redis_cmd("SMEMBERS", _k_posted_surveys())
+        if members and len(members) > max_size:
+            sqlite_members = await sqlite_backend.get_posted_surveys()
+            to_remove = [m for m in members if m not in sqlite_members]
+            if to_remove:
+                await _redis_cmd("SREM", _k_posted_surveys(), *to_remove)
+    except _RedisUnavailable:
+        pass
 
 
 # ── Posted reports (LSRs) ────────────────────────────────────────────────────
@@ -557,6 +584,62 @@ async def add_posted_report(product_id: str) -> None:
 async def prune_posted_reports(max_size: int = 500) -> None:
     await sqlite_backend.prune_posted_reports(max_size)
     _cache_invalidate("posted_reports")
+    try:
+        members = await _redis_cmd("SMEMBERS", _k_posted_reports())
+        if members and len(members) > max_size:
+            sqlite_members = await sqlite_backend.get_posted_reports()
+            to_remove = [m for m in members if m not in sqlite_members]
+            if to_remove:
+                await _redis_cmd("SREM", _k_posted_reports(), *to_remove)
+    except _RedisUnavailable:
+        pass
+
+
+# ── Posted product IDs (cross-feed dedup) ───────────────────────────────────
+
+async def get_posted_product_ids() -> Set[str]:
+    cache_key = "posted_product_ids"
+    hit, val = _cache_get(cache_key)
+    if hit:
+        return set(val)
+    try:
+        result = await _redis_cmd("SMEMBERS", _k_posted_product_ids())
+        members = set(result or [])
+        _cache_set(cache_key, members)
+        return set(members)
+    except _RedisUnavailable as e:
+        logger.debug(f"[STATE] get_posted_product_ids falling back to SQLite: {e}")
+        val = await sqlite_backend.get_posted_product_ids()
+        _cache_set(cache_key, val, ttl=CACHE_TTL_SECONDS / 2)
+        return val
+
+
+async def add_posted_product_id(product_id: str) -> None:
+    _cache_invalidate("posted_product_ids")
+    await sqlite_backend.add_posted_product_id(product_id)
+    try:
+        await _redis_cmd("SADD", _k_posted_product_ids(), product_id)
+    except _RedisUnavailable as e:
+        logger.warning(f"[STATE] add_posted_product_id({product_id}) queued: {e}")
+        await _enqueue_dirty("add_posted_product_id", (product_id,))
+
+
+async def prune_posted_product_ids(max_size: int = 1000) -> None:
+    await sqlite_backend.prune_posted_product_ids(max_size)
+    _cache_invalidate("posted_product_ids")
+    # Prune Redis set as well
+    try:
+        members = await _redis_cmd("SMEMBERS", _k_posted_product_ids())
+        if members and len(members) > max_size:
+            # This is a bit expensive for a set, but sets don't have natural ordering in Redis.
+            # SQLite handles the ordering. We just want to keep them roughly in sync.
+            # Better way: get authoritative list from SQLite after pruning.
+            sqlite_members = await sqlite_backend.get_posted_product_ids()
+            to_remove = [m for m in members if m not in sqlite_members]
+            if to_remove:
+                await _redis_cmd("SREM", _k_posted_product_ids(), *to_remove)
+    except _RedisUnavailable:
+        pass
 
 
 # ── Significant events — routed to events_db, not Redis ─────────────────────
@@ -655,6 +738,17 @@ async def add_posted_warning(
 async def prune_posted_warnings(max_size: int = 500) -> None:
     await sqlite_backend.prune_posted_warnings(max_size)
     _cache_invalidate("posted_warnings")
+    try:
+        # Prune Redis HSET to match SQLite
+        members = await _redis_cmd("HKEYS", _k_posted_warnings())
+        if members and len(members) > max_size:
+            sqlite_data = await sqlite_backend.get_all_posted_warnings()
+            sqlite_keys = set(sqlite_data.keys())
+            to_remove = [m for m in members if m not in sqlite_keys]
+            if to_remove:
+                await _redis_cmd("HDEL", _k_posted_warnings(), *to_remove)
+    except _RedisUnavailable:
+        pass
 
 
 # ── Soundings ─────────────────────────────────────────────────────────────────
@@ -892,6 +986,8 @@ async def mirror_to_sqlite() -> None:
             await sqlite_backend.add_posted_watch(w)
         for r in await get_posted_reports():
             await sqlite_backend.add_posted_report(r)
+        for p in await get_posted_product_ids():
+            await sqlite_backend.add_posted_product_id(p)
 
         # 3. State — paginate SCAN fully (C3 fix)
         state_keys = await _scan_all_keys(f"{_k_state('*')}")
@@ -918,7 +1014,7 @@ async def mirror_to_sqlite() -> None:
 async def _resync_full() -> Dict[str, int]:
     counts: Dict[str, int] = {
         "hashes": 0, "posted_mds": 0, "posted_watches": 0,
-        "posted_surveys": 0, "posted_reports": 0, "state": 0, "urls": 0,
+        "posted_surveys": 0, "posted_reports": 0, "posted_product_ids": 0, "state": 0, "urls": 0,
     }
     try:
         for cache_type in ("auto", "manual"):
@@ -950,6 +1046,11 @@ async def _resync_full() -> Dict[str, int]:
         if reports:
             await _redis_cmd("SADD", _k_posted_reports(), *reports)
             counts["posted_reports"] = len(reports)
+
+        product_ids = await sqlite_backend.get_posted_product_ids()
+        if product_ids:
+            await _redis_cmd("SADD", _k_posted_product_ids(), *product_ids)
+            counts["posted_product_ids"] = len(product_ids)
 
         states = await sqlite_backend.get_all_state()
         if states:


### PR DESCRIPTION
Resolves the merge conflict in #408 and rebases onto current main (post v5.28.1).

**Conflict resolved:** `utils/state.py` line 277 — both sides serialized `posted_warnings` identically; kept `.copy()` for consistency with surrounding fields.

## What's in this PR (from #408)

### State Encapsulation
- `BotState` promoted from passive data structure to active state manager with atomic `async` methods (`add_posted_warning`, `add_posted_md`, etc.)
- Cogs no longer dual-write; all state mutations go through `BotState`
- Eliminates race conditions between in-memory cache and persistent store

### Deduplication Persistence
- `posted_product_ids` now persisted — cross-feed dedup survives restarts and failover transitions

### Transactional Failover Promotion
- Rollback mechanism in `FailoverCog`: if any cog fails to load during promotion, successfully loaded cogs are unloaded and the node demotes back to Standby
- Prevents "partial Primary" state after a failed promotion

### Redis Pruning Fix
- State pruning now explicitly removes stale entries from Redis (previously only pruned the local SQLite mirror, causing indefinite Redis memory growth)
- Pruning uses the authoritative ordered list from SQLite instead of random eviction

### Observability
- Failover, lease renewal, and sync failure counters added to `BotState`
- Metrics surfaced in `/status` dashboard

### Concurrency
- `BotState.to_dict()` iterations wrapped in `.copy()`/`list()` to prevent `RuntimeError: dictionary changed size during iteration` during serialization

Closes #408