### PR TITLE
fix: cap posted_warnings in-memory dict and run hourly prune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`posted_warnings` in-memory dict was unbounded.** v5.29.0 plumbed `prune_posted_warnings` to wipe stale rows from Redis and SQLite, but nothing called it at runtime and the in-memory dict on `BotState` had no cap analog to `posted_product_ids`' `deque(maxlen=1000)`. During multi-day outbreaks the dict grew without bound. Added `BotState.prune_posted_warnings()` which prunes all three layers and preserves unconfirmed placeholders, plus an hourly `prune_posted_warnings_loop` task in `WarningsCog` (cap 500, primary-only).
+
 ## [5.29.0] — 2026-05-19
 
 ### Added

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -63,7 +63,12 @@ logger = logging.getLogger("spc_bot.warnings")
 
 
 class WarningsCog(commands.Cog):
-    MANAGED_TASK_NAMES = [("auto_poll_warnings", "auto_poll_warnings")]
+    MANAGED_TASK_NAMES = [
+        ("auto_poll_warnings", "auto_poll_warnings"),
+        ("prune_posted_warnings_loop", "prune_posted_warnings_loop"),
+    ]
+
+    POSTED_WARNINGS_MAX = 500
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
@@ -81,9 +86,11 @@ class WarningsCog(commands.Cog):
         )
 
         self.auto_poll_warnings.start()
+        self.prune_posted_warnings_loop.start()
 
     def cog_unload(self):
         self.auto_poll_warnings.cancel()
+        self.prune_posted_warnings_loop.cancel()
 
     # ── Warning Channel Routing ─────────────────────────────────────────────
 
@@ -620,6 +627,26 @@ class WarningsCog(commands.Cog):
             logger.info(f"Posted cancellation for {vtec_id}")
         except Exception as e:
             logger.warning(f"Failed to post cancellation for {vtec_id}: {e}")
+
+    @tasks.loop(hours=1)
+    async def prune_posted_warnings_loop(self):
+        """Cap ``posted_warnings`` growth — warnings churn far faster than
+        watches and the in-memory dict was previously unbounded."""
+        if not self.bot.state.is_primary:
+            return
+        try:
+            removed = await self.bot.state.prune_posted_warnings(self.POSTED_WARNINGS_MAX)
+            if removed:
+                logger.info(
+                    f"Pruned {removed} posted_warnings entries "
+                    f"(cap={self.POSTED_WARNINGS_MAX})"
+                )
+        except Exception as e:
+            logger.exception(f"prune_posted_warnings_loop failed: {e}")
+
+    @prune_posted_warnings_loop.before_loop
+    async def _before_prune_posted_warnings(self):
+        await self.bot.wait_until_ready()
 
     @tasks.loop(seconds=30)
     async def auto_poll_warnings(self):

--- a/tests/test_state_split.py
+++ b/tests/test_state_split.py
@@ -1,4 +1,6 @@
 # tests/test_state_split.py
+from unittest.mock import AsyncMock, patch
+
 from utils.state import BotState, PostingLog, TimingTracker, HashStore
 
 
@@ -61,6 +63,36 @@ def test_to_dict_output_shape_unchanged():
     assert d["iembot_last_seqnum"] == 7
     assert "0100" in d["posted_mds"]
     assert d["auto_cache"] == {"u": "h"}
+
+
+async def test_prune_posted_warnings_drops_evicted_entries():
+    s = BotState()
+    s.posted_warnings["A"] = {"message_id": 1, "channel_id": 1, "area": ""}
+    s.posted_warnings["B"] = {"message_id": 2, "channel_id": 1, "area": ""}
+    s.posted_warnings["C"] = {"message_id": 3, "channel_id": 1, "area": ""}
+
+    with patch("utils.state_store.prune_posted_warnings", new=AsyncMock()) as prune, \
+         patch("utils.state_store.get_all_posted_warnings", new=AsyncMock(return_value={"B": {}, "C": {}})):
+        removed = await s.prune_posted_warnings(max_size=2)
+
+    prune.assert_awaited_once_with(2)
+    assert removed == 1
+    assert set(s.posted_warnings.keys()) == {"B", "C"}
+
+
+async def test_prune_posted_warnings_preserves_placeholders():
+    """Unconfirmed placeholders (empty-dict values) must survive prune —
+    a concurrent post may be mid-flight before its row hits SQLite."""
+    s = BotState()
+    s.posted_warnings["OLD"] = {"message_id": 1, "channel_id": 1, "area": ""}
+    s.posted_warnings["INFLIGHT"] = {}  # placeholder mid-post
+
+    with patch("utils.state_store.prune_posted_warnings", new=AsyncMock()), \
+         patch("utils.state_store.get_all_posted_warnings", new=AsyncMock(return_value={})):
+        await s.prune_posted_warnings(max_size=10)
+
+    assert "INFLIGHT" in s.posted_warnings
+    assert "OLD" not in s.posted_warnings
 
 
 def test_substores_are_independent():

--- a/utils/state.py
+++ b/utils/state.py
@@ -234,6 +234,24 @@ class BotState:
         self.sounding_handled_watches.add(watch_number)
         await state_store.add_sounding_handled_watch(watch_number)
 
+    async def prune_posted_warnings(self, max_size: int = 500) -> int:
+        """Trim posted_warnings to the most recent ``max_size`` entries across
+        SQLite, Redis, and the in-memory dict.
+
+        Returns the number of in-memory entries removed. Unconfirmed
+        placeholders (empty-dict values) are always preserved — a concurrent
+        post may be mid-flight and the persisted row has not been written yet.
+        """
+        from utils import state_store
+        await state_store.prune_posted_warnings(max_size)
+        surviving = await state_store.get_all_posted_warnings()
+        before = len(self.posted_warnings)
+        self.posted_warnings = {
+            k: v for k, v in self.posted_warnings.items()
+            if k in surviving or not v
+        }
+        return before - len(self.posted_warnings)
+
     async def add_csu_posted(self, day: str) -> None:
         from utils import state_store
         self.csu_posted.add(str(day))


### PR DESCRIPTION
## Summary
- v5.29.0 plumbed `prune_posted_warnings` to wipe stale rows from Redis + SQLite, but nothing called it at runtime, and `BotState.posted_warnings` (a plain `dict`) had no maxlen analog to `posted_product_ids`' `deque(maxlen=1000)`. Multi-day outbreaks grew the dict without bound.
- Added `BotState.prune_posted_warnings(max_size=500)`: prunes SQLite + Redis via `state_store`, then reconciles the in-memory dict against surviving keys. Unconfirmed placeholders (empty-dict values) are preserved so a concurrent post mid-flight isn't evicted before its row reaches SQLite.
- Wired up an hourly `prune_posted_warnings_loop` task in `WarningsCog`, primary-only, registered under `MANAGED_TASK_NAMES`.

This is PR A of a two-PR sequence. PR B will refactor `BotState` to encapsulate all `posted_warnings` mutations behind an async context manager so the eight current direct-mutation sites in `cogs/warnings.py` (the "three sources of truth" issue from the v5.28.0 Opus review) can't silently drift between memory / SQLite / Redis.

## Test plan
- [x] `tests/test_state_split.py::test_prune_posted_warnings_drops_evicted_entries` — evicted SQLite keys are removed from memory
- [x] `tests/test_state_split.py::test_prune_posted_warnings_preserves_placeholders` — unconfirmed placeholders survive prune
- [x] Full `tests/test_state_split.py + test_warnings.py + test_db.py` suites pass (47 tests)
- [ ] Live verify after merge: hourly log line `Pruned N posted_warnings entries (cap=500)` once warning count exceeds 500