### PR TITLE
fix: cross-validate NWS API watch ETNs against SPC watch index page

### DIFF
--- a/cogs/watch_fetch.py
+++ b/cogs/watch_fetch.py
@@ -89,6 +89,18 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
         logger.warning(f"NWS API JSON parse error: {e}")
         return None
 
+    # Fetch SPC watch index to build authoritative set of active watch numbers.
+    # The NWS API occasionally carries stale/bogus WCN continuations from local
+    # WFOs for watches that SPC issued months ago (e.g. KILN still sending CON
+    # for watch #0001 from January). The SPC index page is the ground truth.
+    spc_html = await http_get_text(SPC_WATCH_INDEX_URL)
+    valid_etns: set = set()
+    if spc_html:
+        for wm in _WW_HREF_RE.finditer(spc_html):
+            valid_etns.add(wm.group(1).zfill(4))
+    else:
+        logger.warning("Could not fetch SPC watch index for ETN validation — accepting all NWS API results")
+
     result = {}
     for feature in data.get("features", []):
         props = feature.get("properties", {})
@@ -99,6 +111,9 @@ async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
             if not m:
                 continue
             watch_num = m.group(2).zfill(4)
+            if valid_etns and watch_num not in valid_etns:
+                logger.debug(f"Skipping watch #{watch_num} — not listed on SPC watch index")
+                continue
             wtype = "TORNADO" if m.group(1).upper() == "TO" else "SVR"
             if watch_num in result:
                 break

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -28,6 +28,15 @@ class TestFetchActiveWatchesNWS:
             }
         }
 
+    @staticmethod
+    def _spc_html(*watch_nums):
+        """Build a minimal SPC watch index HTML listing the given watch numbers."""
+        links = "".join(
+            f'<a href="/products/watch/ww{n.zfill(4)}.html">Watch {n}</a>'
+            for n in watch_nums
+        )
+        return f"<html><body>{links}</body></html>"
+
     @pytest.mark.asyncio
     async def test_valid_tornado_watch(self):
         """Valid TO.A VTEC string is parsed as TORNADO watch."""
@@ -43,6 +52,10 @@ class TestFetchActiveWatchesNWS:
             "cogs.watch_fetch.http_get_bytes_conditional",
             new_callable=AsyncMock,
             return_value=(payload, 200, None),
+        ), patch(
+            "cogs.watch_fetch.http_get_text",
+            new_callable=AsyncMock,
+            return_value=self._spc_html("0042"),
         ):
             result = await fetch_active_watches_nws()
 
@@ -65,6 +78,10 @@ class TestFetchActiveWatchesNWS:
             "cogs.watch_fetch.http_get_bytes_conditional",
             new_callable=AsyncMock,
             return_value=(payload, 200, None),
+        ), patch(
+            "cogs.watch_fetch.http_get_text",
+            new_callable=AsyncMock,
+            return_value=self._spc_html("0101"),
         ):
             result = await fetch_active_watches_nws()
 
@@ -86,6 +103,10 @@ class TestFetchActiveWatchesNWS:
             "cogs.watch_fetch.http_get_bytes_conditional",
             new_callable=AsyncMock,
             return_value=(payload, 200, None),
+        ), patch(
+            "cogs.watch_fetch.http_get_text",
+            new_callable=AsyncMock,
+            return_value=self._spc_html("0007"),
         ):
             result = await fetch_active_watches_nws()
 
@@ -106,6 +127,10 @@ class TestFetchActiveWatchesNWS:
             "cogs.watch_fetch.http_get_bytes_conditional",
             new_callable=AsyncMock,
             return_value=(payload, 200, None),
+        ), patch(
+            "cogs.watch_fetch.http_get_text",
+            new_callable=AsyncMock,
+            return_value=self._spc_html("0042"),
         ):
             result = await fetch_active_watches_nws()
 
@@ -144,6 +169,10 @@ class TestFetchActiveWatchesNWS:
             "cogs.watch_fetch.http_get_bytes_conditional",
             new_callable=AsyncMock,
             return_value=(payload, 200, None),
+        ), patch(
+            "cogs.watch_fetch.http_get_text",
+            new_callable=AsyncMock,
+            return_value=self._spc_html("0055"),
         ):
             result = await fetch_active_watches_nws()
 
@@ -189,11 +218,45 @@ class TestFetchActiveWatchesNWS:
             "cogs.watch_fetch.http_get_bytes_conditional",
             new_callable=AsyncMock,
             return_value=(payload, 200, None),
+        ), patch(
+            "cogs.watch_fetch.http_get_text",
+            new_callable=AsyncMock,
+            return_value=self._spc_html(),
         ):
             result = await fetch_active_watches_nws()
 
         assert result == {}
         assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_stale_wfo_etns_filtered_by_spc_index(self):
+        """WFO WCN features with ETNs absent from the SPC index are dropped."""
+        from cogs.watches import fetch_active_watches_nws
+
+        # NWS API returns two features: one valid (0230), one stale WFO ETN (0001)
+        valid_feature = self._make_feature(
+            "/O.CON.KCLE.SV.A.0230.000000T0000Z-260520T0200Z/",
+            expires="2026-05-20T02:00:00+00:00",
+        )
+        stale_feature = self._make_feature(
+            "/O.CON.KILN.SV.A.0001.000000T0000Z-260520T0200Z/",
+            expires="2026-05-20T02:00:00+00:00",
+        )
+        payload = self._make_response([valid_feature, stale_feature])
+
+        with patch(
+            "cogs.watch_fetch.http_get_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=(payload, 200, None),
+        ), patch(
+            "cogs.watch_fetch.http_get_text",
+            new_callable=AsyncMock,
+            return_value=self._spc_html("0230"),  # only 0230 is on the SPC page
+        ):
+            result = await fetch_active_watches_nws()
+
+        assert "0230" in result
+        assert "0001" not in result
 
 
 # ── post_watch_now (iembot fast-path) ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- After parsing the NWS Alerts API, fetch the SPC watch index page and drop any ETN that doesn't appear there
- The SPC page is the authoritative source of genuinely active watch numbers
- If the SPC index fetch fails, all NWS API results are accepted (fail-open) so we don't lose watches on a transient fetch error

## Root cause

KILN (NWS Cincinnati) was emitting a stale `CON` (continuation) WCN for SPC watch #0001 from January 2026 — never properly cancelled. This feature passes the `/O.` operational-class filter because it is an actual (if bogus) operational product. The bot was treating it as a real active watch, fetching `ww0001.html` (a tornado watch from January), and posting it.

The NWS Alerts API has no reliable way to distinguish a stale WFO WCN from a valid one based on the VTEC string alone. The SPC watch index page, however, only lists watches that SPC considers active — so cross-referencing eliminates the bogus entry.

## Test plan

- [x] New test `test_stale_wfo_etns_filtered_by_spc_index` verifies KILN-0001 pattern is dropped while KCLE-0230 passes through
- [x] All 448 tests pass