### PR TITLE
fix: pin VTEC regex to KWNS to prevent WFO ETN collisions

### DIFF
--- a/cogs/watch_fetch.py
+++ b/cogs/watch_fetch.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("spc_bot")
 # Hoisted patterns — VTEC is scanned in a loop over every active feature,
 # so caching the compiled form measurably helps on large NWS payloads.
 _VTEC_RE = re.compile(
-    r"/[^.]+\.[^.]+\.[^.]+\.(SV|TO)\.A\.(\d{4})\.",
+    r"/[^.]+\.[^.]+\.KWNS\.(SV|TO)\.A\.(\d{4})\.",
     re.IGNORECASE,
 )
 _WW_HREF_RE = re.compile(r'href="[^"]*ww(\d+)\.html"', re.IGNORECASE)


### PR DESCRIPTION
## Summary

- The `_VTEC_RE` regex in `watch_fetch.py` was matching any WFO's VTEC string (`[^.]+` for the WFO segment), not just SPC's
- The NWS Alerts API returns both SPC's watch alert and Watch County Notification (WCN) products from every WFO in the watch area; each WFO has its own ETN sequence resetting to `0001` each year
- Today a WFO's WCN with ETN `0001` appeared before SPC's entry in the API response, so the bot grabbed `0001` as the watch number, fetched `ww0001.html` (January's tornado watch), and posted it — including the tornado watch graphic — instead of the actual current watch
- Fix: pin the WFO segment to `KWNS` (SPC's official identifier), so only SPC-issued VTECs are parsed

## Root cause introduced

Commit `a09a0e9` (April 22) when `_VTEC_RE` was hoisted to module level. The regex was always too broad but never triggered until watch numbers crossed ~230, putting them in range of WFO ETN sequences.

## Test plan

- All 447 existing tests pass (including `tests/test_watches.py` which exercises VTEC parsing with `KWNS` fixtures)
- Manually confirmed the WFO WCN scenario: a VTEC like `/O.NEW.KPBZ.SV.A.0001.../` will now correctly be ignored