### PR TITLE
feat: per-endpoint HTTP latency tracking with P50/P95 in /status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Per-endpoint HTTP latency tracking.** `bot.state.http_latency` was a single rolling average across every HTTP call, which made "the bot feels slow" reports indistinguishable between NWS API delays, IEM Autoplot delays, and Discord delays. `utils/http.py` now extracts the hostname from each request URL and passes it through the latency callback; `BotState.update_http_latency()` keeps a per-host rolling window (`deque(maxlen=100)`). `BotState.http_latency_percentiles(host)` returns nearest-rank P50/P95 in seconds. `/status` surfaces the top 5 hosts by sample count under a new "🌐 HTTP Endpoints" field. The callback is back-compatible with the legacy `cb(latency)` signature via a `TypeError` fallback.
+
 ### Tests
 - **Failover fault-injection coverage for `_do_promote` cog-load rollback.** v5.29.0 (#412) added per-cog transactional rollback inside `_do_promote` — if `bot.load_extension(name)` raises on any cog in `ALL_EXTENSIONS`, the previously-loaded cogs are unloaded in reverse order and the bot demotes back to standby. That code path had no test coverage; a regression would only surface during a real failover-with-broken-cog combination at 3am. Added 4 fault-injection tests in `tests/test_failover_coverage.py::TestPromoteFaultInjection` covering: partial-load reverse-order rollback, rollback that continues past an `unload_extension` failure, full-success path (tree.sync called, no demote), and first-cog-fails (no unloads but still demotes).
 

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -347,6 +347,28 @@ class StatusView(discord.ui.View):
         )
         embed.add_field(name="📡 Connectivity", value=conn_val, inline=True)
 
+        # Per-host HTTP latency breakdown (P50 / P95)
+        by_host = self.bot.state.http_latency_by_host
+        if by_host:
+            # Sort hosts by sample count descending — busy endpoints first
+            ranked = sorted(by_host.items(), key=lambda kv: -len(kv[1]))[:5]
+            host_lines = []
+            for host, samples in ranked:
+                pct = self.bot.state.http_latency_percentiles(host)
+                if pct is None:
+                    continue
+                p50, p95 = pct
+                host_lines.append(
+                    f"`{host}` — p50 `{p50 * 1000:.0f}ms` p95 `{p95 * 1000:.0f}ms` "
+                    f"(n={len(samples)})"
+                )
+            if host_lines:
+                embed.add_field(
+                    name="🌐 HTTP Endpoints",
+                    value="\n".join(host_lines),
+                    inline=False,
+                )
+
         # Performance metrics
         nwws_tput = self.bot.state.nwws_throughput
         iem_lat = self.bot.state.iembot_latency

--- a/tests/test_state_split.py
+++ b/tests/test_state_split.py
@@ -169,6 +169,49 @@ async def test_remove_posted_product_id_silent_when_absent():
     remove.assert_awaited_once_with("PROD-not-here")
 
 
+def test_update_http_latency_without_host_back_compatible():
+    """Pre-R3 callers passed only the latency value; that must still work."""
+    s = BotState()
+    s.update_http_latency(0.250)
+    assert s.http_latency == 0.250
+    assert s.http_latency_by_host == {}
+
+
+def test_update_http_latency_with_host_buckets_samples():
+    s = BotState()
+    s.update_http_latency(0.100, host="api.weather.gov")
+    s.update_http_latency(0.200, host="api.weather.gov")
+    s.update_http_latency(0.500, host="mesonet.agron.iastate.edu")
+    assert list(s.http_latency_by_host["api.weather.gov"]) == [0.100, 0.200]
+    assert list(s.http_latency_by_host["mesonet.agron.iastate.edu"]) == [0.500]
+
+
+def test_http_latency_per_host_rolling_window_caps_growth():
+    s = BotState()
+    for i in range(s.HTTP_LATENCY_WINDOW + 50):
+        s.update_http_latency(float(i) / 1000, host="api.weather.gov")
+    samples = s.http_latency_by_host["api.weather.gov"]
+    assert len(samples) == s.HTTP_LATENCY_WINDOW
+    # Oldest samples evicted — first kept should be sample #50
+    assert samples[0] == 50.0 / 1000
+
+
+def test_http_latency_percentiles_returns_none_for_unknown_host():
+    s = BotState()
+    assert s.http_latency_percentiles("nowhere.invalid") is None
+
+
+def test_http_latency_percentiles_computes_p50_p95():
+    s = BotState()
+    # 100 samples ranging 0.001..0.100s
+    for i in range(1, 101):
+        s.update_http_latency(i / 1000, host="api.weather.gov")
+    p50, p95 = s.http_latency_percentiles("api.weather.gov")
+    # P50 of 1..100 ≈ 50ms; P95 ≈ 95ms (nearest-rank)
+    assert 0.045 <= p50 <= 0.055
+    assert 0.090 <= p95 <= 0.100
+
+
 def test_substores_are_independent():
     """Separate BotState instances must not share sub-store state."""
     a = BotState()

--- a/utils/http.py
+++ b/utils/http.py
@@ -201,7 +201,12 @@ async def http_get_bytes_conditional(
         ) as response:
             latency = time.perf_counter() - start
             if _latency_callback:
-                _latency_callback(latency)
+                try:
+                    _latency_callback(latency, host=urlparse(url).hostname)
+                except TypeError:
+                    # Legacy callback signature (latency-only) — preserve to
+                    # avoid breaking external consumers that haven't migrated.
+                    _latency_callback(latency)
 
             if response.status in (429, 503, 502, 504):
                 # Tenacity handles the backoff/retry; we just signal the failure

--- a/utils/state.py
+++ b/utils/state.py
@@ -169,16 +169,45 @@ class BotState:
         self.discord_gateway_ip: Optional[str] = None
         self.discord_gateway_location: Optional[str] = None
 
+        # Per-host rolling-window HTTP latency samples (seconds).
+        # Bounded so a long-lived process can't accumulate samples forever.
+        self.http_latency_by_host: Dict[str, deque[float]] = {}
+
         self.hashes = HashStore()
         self.posting = PostingLog()
         self.timing = TimingTracker()
 
-    def update_http_latency(self, latency: float) -> None:
-        """Update the rolling average of HTTP latency."""
+    HTTP_LATENCY_WINDOW = 100  # samples kept per host
+
+    def update_http_latency(self, latency: float, host: Optional[str] = None) -> None:
+        """Update the rolling average of HTTP latency.
+
+        When ``host`` is provided, also append the sample to the per-host
+        rolling window so ``/status`` can show P50/P95 broken out by
+        endpoint (NWS API vs IEM Autoplot vs Discord etc.)."""
         if self.http_latency is not None:
             self.http_latency = (self.http_latency * 0.9) + (latency * 0.1)
         else:
             self.http_latency = latency
+
+        if host:
+            samples = self.http_latency_by_host.get(host)
+            if samples is None:
+                samples = deque(maxlen=self.HTTP_LATENCY_WINDOW)
+                self.http_latency_by_host[host] = samples
+            samples.append(latency)
+
+    def http_latency_percentiles(self, host: str) -> Optional[tuple[float, float]]:
+        """Return (p50, p95) seconds for ``host``, or None if no samples."""
+        samples = self.http_latency_by_host.get(host)
+        if not samples:
+            return None
+        ordered = sorted(samples)
+        n = len(ordered)
+        p50 = ordered[n // 2]
+        # nearest-rank P95; for small n this is just the max.
+        p95 = ordered[min(n - 1, max(0, int(round(0.95 * n)) - 1))]
+        return (p50, p95)
 
     # ── State Update Methods (Encapsulation) ───────────────────────────────
 


### PR DESCRIPTION
## Summary
`bot.state.http_latency` was a single rolling average across every HTTP call, which made "the bot feels slow" reports indistinguishable between NWS API delays, IEM Autoplot delays, and Discord delays.

- `utils/http.py` extracts the hostname from each request URL via `urlparse()` and passes it through the latency callback. Wrapped in `try/except TypeError` to stay back-compatible with any callback that only accepts `(latency,)`.
- `BotState.update_http_latency(latency, host=None)` keeps a per-host rolling window (`deque(maxlen=HTTP_LATENCY_WINDOW=100)`). Global `http_latency` rolling average is unchanged.
- `BotState.http_latency_percentiles(host)` returns nearest-rank `(p50, p95)` in seconds, or `None` for unknown hosts.
- `cogs/status.py` shows top-5-by-sample-count hosts in a new "🌐 HTTP Endpoints" field with per-host P50/P95 + sample count.

This is **R3** of the v5.28.0-review backlog cleanup. Stacked alongside R2 (#419, no conflict — different files).

## Test plan
- [x] 5 new tests in `test_state_split.py` cover back-compat, bucketing, rolling-window cap, percentile correctness, unknown-host None
- [x] Full suite: 434 passed
- [ ] Live verify after merge: `/status` shows endpoint breakdown after ~100 HTTP calls; confirm `api.weather.gov`, `mesonet.agron.iastate.edu`, `discord.com` separated