### PR TITLE
fix: correct VTEC operational-class filter and HTML fallback tornado classifier

### DIFF
--- a/cogs/watch_fetch.py
+++ b/cogs/watch_fetch.py
@@ -23,11 +23,11 @@ logger = logging.getLogger("spc_bot")
 # Hoisted patterns — VTEC is scanned in a loop over every active feature,
 # so caching the compiled form measurably helps on large NWS payloads.
 _VTEC_RE = re.compile(
-    r"/[^.]+\.[^.]+\.KWNS\.(SV|TO)\.A\.(\d{4})\.",
+    r"/O\.[^.]+\.[A-Z]{4}\.(SV|TO)\.A\.(\d{4})\.",
     re.IGNORECASE,
 )
 _WW_HREF_RE = re.compile(r'href="[^"]*ww(\d+)\.html"', re.IGNORECASE)
-_TORNADO_WATCH_RE = re.compile(r"Tornado Watch", re.IGNORECASE)
+_TORNADO_WATCH_RE = re.compile(r"Tornado Watch Number", re.IGNORECASE)
 
 # Module-level conditional-GET state for the NWS active-alerts feed.
 _nws_last_parsed: Optional[Dict[str, dict]] = None


### PR DESCRIPTION
## Summary

- **`_VTEC_RE`**: Replaces the over-narrow `KWNS` office pin with `/O\.` (operational action-class prefix) + `[A-Z]{4}` (any WFO). Rejects test/experimental watches (`/T.`, `/E.`) while correctly matching both SPC-direct VTEC strings *and* WFO-issued Watch County Notifications that share the same ETN.
- **`_TORNADO_WATCH_RE`**: Changed from `"Tornado Watch"` to `"Tornado Watch Number"` so the HTML fallback classifier matches only the actual product title — not the SPC site navigation menu, which contains "Tornado Watch" as a link on every page (causing all SVR watches to be misclassified as tornado watches when the HTML fallback was active).

## Root cause chain

1. `#427` pinned `_VTEC_RE` to `KWNS` to fix test-watch ETN collisions, but WFO-issued WCNs (Watch County Notifications) use local WFO IDs, not `KWNS` — so the filter rejected all valid watch features.
2. An empty NWS API result (`{}`) triggers the HTML scraper fallback.
3. In the HTML fallback, `_TORNADO_WATCH_RE = re.compile(r"Tornado Watch")` matched the nav menu present on every SPC page, classifying every active SVR watch as a Tornado Watch.

## Test plan

- [x] All 447 unit tests pass locally
- [ ] Verify next real watch posts with correct type and number after deploy