### PR TITLE
perf: O(1) posted_product_ids membership lookup via BoundedFIFOKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Performance
+- **O(1) `posted_product_ids` membership lookup.** `posted_product_ids` was a `deque(maxlen=1000)`, so the `in` check on the hot dedup path (NWWS + IEMBot triggers + NWS poll all hit it per product) was O(N) — measurable during severe weather outbreaks with thousands of products/sec. Replaced with `BoundedFIFOKeys`, a dict-backed FIFO (`dict` preserves insertion order in CPython 3.7+) that gives O(1) `in` / `append` / `remove` while keeping the same drop-in interface (`.append()`, `.remove()` with `ValueError`, `.extend()`, `in`, `list()`, `len()`). No call sites changed.
+
 ## [5.31.0] — 2026-05-19
 
 ### Added

--- a/tests/test_state_split.py
+++ b/tests/test_state_split.py
@@ -272,6 +272,61 @@ def test_sweep_active_grace_window_prevents_racing_cancellation():
     assert "KOUN.TO.W.0050" in s.active_warnings
 
 
+def test_bounded_fifo_keys_dedups_on_append():
+    """append() on an existing key must be a no-op so a high-rate dup
+    stream can't churn the FIFO order."""
+    from utils.state import BoundedFIFOKeys
+    f = BoundedFIFOKeys(maxlen=3)
+    f.append("A")
+    f.append("B")
+    f.append("A")  # duplicate
+    f.append("C")
+    assert list(f) == ["A", "B", "C"]
+    assert len(f) == 3
+
+
+def test_bounded_fifo_keys_evicts_oldest_at_cap():
+    from utils.state import BoundedFIFOKeys
+    f = BoundedFIFOKeys(maxlen=3)
+    for k in ["A", "B", "C", "D"]:
+        f.append(k)
+    assert list(f) == ["B", "C", "D"]
+    assert "A" not in f
+    assert "D" in f
+
+
+def test_bounded_fifo_keys_in_check_is_constant_time():
+    """Smoke test: a 10k-element dict-backed `in` check is much faster
+    than the old O(N) deque scan. This is the whole reason for the swap."""
+    from utils.state import BoundedFIFOKeys
+    f = BoundedFIFOKeys(maxlen=10_000)
+    for i in range(10_000):
+        f.append(f"PROD-{i}")
+    # Lookup the key we just added should be instant; an absent one too.
+    assert "PROD-9999" in f
+    assert "PROD-not-here" not in f
+
+
+def test_bounded_fifo_keys_remove_raises_when_absent():
+    """deque.remove() raises ValueError when the item isn't present, and
+    BotState.remove_posted_product_id catches ValueError. Preserve."""
+    from utils.state import BoundedFIFOKeys
+    import pytest
+    f = BoundedFIFOKeys(maxlen=10)
+    f.append("A")
+    f.remove("A")
+    with pytest.raises(ValueError):
+        f.remove("not-here")
+
+
+def test_bounded_fifo_keys_extend_appends_each():
+    from utils.state import BoundedFIFOKeys
+    f = BoundedFIFOKeys(maxlen=10)
+    f.extend(["A", "B", "C"])
+    f.extend(["D"])
+    assert list(f) == ["A", "B", "C", "D"]
+
+
 def test_substores_are_independent():
     """Separate BotState instances must not share sub-store state."""
     a = BotState()

--- a/utils/state.py
+++ b/utils/state.py
@@ -46,6 +46,56 @@ class RecentLogHandler(logging.Handler):
         return list(self.buffer)
 
 
+class BoundedFIFOKeys:
+    """Insertion-ordered FIFO set with O(1) ``in``, ``append``, ``remove``.
+
+    Backed by ``dict`` (which preserves insertion order in CPython 3.7+).
+    Drop-in for a ``deque(maxlen=N)`` of strings on the hot dedup path,
+    where ``in`` was previously O(N) and dominated the cost during severe
+    weather outbreaks with thousands of products/sec.
+
+    Only the methods used by callers of ``posted_product_ids`` are
+    implemented; this is not a general container.
+    """
+
+    __slots__ = ("_d", "_maxlen")
+
+    def __init__(self, maxlen: int = 1000):
+        self._d: Dict[str, None] = {}
+        self._maxlen = maxlen
+
+    def append(self, key: str) -> None:
+        if key in self._d:
+            return
+        self._d[key] = None
+        while len(self._d) > self._maxlen:
+            # Evict oldest (dicts preserve insertion order; first key is oldest)
+            try:
+                oldest = next(iter(self._d))
+            except StopIteration:
+                break
+            del self._d[oldest]
+
+    def extend(self, keys) -> None:
+        for k in keys:
+            self.append(k)
+
+    def remove(self, key: str) -> None:
+        # Match deque.remove semantics: ValueError if absent
+        if key not in self._d:
+            raise ValueError(key)
+        del self._d[key]
+
+    def __contains__(self, key) -> bool:
+        return key in self._d
+
+    def __iter__(self):
+        return iter(self._d)
+
+    def __len__(self) -> int:
+        return len(self._d)
+
+
 class HashStore:
     """Image-hash caches and partial-update state."""
 
@@ -87,7 +137,7 @@ class PostingLog:
         # Currently-active VTEC IDs mapping to their latest vtec metadata dict
         self.active_warnings: Dict[str, dict] = {}
         self.posted_reports: Set[str] = set()
-        self.posted_product_ids: deque = deque(maxlen=1000)
+        self.posted_product_ids: BoundedFIFOKeys = BoundedFIFOKeys(maxlen=1000)
         self.posted_soundings: Set[str] = set()
         self.sounding_handled_watches: Set[str] = set()
 


### PR DESCRIPTION
## Summary
`posted_product_ids` was a `deque(maxlen=1000)`, so `product_id in bot.state.posted_product_ids` on the hot dedup path (NWWS + IEMBot triggers + NWS poll all hit it per product) was O(N) — measurable during severe weather outbreaks with thousands of products/sec.

- Added `BoundedFIFOKeys`: dict-backed FIFO (`dict` preserves insertion order in CPython 3.7+). O(1) for `in` / `append` / `remove`. Drop-in interface (`append`, `remove` with `ValueError`, `extend`, `in`, `list`, `len`). Only the methods callers actually use are implemented — not a general container.
- Replaced `deque(maxlen=1000)` with `BoundedFIFOKeys(maxlen=1000)` in `PostingLog.posted_product_ids`. **No other call sites change** — every reader/writer (`utils/state.py`, `cogs/warnings.py`, `cogs/failover.py`, `main.py`) uses methods both types implement.
- Test fixtures in `tests/test_warnings.py` and `tests/test_iem_races.py` use `deque(maxlen=1000)` to shadow `bot.state.posted_product_ids`; that still works because they test against the same interface.

First of 4 PRs from Gemini's v5.33.0 plan (faster dedup, bigger connection pools, standby watchdog, shutdown cancellation).

## Test plan
- [x] 5 new tests in `test_state_split.py` cover dedup on append, FIFO eviction at cap, large-set in-check, `remove()` `ValueError` contract, `extend()`
- [x] Full suite: 447 passed