### PR TITLE
fix: cancel cache-cleanup task on shutdown + run watchdog probes on STANDBY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ version numbers follow [SemVer](https://semver.org/).
 - **O(1) `posted_product_ids` membership lookup.** `posted_product_ids` was a `deque(maxlen=1000)`, so the `in` check on the hot dedup path (NWWS + IEMBot triggers + NWS poll all hit it per product) was O(N) — measurable during severe weather outbreaks with thousands of products/sec. Replaced with `BoundedFIFOKeys`, a dict-backed FIFO (`dict` preserves insertion order in CPython 3.7+) that gives O(1) `in` / `append` / `remove` while keeping the same drop-in interface (`.append()`, `.remove()` with `ValueError`, `.extend()`, `in`, `list()`, `len()`). No call sites changed.
 - **Bumped connection pool limits.** `aiohttp.TCPConnector` `limit` 20→100 and `limit_per_host` 10→25 in `utils/http.py`; SQLite read pool `_READ_POOL_SIZE` 3→10 in `utils/db.py`. The old caps throttled the bot during outbreaks when radar-frame bursts, concurrent slash commands, and warning-image downloads stacked up against the connector before reaching the server. 25 per host is well below what NWS API / IEM Autoplot tolerate.
 
+### Fixed
+- **`_periodic_cache_cleanup` task leaked on shutdown.** `on_ready` spawned it via bare `asyncio.create_task(...)` without saving the handle. `_shutdown()` never knew about it, so on a clean stop the task kept running until the event loop was torn down — systemd saw a stale process and waited out the kill timeout. Saved the handle as a module global `_cache_cleanup_task`; `_shutdown()` now cancels it alongside `watchdog_task`, `periodic_sync`, and `snapshot_events_task`.
+
+### Changed
+- **Watchdog probes now run on STANDBY too.** The probe block previously bailed out entirely on standby, meaning the replica's aiohttp session, TCP keepalives, and DNS cache went cold; the first request after a failover-promotion would have to redo all that work just when latency mattered most. Probes run on both roles; Discord-channel alerts (`session reset`, `probe degraded`) and the session-teardown action stay gated to Primary so the two nodes don't duplicate noise, and managed-task supervision still short-circuits on standby (those cogs aren't loaded there).
+
 ## [5.31.0] — 2026-05-19
 
 ### Added

--- a/main.py
+++ b/main.py
@@ -252,6 +252,9 @@ _task_alerted = set()
 # startup "task is down" alert immediately followed by "recovered".
 _task_seen_running = set()
 _session_probe_failures = 0
+# Tracked so _shutdown() can cancel the cache-cleanup background task
+# spawned in on_ready — otherwise systemd hangs on stop until SIGKILL.
+_cache_cleanup_task: "asyncio.Task | None" = None
 
 
 async def send_bot_alert(
@@ -325,7 +328,10 @@ async def on_ready():
     if not hasattr(bot, "_cache_cleanup_scheduled"):
         bot._cache_cleanup_scheduled = True
         logger.debug("[CACHE] Scheduling daily cache cleanup task")
-        asyncio.create_task(_periodic_cache_cleanup())
+        global _cache_cleanup_task
+        _cache_cleanup_task = asyncio.create_task(
+            _periodic_cache_cleanup(), name="periodic_cache_cleanup"
+        )
 
 @tasks.loop(hours=24)
 async def periodic_sync():
@@ -378,14 +384,15 @@ async def watchdog_task():
     global _session_probe_failures
     await bot.wait_until_ready()
 
-    # If we are in STANDBY, do not monitor or restart tasks as they
-    # are suppressed by the failover mechanism.
-    if not bot.state.is_primary:
-        return
-
     # Probe two independent endpoints. We only count a failure if BOTH fail —
     # a single-endpoint outage (e.g. NWS maintenance) shouldn't trigger a
     # session teardown or operator alert.
+    #
+    # The probes themselves run on STANDBY too so the replica keeps its
+    # aiohttp session, TCP keepalives, and DNS cache warm — promotion
+    # should never be the first time a request goes out from this process.
+    # Discord-channel alerts and managed-task supervision below are still
+    # gated to PRIMARY to avoid duplicate noise from both nodes.
     _PROBE_PRIMARY = "https://api.weather.gov/"
     _PROBE_SECONDARY = "https://mesonet.agron.iastate.edu/"
 
@@ -404,6 +411,11 @@ async def watchdog_task():
     primary_ok = await _head_ok(_PROBE_PRIMARY)
     probe_healthy = primary_ok or await _head_ok(_PROBE_SECONDARY)
 
+    # Only the Primary surfaces alerts and recreates the shared session —
+    # we don't want both nodes posting "session reset" to Discord, and the
+    # session-teardown action is meaningless on standby (no traffic flowing).
+    primary_role = bot.state.is_primary
+
     if probe_healthy:
         if _session_probe_failures > 0:
             logger.info(f"Session probe recovered after {_session_probe_failures} failure(s)")
@@ -412,31 +424,32 @@ async def watchdog_task():
         _session_probe_failures += 1
         if _session_probe_failures >= 3:
             logger.warning(
-                f"Session probe failed {_session_probe_failures} consecutive times — "
-                "tearing down and recreating"
+                f"Session probe failed {_session_probe_failures} consecutive times"
+                + (" — tearing down and recreating" if primary_role else " (standby; not resetting session)")
             )
-            try:
-                ch = bot.get_channel(DEV_CHANNEL_ID) or await bot.fetch_channel(DEV_CHANNEL_ID)
-                await ch.send(embed=discord.Embed(
-                    title="⚠️ Watchdog: session reset",
-                    description=(
-                        f"Both `{_PROBE_PRIMARY}` and `{_PROBE_SECONDARY}` failed "
-                        f"{_session_probe_failures} consecutive cycles. "
-                        "Tearing down and recreating the aiohttp session."
-                    ),
-                    color=discord.Color.red(),
-                ))
-            except Exception as alert_err:
-                logger.warning(f"Could not send session-reset alert: {alert_err}")
-            await utils.http.close_session()
-            await utils.http.ensure_session()
+            if primary_role:
+                try:
+                    ch = bot.get_channel(DEV_CHANNEL_ID) or await bot.fetch_channel(DEV_CHANNEL_ID)
+                    await ch.send(embed=discord.Embed(
+                        title="⚠️ Watchdog: session reset",
+                        description=(
+                            f"Both `{_PROBE_PRIMARY}` and `{_PROBE_SECONDARY}` failed "
+                            f"{_session_probe_failures} consecutive cycles. "
+                            "Tearing down and recreating the aiohttp session."
+                        ),
+                        color=discord.Color.red(),
+                    ))
+                except Exception as alert_err:
+                    logger.warning(f"Could not send session-reset alert: {alert_err}")
+                await utils.http.close_session()
+                await utils.http.ensure_session()
             _session_probe_failures = 0
         else:
             logger.info(
                 f"Session probe failed ({_session_probe_failures}/3) — "
                 "waiting for next cycle"
             )
-            if _session_probe_failures == 2:
+            if _session_probe_failures == 2 and primary_role:
                 try:
                     ch = bot.get_channel(DEV_CHANNEL_ID) or await bot.fetch_channel(DEV_CHANNEL_ID)
                     await ch.send(embed=discord.Embed(
@@ -449,6 +462,11 @@ async def watchdog_task():
                     ))
                 except Exception as alert_err:
                     logger.warning(f"Could not send degradation alert: {alert_err}")
+
+    # Managed-task supervision below only runs on Primary — STANDBY has its
+    # alerting cogs unloaded, so there's nothing to supervise.
+    if not primary_role:
+        return
 
     # Grace period for startup race: tasks need a few ticks to schedule
     # their first iteration after wait_until_ready() unblocks.
@@ -577,6 +595,8 @@ async def _shutdown():
         periodic_sync.cancel()
     if snapshot_events_task.is_running():
         snapshot_events_task.cancel()
+    if _cache_cleanup_task is not None and not _cache_cleanup_task.done():
+        _cache_cleanup_task.cancel()
 
     # 2. Close DB, HTTP session, and plot worker pool
     try:


### PR DESCRIPTION
## Summary
Two `main.py` reliability fixes from the v5.33.0 plan:

### 1. `_periodic_cache_cleanup` task leaked on shutdown
`on_ready` spawned it via bare `asyncio.create_task(...)` without saving the handle. `_shutdown()` never knew about it, so on a clean stop the task kept running until the event loop was torn down — systemd saw a stale process and waited out the kill timeout. Saved the handle as a module global `_cache_cleanup_task`; `_shutdown()` now cancels it alongside `watchdog_task`, `periodic_sync`, and `snapshot_events_task`.

### 2. Watchdog probes now run on STANDBY too
The probe block previously bailed out entirely on standby, meaning the replica's aiohttp session, TCP keepalives, and DNS cache went cold; the first request after a failover-promotion would have to redo all that work just when latency mattered most.

Probes run on both roles now. Discord-channel alerts (`session reset`, `probe degraded`) and the session-teardown action stay gated to Primary so the two nodes don't duplicate noise. Managed-task supervision still short-circuits on standby (those cogs aren't loaded there).

Third (and final) of the v5.33.0 plan PRs — alongside #423 (BoundedFIFOKeys) and #424 (connection pool limits).

## Test plan
- [x] Full suite: 442 passed (no behavior changes the existing tests cover)
- [ ] Live verify after merge: confirm `SIGTERM` on the bot returns control to systemd in under the usual timeout (no dangling cache-cleanup task)
- [ ] Live verify after merge: standby node logs `Session probe recovered` periodically, confirming the probe actually runs there