### PR TITLE
refactor: route posted_warnings mutations through claim context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ version numbers follow [SemVer](https://semver.org/).
 ### Fixed
 - **`posted_warnings` in-memory dict was unbounded.** v5.29.0 plumbed `prune_posted_warnings` to wipe stale rows from Redis and SQLite, but nothing called it at runtime and the in-memory dict on `BotState` had no cap analog to `posted_product_ids`' `deque(maxlen=1000)`. During multi-day outbreaks the dict grew without bound. Added `BotState.prune_posted_warnings()` which prunes all three layers and preserves unconfirmed placeholders, plus an hourly `prune_posted_warnings_loop` task in `WarningsCog` (cap 500, primary-only).
 
+### Refactored
+- **`posted_warnings` mutations now go through `BotState.claim_posted_warning` context manager.** Resolves the v5.28.0 Opus-review "three sources of truth" issue. `cogs/warnings.py` had eight call sites that mutated `bot.state.posted_warnings` and `posted_product_ids` directly — placeholder writes, `del`/`pop` rollbacks, and `posted_product_ids.remove()` — none of which touched SQLite or Redis, causing silent drift between the three storage layers. Same class of bug that caused the sounding dedup race in #390. Added `PostedWarningClaim` async context manager that writes a placeholder on enter, exposes `confirm()`/`abort()`, and auto-rolls back the in-memory placeholder on any exit path (early `continue`, leaked exception, missed `confirm`). Added `BotState.remove_posted_warning()` and `BotState.remove_posted_product_id()` that delete across memory + SQLite + Redis (with `_replay` queueing for offline Redis), plus matching `utils/db.py` helpers. Both NWWS-trigger and NWS-poll paths in `cogs/warnings.py` now use the context manager; no direct `posted_warnings[...]` writes remain in cogs.
+
 ## [5.29.0] — 2026-05-19
 
 ### Added

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -275,103 +275,87 @@ class WarningsCog(commands.Cog):
 
         self._in_flight_vtecs.add(vtec_id)
 
+        # Claim dedup keys BEFORE any awaits so concurrent tasks hitting
+        # the same path see the state immediately. For updates the
+        # posted_warnings entry already exists, so the claim no-ops on
+        # enter/exit — but claim.confirm() still updates persistence.
+        await self.bot.state.add_posted_product_id(product_id)
+
         try:
-            # Claim the dedup key BEFORE any awaits so concurrent tasks
-            # hitting the same path see the state immediately.
-            # For updates, we don't overwrite the dict yet, but we mark the product.
-            await self.bot.state.add_posted_product_id(product_id)
-            if not is_update:
-                # We still need a placeholder in memory to prevent concurrent races 
-                # before the message is actually sent.
-                self.bot.state.posted_warnings[vtec_id] = {} 
+            async with self.bot.state.claim_posted_warning(vtec_id) as claim:
+                self.bot.state.active_warnings[vtec_id] = vtec
 
-            self.bot.state.active_warnings[vtec_id] = vtec
+                # Log significant events (tornadoes, hail, wind) to DB
+                event_id = await self._check_and_log_significant_event(event, raw_text, vtec)
 
-            # Log significant events (tornadoes, hail, wind) to DB
-            event_id = await self._check_and_log_significant_event(event, raw_text, vtec)
+                emoji, display_event, color, footer_id = get_warning_style(event, raw_text, vtec=vtec)
 
-            emoji, display_event, color, footer_id = get_warning_style(event, raw_text, vtec=vtec)
+                prev_area = self.bot.state.posted_warnings.get(vtec_id, {}).get("area", "")
+                concise_text = build_concise_warning_text(
+                    display_event, vtec, raw_text=raw_text, is_update=is_update, prev_area=prev_area
+                )
 
-            prev_area = self.bot.state.posted_warnings.get(vtec_id, {}).get("area", "")
-            concise_text = build_concise_warning_text(
-                display_event, vtec, raw_text=raw_text, is_update=is_update, prev_area=prev_area
-            )
+                embed = discord.Embed(
+                    title=f"{emoji} {display_event}",
+                    description=concise_text,
+                    color=color,
+                    timestamp=datetime.now(timezone.utc),
+                )
+                footer_text = f"VTEC {vtec_id}"
+                if footer_id:
+                    footer_text += f" | {footer_id}"
+                embed.set_footer(text=footer_text)
 
-            embed = discord.Embed(
-                title=f"{emoji} {display_event}",
-                description=concise_text,
-                color=color,
-                timestamp=datetime.now(timezone.utc),
-            )
-            footer_text = f"VTEC {vtec_id}"
-            if footer_id:
-                footer_text += f" | {footer_id}"
-            embed.set_footer(text=footer_text)
+                # Add Environmental Button for Tornado Warnings
+                view = None
+                if event == "Tornado Warning" and event_id:
+                    view = EnvironmentalView(event_id)
 
-            # Add Environmental Button for Tornado Warnings
-            view = None
-            if event == "Tornado Warning" and event_id:
-                view = EnvironmentalView(event_id)
-
-            # Download IEM Autoplot image (only if we have a real ETN, or it's an SPS)
-            files = []
-            has_etn = vtec.get("etn") and vtec["etn"] != "0"
-            logger.debug(f"[WARN_IMG_CHECK] {vtec['vtec_id']}: has_etn={has_etn} phenom={vtec.get('phenom')}")
-            if has_etn or vtec.get("phenom") == "SPS":
-                image_url = iem_autoplot_url(vtec)
-                logger.debug(f"[WARN_IMG_IEMBOT] {vtec['vtec_id']}: {image_url}")
-                filename = f"warning_{vtec_id.replace('.', '_')}.png"
-                f = await _download_warning_image(image_url, filename)
-                if f:
-                    files.append(f)
-                    embed.set_image(url=f"attachment://{filename}")
+                # Download IEM Autoplot image (only if we have a real ETN, or it's an SPS)
+                files = []
+                has_etn = vtec.get("etn") and vtec["etn"] != "0"
+                logger.debug(f"[WARN_IMG_CHECK] {vtec['vtec_id']}: has_etn={has_etn} phenom={vtec.get('phenom')}")
+                if has_etn or vtec.get("phenom") == "SPS":
+                    image_url = iem_autoplot_url(vtec)
+                    logger.debug(f"[WARN_IMG_IEMBOT] {vtec['vtec_id']}: {image_url}")
+                    filename = f"warning_{vtec_id.replace('.', '_')}.png"
+                    f = await _download_warning_image(image_url, filename)
+                    if f:
+                        files.append(f)
+                        embed.set_image(url=f"attachment://{filename}")
+                    else:
+                        logger.warning(f"[WARN_IMG_FAIL] {vtec['vtec_id']}: image download returned None")
                 else:
-                    logger.warning(f"[WARN_IMG_FAIL] {vtec['vtec_id']}: image download returned None")
-            else:
-                logger.debug(f"[WARN_IMG_SKIP] {vtec['vtec_id']}: no ETN, not downloading image")
+                    logger.debug(f"[WARN_IMG_SKIP] {vtec['vtec_id']}: no ETN, not downloading image")
 
-            try:
-                msg = await channel.send(embed=embed, files=files, view=view)
-                logger.info(f"Posted (iembot) {event} {vtec_id} ({'Update' if is_update else 'Issuance'})")
-
-                # Simple area extraction for persistence
-                area_m = re.search(r"for (.+?) till", concise_text)
-                area_desc = area_m.group(1) if area_m else "affected area"
-
-                tornado_confidence, tornado_severity = get_tornado_attributes(event, raw_text)
-                await self.bot.state.add_posted_warning(
-                    vtec_id,
-                    msg.id,
-                    msg.channel.id,
-                    time.time(),
-                    area=area_desc,
-                    tornado_confidence=tornado_confidence,
-                    tornado_severity=tornado_severity,
-                )
-            except discord.Forbidden as e:
-                await self._notify_channel_error(channel, ["send_messages (403 Forbidden)"])
                 try:
-                    self.bot.state.posted_product_ids.remove(product_id)
-                except ValueError:
-                    pass
-                if not is_update and vtec_id in self.bot.state.posted_warnings:
-                    del self.bot.state.posted_warnings[vtec_id]
-                self.bot.state.active_warnings.pop(vtec_id, None)
-                logger.error(f"iembot send forbidden for {vtec_id} in channel {channel.id}: {e}")
-                return
-            except discord.HTTPException as e:
-                # Roll back the dedup claim on a hard send failure
-                try:
-                    self.bot.state.posted_product_ids.remove(product_id)
-                except ValueError:
-                    pass
-                if not is_update and vtec_id in self.bot.state.posted_warnings:
-                    del self.bot.state.posted_warnings[vtec_id]
-                self.bot.state.active_warnings.pop(vtec_id, None)
-                logger.exception(
-                    f"iembot send failed for {vtec_id}: {e}"
-                )
-                return
+                    msg = await channel.send(embed=embed, files=files, view=view)
+                    logger.info(f"Posted (iembot) {event} {vtec_id} ({'Update' if is_update else 'Issuance'})")
+
+                    # Simple area extraction for persistence
+                    area_m = re.search(r"for (.+?) till", concise_text)
+                    area_desc = area_m.group(1) if area_m else "affected area"
+
+                    tornado_confidence, tornado_severity = get_tornado_attributes(event, raw_text)
+                    await claim.confirm(
+                        msg.id,
+                        msg.channel.id,
+                        time.time(),
+                        area=area_desc,
+                        tornado_confidence=tornado_confidence,
+                        tornado_severity=tornado_severity,
+                    )
+                except discord.Forbidden as e:
+                    await self._notify_channel_error(channel, ["send_messages (403 Forbidden)"])
+                    await self.bot.state.remove_posted_product_id(product_id)
+                    self.bot.state.active_warnings.pop(vtec_id, None)
+                    logger.error(f"iembot send forbidden for {vtec_id} in channel {channel.id}: {e}")
+                    return  # claim auto-rolls back on context exit
+                except discord.HTTPException as e:
+                    await self.bot.state.remove_posted_product_id(product_id)
+                    self.bot.state.active_warnings.pop(vtec_id, None)
+                    logger.exception(f"iembot send failed for {vtec_id}: {e}")
+                    return  # claim auto-rolls back on context exit
         finally:
             self._in_flight_vtecs.discard(vtec_id)
 
@@ -804,40 +788,31 @@ class WarningsCog(commands.Cog):
                 if vtec_dict["action"] not in ("NEW", "CON", "EXT", "UPG"):
                     continue
 
-                # Claim the dedup key BEFORE any awaits
-                self.bot.state.posted_warnings[issuance_id] = {}  # placeholder
+                async with self.bot.state.claim_posted_warning(issuance_id) as claim:
+                    try:
+                        event_ch = await self._resolve_warning_channel(event, vtec_phenom=vtec_dict.get("phenom"))
+                        if event_ch is None:
+                            continue  # claim auto-rolls back
+                        msg, area_desc = await self._post_warning(feature, event_ch, vtec_dict, event)
+                    except discord.HTTPException as e:
+                        logger.exception(f"Send failed for {issuance_id}: {e}")
+                        continue  # claim auto-rolls back
 
-                try:
-                    event_ch = await self._resolve_warning_channel(event, vtec_phenom=vtec_dict.get("phenom"))
-                    if event_ch is None:
-                        self.bot.state.posted_warnings.pop(issuance_id, None)
-                        continue
-                    msg, area_desc = await self._post_warning(feature, event_ch, vtec_dict, event)
-                except discord.HTTPException as e:
-                    logger.exception(f"Send failed for {issuance_id}: {e}")
-                    # Roll back placeholder on failure
-                    if issuance_id in self.bot.state.posted_warnings and not self.bot.state.posted_warnings[issuance_id]:
-                        del self.bot.state.posted_warnings[issuance_id]
-                    continue
-
-                self.bot.state.active_warnings[issuance_id] = vtec_dict
-                try:
-                    description = props.description or ""
-                    params = props.parameters.model_dump() if props.parameters else {}
-                    tornado_confidence, tornado_severity = get_tornado_attributes(event, description, params)
-                    await self.bot.state.add_posted_warning(
-                        issuance_id,
-                        msg.id,
-                        msg.channel.id,
-                        time.time(),
-                        area=area_desc,
-                        tornado_confidence=tornado_confidence,
-                        tornado_severity=tornado_severity,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to persist {issuance_id}: {e}"
-                    )
+                    self.bot.state.active_warnings[issuance_id] = vtec_dict
+                    try:
+                        description = props.description or ""
+                        params = props.parameters.model_dump() if props.parameters else {}
+                        tornado_confidence, tornado_severity = get_tornado_attributes(event, description, params)
+                        await claim.confirm(
+                            msg.id,
+                            msg.channel.id,
+                            time.time(),
+                            area=area_desc,
+                            tornado_confidence=tornado_confidence,
+                            tornado_severity=tornado_severity,
+                        )
+                    except Exception as e:
+                        logger.warning(f"Failed to persist {issuance_id}: {e}")
             finally:
                 self._in_flight_vtecs.discard(issuance_id)
 

--- a/tests/test_state_split.py
+++ b/tests/test_state_split.py
@@ -95,6 +95,80 @@ async def test_prune_posted_warnings_preserves_placeholders():
     assert "OLD" not in s.posted_warnings
 
 
+async def test_claim_inserts_placeholder_on_enter():
+    s = BotState()
+    async with s.claim_posted_warning("KOUN.TO.W.0042"):
+        assert "KOUN.TO.W.0042" in s.posted_warnings
+        assert s.posted_warnings["KOUN.TO.W.0042"] == {}
+
+
+async def test_claim_rolls_back_when_not_confirmed():
+    s = BotState()
+    async with s.claim_posted_warning("KOUN.TO.W.0042"):
+        pass  # never confirmed
+    assert "KOUN.TO.W.0042" not in s.posted_warnings
+
+
+async def test_claim_rolls_back_on_exception():
+    s = BotState()
+    with patch("utils.state_store.add_posted_warning", new=AsyncMock()):
+        try:
+            async with s.claim_posted_warning("KOUN.TO.W.0042"):
+                raise RuntimeError("send failed")
+        except RuntimeError:
+            pass
+    assert "KOUN.TO.W.0042" not in s.posted_warnings
+
+
+async def test_claim_confirm_persists_and_survives_exit():
+    s = BotState()
+    with patch("utils.state_store.add_posted_warning", new=AsyncMock()) as persist:
+        async with s.claim_posted_warning("KOUN.TO.W.0042") as claim:
+            await claim.confirm(message_id=1, channel_id=2, area="Cleveland")
+        persist.assert_awaited_once()
+    assert s.posted_warnings["KOUN.TO.W.0042"]["message_id"] == 1
+    assert s.posted_warnings["KOUN.TO.W.0042"]["area"] == "Cleveland"
+
+
+async def test_claim_no_ops_when_vtec_already_claimed():
+    """Concurrent NWWS + IEM trigger on the same vtec: second claim sees
+    the first task's entry, leaves it alone on exit (no clobber)."""
+    s = BotState()
+    s.posted_warnings["KOUN.TO.W.0042"] = {"message_id": 999, "channel_id": 888}
+
+    async with s.claim_posted_warning("KOUN.TO.W.0042"):
+        pass  # never confirmed; should NOT roll back the existing entry
+
+    assert s.posted_warnings["KOUN.TO.W.0042"]["message_id"] == 999
+
+
+async def test_claim_abort_marks_for_rollback():
+    s = BotState()
+    async with s.claim_posted_warning("KOUN.TO.W.0042") as claim:
+        claim.abort()
+    assert "KOUN.TO.W.0042" not in s.posted_warnings
+
+
+async def test_remove_posted_warning_clears_memory_and_persistence():
+    s = BotState()
+    s.posted_warnings["KOUN.TO.W.0042"] = {"message_id": 1, "channel_id": 2}
+
+    with patch("utils.state_store.remove_posted_warning", new=AsyncMock()) as remove:
+        await s.remove_posted_warning("KOUN.TO.W.0042")
+
+    remove.assert_awaited_once_with("KOUN.TO.W.0042")
+    assert "KOUN.TO.W.0042" not in s.posted_warnings
+
+
+async def test_remove_posted_product_id_silent_when_absent():
+    """Rollback path must tolerate the deque already lacking the entry —
+    e.g. a maxlen=1000 eviction beat the rollback to it."""
+    s = BotState()
+    with patch("utils.state_store.remove_posted_product_id", new=AsyncMock()) as remove:
+        await s.remove_posted_product_id("PROD-not-here")
+    remove.assert_awaited_once_with("PROD-not-here")
+
+
 def test_substores_are_independent():
     """Separate BotState instances must not share sub-store state."""
     a = BotState()

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -182,6 +182,8 @@ def test_extract_narrative_falls_back_when_no_bulletin_header():
 def _make_cog(posted: dict | None = None) -> WarningsCog:
     """Build a WarningsCog with mocked bot/channel for unit testing the
     iembot path without touching Discord, the DB, or the network."""
+    from utils.state import PostedWarningClaim
+
     cog = WarningsCog.__new__(WarningsCog)
     cog._in_flight_vtecs = set()
     cog._perm_warned = set()
@@ -193,7 +195,14 @@ def _make_cog(posted: dict | None = None) -> WarningsCog:
     cog.bot.state.posted_product_ids = deque(maxlen=1000)
     cog.bot.state.add_posted_warning = AsyncMock()
     cog.bot.state.add_posted_product_id = AsyncMock()
-    cog.bot.state.add_posted_product_id = AsyncMock()
+    cog.bot.state.remove_posted_product_id = AsyncMock()
+    cog.bot.state.remove_posted_warning = AsyncMock()
+    # claim_posted_warning must return a real PostedWarningClaim so the
+    # placeholder/confirm/rollback semantics match production. The claim
+    # delegates to bot.state.add_posted_warning, which is mocked above.
+    cog.bot.state.claim_posted_warning = lambda vtec_id: PostedWarningClaim(
+        cog.bot.state, vtec_id
+    )
     channel = MagicMock()
     channel.send = AsyncMock()
     cog.bot.get_channel = MagicMock(return_value=channel)
@@ -518,6 +527,8 @@ def _nws_response(features: list) -> bytes:
 
 
 def _make_tick_cog(active=None, posted=None):
+    from utils.state import PostedWarningClaim
+
     cog = WarningsCog.__new__(WarningsCog)
     cog._in_flight_vtecs = set()
     cog._perm_warned = set()
@@ -530,9 +541,20 @@ def _make_tick_cog(active=None, posted=None):
     cog.bot.state.is_primary = True
     cog.bot.state.posted_warnings = posted or {}
     cog.bot.state.active_warnings = active or {}
-    cog.bot.state.add_posted_warning = AsyncMock()
+
+    async def _mock_add_warning(vtec_id, msg_id, chan_id, *args, **kwargs):
+        area = kwargs.get("area", args[1] if len(args) > 1 else "")
+        cog.bot.state.posted_warnings[vtec_id] = {
+            "message_id": msg_id, "channel_id": chan_id, "area": area,
+        }
+
+    cog.bot.state.add_posted_warning = AsyncMock(side_effect=_mock_add_warning)
     cog.bot.state.add_posted_product_id = AsyncMock()
-    cog.bot.state.add_posted_product_id = AsyncMock()
+    cog.bot.state.remove_posted_product_id = AsyncMock()
+    cog.bot.state.remove_posted_warning = AsyncMock()
+    cog.bot.state.claim_posted_warning = lambda vtec_id: PostedWarningClaim(
+        cog.bot.state, vtec_id
+    )
     channel = MagicMock()
     channel.id = 12345
     channel.name = "test-channel"

--- a/utils/db.py
+++ b/utils/db.py
@@ -523,6 +523,16 @@ async def prune_posted_product_ids(max_size: int = 1000):
     )
 
 
+async def remove_posted_product_id(product_id: str):
+    """Drop a single product ID — used to roll back a claim when the
+    downstream post fails."""
+    await _write(
+        "DELETE FROM posted_product_ids WHERE product_id = ?",
+        (product_id,),
+        f"remove_posted_product_id({product_id})",
+    )
+
+
 # ── Posted warnings ───────────────────────────────────────────────────────────
 
 async def get_all_posted_warnings() -> dict:
@@ -588,6 +598,16 @@ async def add_posted_warning(
              tornado_severity=excluded.tornado_severity""",
         (vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity),
         f"add_posted_warning({vtec_id})",
+    )
+
+
+async def remove_posted_warning(vtec_id: str):
+    """Drop a single posted-warning row — used to roll back a claim when
+    the Discord post fails."""
+    await _write(
+        "DELETE FROM posted_warnings WHERE vtec_id = ?",
+        (vtec_id,),
+        f"remove_posted_warning({vtec_id})",
     )
 
 

--- a/utils/state.py
+++ b/utils/state.py
@@ -252,6 +252,40 @@ class BotState:
         }
         return before - len(self.posted_warnings)
 
+    async def remove_posted_warning(self, vtec_id: str) -> None:
+        """Roll back a posted warning across memory + SQLite + Redis."""
+        from utils import state_store
+        self.posted_warnings.pop(vtec_id, None)
+        await state_store.remove_posted_warning(vtec_id)
+
+    async def remove_posted_product_id(self, product_id: str) -> None:
+        """Roll back a posted product ID across memory + SQLite + Redis.
+        Silently no-ops if the id is not currently in the in-memory deque."""
+        from utils import state_store
+        try:
+            self.posted_product_ids.remove(product_id)
+        except ValueError:
+            pass
+        await state_store.remove_posted_product_id(product_id)
+
+    def claim_posted_warning(self, vtec_id: str) -> "PostedWarningClaim":
+        """Open an async context that reserves ``vtec_id`` in
+        ``posted_warnings`` as a synchronous dedup signal.
+
+        Usage::
+
+            async with state.claim_posted_warning(vtec_id) as claim:
+                msg = await channel.send(...)
+                await claim.confirm(msg.id, msg.channel.id, ...)
+
+        If ``confirm`` is not called (caller aborts, exception leaks, or
+        an early ``continue`` skips it), the placeholder is rolled back on
+        exit. If the vtec_id was already claimed when the context opens —
+        e.g. a concurrent NWWS and IEM trigger racing for the same warning
+        — the new claim becomes a no-op and exiting will not touch the
+        other task's entry."""
+        return PostedWarningClaim(self, vtec_id)
+
     async def add_csu_posted(self, day: str) -> None:
         from utils import state_store
         self.csu_posted.add(str(day))
@@ -312,3 +346,78 @@ class BotState:
                 for k, v in self.last_post_times.copy().items()
             },
         }
+
+
+class PostedWarningClaim:
+    """Async context manager guarding a single ``posted_warnings`` entry.
+
+    On enter, an empty-dict placeholder is written to ``state.posted_warnings``
+    so concurrent tasks that check ``vtec_id in state.posted_warnings`` before
+    awaiting immediately see the reservation. The caller must then either:
+
+      * call ``await claim.confirm(message_id, channel_id, …)`` after the
+        Discord post succeeds — this persists the real entry across SQLite +
+        Redis via ``BotState.add_posted_warning`` and leaves the placeholder
+        promoted to a real row, or
+      * let the context exit without confirming (explicit ``claim.abort()``,
+        an early ``continue``, or a leaked exception) — the placeholder is
+        rolled back from memory on exit. SQLite + Redis are not touched
+        because the placeholder was never persisted.
+
+    If the vtec_id was already claimed when this context opens (concurrent
+    NWWS + IEM trigger racing on the same warning), the new claim becomes a
+    no-op: ``__aexit__`` will not clobber the other task's entry, and
+    ``confirm`` still persists the real row (last writer wins, matching
+    pre-refactor behavior).
+    """
+
+    __slots__ = ("_state", "_vtec_id", "_confirmed", "_already_claimed")
+
+    def __init__(self, state: "BotState", vtec_id: str):
+        self._state = state
+        self._vtec_id = vtec_id
+        self._confirmed = False
+        self._already_claimed = False
+
+    async def __aenter__(self) -> "PostedWarningClaim":
+        if self._vtec_id in self._state.posted_warnings:
+            self._already_claimed = True
+        else:
+            self._state.posted_warnings[self._vtec_id] = {}
+        return self
+
+    def abort(self) -> None:
+        """Mark the claim for rollback. The placeholder is dropped when
+        the context exits. A no-op after ``confirm`` has been called."""
+        self._confirmed = False
+
+    async def confirm(
+        self,
+        message_id: int,
+        channel_id: int,
+        posted_at: float = 0.0,
+        area: str = "",
+        tornado_confidence: Optional[str] = None,
+        tornado_severity: Optional[str] = None,
+    ) -> None:
+        """Persist the real entry across memory + SQLite + Redis. After
+        this call the claim will not roll back on context exit."""
+        await self._state.add_posted_warning(
+            self._vtec_id,
+            message_id,
+            channel_id,
+            posted_at,
+            area,
+            tornado_confidence,
+            tornado_severity,
+        )
+        self._confirmed = True
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._confirmed or self._already_claimed:
+            return
+        # Only remove the entry if it's still the empty placeholder we
+        # inserted on enter. A confirm() that wrote a real dict and then
+        # raised — or an unrelated writer — must not be wiped.
+        if self._state.posted_warnings.get(self._vtec_id) == {}:
+            self._state.posted_warnings.pop(self._vtec_id, None)

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -278,6 +278,12 @@ async def _replay(op: str, args: tuple) -> None:
     elif op == "add_posted_product_id":
         (product_id,) = args
         await _redis_cmd("SADD", _k_posted_product_ids(), product_id)
+    elif op == "remove_posted_product_id":
+        (product_id,) = args
+        await _redis_cmd("SREM", _k_posted_product_ids(), product_id)
+    elif op == "remove_posted_warning":
+        (vtec_id,) = args
+        await _redis_cmd("HDEL", _k_posted_warnings(), vtec_id)
     elif op == "add_posted_warning":
         # Handle both old (5-element) and new (7-element) formats
         vtec_id = args[0]
@@ -624,6 +630,17 @@ async def add_posted_product_id(product_id: str) -> None:
         await _enqueue_dirty("add_posted_product_id", (product_id,))
 
 
+async def remove_posted_product_id(product_id: str) -> None:
+    """Roll back an `add_posted_product_id` write across SQLite + Redis."""
+    _cache_invalidate("posted_product_ids")
+    await sqlite_backend.remove_posted_product_id(product_id)
+    try:
+        await _redis_cmd("SREM", _k_posted_product_ids(), product_id)
+    except _RedisUnavailable as e:
+        logger.warning(f"[STATE] remove_posted_product_id({product_id}) queued: {e}")
+        await _enqueue_dirty("remove_posted_product_id", (product_id,))
+
+
 async def prune_posted_product_ids(max_size: int = 1000) -> None:
     await sqlite_backend.prune_posted_product_ids(max_size)
     _cache_invalidate("posted_product_ids")
@@ -733,6 +750,17 @@ async def add_posted_warning(
             "add_posted_warning",
             (vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity),
         )
+
+
+async def remove_posted_warning(vtec_id: str) -> None:
+    """Roll back an `add_posted_warning` write across SQLite + Redis."""
+    _cache_invalidate("posted_warnings")
+    await sqlite_backend.remove_posted_warning(vtec_id)
+    try:
+        await _redis_cmd("HDEL", _k_posted_warnings(), vtec_id)
+    except _RedisUnavailable as e:
+        logger.warning(f"[STATE] remove_posted_warning({vtec_id}) queued: {e}")
+        await _enqueue_dirty("remove_posted_warning", (vtec_id,))
 
 
 async def prune_posted_warnings(max_size: int = 500) -> None:


### PR DESCRIPTION
## Summary
Resolves the v5.28.0 Opus-review "three sources of truth" issue. `cogs/warnings.py` had 8 call sites that mutated `bot.state.posted_warnings` and `posted_product_ids` directly — placeholder writes, `del`/`pop` rollbacks, and `posted_product_ids.remove()` — none of which touched SQLite or Redis, causing silent drift between the three storage layers. Same class of bug that caused the sounding dedup race in #390.

- **New `PostedWarningClaim` async context manager.** On enter, inserts an empty-dict placeholder into `bot.state.posted_warnings` as a synchronous dedup signal for concurrent tasks. Caller calls `await claim.confirm(...)` to persist the real entry, or lets the context exit without confirming — the placeholder is rolled back automatically on early `continue`, leaked exception, or missed `confirm`. If the vtec_id was already claimed on enter (concurrent NWWS + IEM race on the same warning), the new claim no-ops on exit so it can't clobber the other task's entry.
- **`BotState.remove_posted_warning()` / `remove_posted_product_id()`.** Delete across memory + SQLite + Redis. Both queue to `_replay` if Redis is unavailable, mirroring the existing `add_*` pattern. Backed by new `utils/db.py` helpers and `utils/state_store.py` wrappers + `_replay` cases.
- **Both warning-post paths refactored.** NWWS trigger (`post_warning_now`) and NWS-poll (`_tick`) now use the context manager. After this change there are **no direct `posted_warnings[...]` writes or `.pop()` / `del` calls remaining in `cogs/`**. `main.py:122` hydration is intentionally left as a bulk write (canonical SQLite → memory at startup; not a runtime mutation).

This is PR B of a two-PR sequence. PR #416 caps the in-memory `posted_warnings` dict (the persistence layers were already capped via `prune_posted_warnings` as of v5.29.0 but never called at runtime).

## Test plan
- [x] 7 new `PostedWarningClaim` lifecycle tests in `tests/test_state_split.py` — placeholder insert, rollback on no-confirm, rollback on exception, confirm persists, no-op when already-claimed, explicit `abort()`, `remove_*` helpers
- [x] Updated `_make_cog` / `_make_tick_cog` test fixtures to wire `claim_posted_warning` to a real `PostedWarningClaim` so placeholder semantics match production
- [x] Full local suite: **427 passed**
- [ ] Live verify after merge: trigger a TOR warning via NWWS → confirm placeholder visible in logs before `channel.send`, real row persisted on success; force a Discord 5xx → confirm placeholder rolled back from `bot.state.posted_warnings` (no stale entry blocks the retry)