### PR TITLE
perf: bump aiohttp + SQLite connection pool limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ version numbers follow [SemVer](https://semver.org/).
 
 ### Performance
 - **O(1) `posted_product_ids` membership lookup.** `posted_product_ids` was a `deque(maxlen=1000)`, so the `in` check on the hot dedup path (NWWS + IEMBot triggers + NWS poll all hit it per product) was O(N) — measurable during severe weather outbreaks with thousands of products/sec. Replaced with `BoundedFIFOKeys`, a dict-backed FIFO (`dict` preserves insertion order in CPython 3.7+) that gives O(1) `in` / `append` / `remove` while keeping the same drop-in interface (`.append()`, `.remove()` with `ValueError`, `.extend()`, `in`, `list()`, `len()`). No call sites changed.
+- **Bumped connection pool limits.** `aiohttp.TCPConnector` `limit` 20→100 and `limit_per_host` 10→25 in `utils/http.py`; SQLite read pool `_READ_POOL_SIZE` 3→10 in `utils/db.py`. The old caps throttled the bot during outbreaks when radar-frame bursts, concurrent slash commands, and warning-image downloads stacked up against the connector before reaching the server. 25 per host is well below what NWS API / IEM Autoplot tolerate.
 
 ## [5.31.0] — 2026-05-19
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -32,7 +32,7 @@ DB_PATH = os.path.join(CACHE_DIR, "bot_state.db")
 _LOCK = asyncio.Lock()
 _db: Optional[aiosqlite.Connection] = None
 _read_pool: asyncio.Queue[aiosqlite.Connection] = asyncio.Queue()
-_READ_POOL_SIZE = 3
+_READ_POOL_SIZE = 10  # raised from 3 — multiple slash commands + watchdog reads
 _last_product_cache_prune: float = 0.0
 _PRODUCT_CACHE_PRUNE_INTERVAL = 3600.0  # 1 hour
 

--- a/utils/http.py
+++ b/utils/http.py
@@ -115,8 +115,13 @@ async def ensure_session() -> aiohttp.ClientSession:
     async with _session_lock:
         if http_session is None or http_session.closed:
             connector = aiohttp.TCPConnector(
-                limit=20,
-                limit_per_host=10,
+                # Pool sizes raised from 20/10 to 100/25 so radar-frame
+                # bursts, concurrent slash commands, and outbreak-time
+                # warning images don't throttle on the connector before
+                # they even hit the server. 25 per host is well below
+                # what NWS API / IEM Autoplot will tolerate.
+                limit=100,
+                limit_per_host=25,
                 ttl_dns_cache=300,
                 keepalive_timeout=75,
             )


### PR DESCRIPTION
## Summary
- `aiohttp.TCPConnector`: `limit` **20 → 100**, `limit_per_host` **10 → 25** (`utils/http.py`)
- SQLite read pool: `_READ_POOL_SIZE` **3 → 10** (`utils/db.py`)

The old caps throttled the bot during outbreaks when radar-frame bursts, concurrent slash commands, and warning-image downloads stacked up against the connector before reaching the server. 25 per host is well below what NWS API / IEM Autoplot tolerate, and a 10-slot SQLite read pool accommodates several `/status`, `/sounding`, `/watches` commands fanning out at once.

Memory impact: aiohttp connectors are lightweight; SQLite read connections add ~1MB each. Total bump is ~7MB on the 12GB hosts.

Second of 4 PRs from Gemini's v5.33.0 plan.

## Test plan
- [x] Full suite: 442 passed (no behavior changes to test)
- [ ] Live verify after merge: confirm via logs that radar/image downloads during a severe-wx test no longer queue on the connector