### PR TITLE
chore: ignore artifact action bumps past v4 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,15 @@ updates:
     labels:
       - dependencies
       - ci
+    ignore:
+      # upload-artifact and download-artifact were bumped to v7/v8 previously
+      # (PR #335) and had to be reverted twice (#396, #397) due to breakage
+      # in the Docker multi-platform digest workflow. Stay on @v4 until the
+      # root cause is diagnosed.
+      - dependency-name: "actions/upload-artifact"
+        versions: [">=5"]
+      - dependency-name: "actions/download-artifact"
+        versions: [">=5"]
 
   # Rust crate dependencies
   - package-ecosystem: cargo


### PR DESCRIPTION
Closes #402 and #403 for good.

**History:** Dependabot previously bumped `download-artifact` 4→8 (PR #335, merged). It broke the Docker multi-platform digest workflow and had to be explicitly reverted twice — once for `docker-publish.yml` (#396) and once for `tests.yml` (#397). Dependabot then immediately reopened the same PRs as #402/#403.

**Fix:** Ignore rules added to `dependabot.yml` for both actions at any version ≥5. They'll stay on `@v4` until someone has time to debug what broke in the digest merge step.