### PR TITLE
fix: harden /failover slash command interaction handling

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -584,6 +584,23 @@ class FailoverCog(commands.Cog):
 
     # ── Slash command ─────────────────────────────────────────────────────
 
+    async def cog_app_command_error(
+        self, interaction: discord.Interaction, error: app_commands.AppCommandError
+    ) -> None:
+        """Use followup.send() when the interaction was already deferred."""
+        logger.error(f"AppCommand error: Command 'failover' raised an exception: {error}")
+        try:
+            if interaction.response.is_done():
+                await interaction.followup.send(
+                    f"❌ An error occurred: `{error}`", ephemeral=True
+                )
+            else:
+                await interaction.response.send_message(
+                    f"❌ An error occurred: `{error}`", ephemeral=True
+                )
+        except Exception as reply_err:
+            logger.warning(f"[FAILOVER] Could not send error reply: {reply_err}")
+
     @app_commands.command(
         name="failover",
         description="Manually designate the Primary node (Admin only)"
@@ -610,10 +627,13 @@ class FailoverCog(commands.Cog):
             return
 
         now = int(time.time())
-        active_nodes = [
-            node_id for node_id, ts_str in nodes_raw.items()
-            if (now - int(ts_str)) < 300
-        ]
+        active_nodes = []
+        for node_id, ts_str in nodes_raw.items():
+            try:
+                if (now - int(ts_str)) < 300:
+                    active_nodes.append(node_id)
+            except (ValueError, TypeError):
+                pass
 
         if not active_nodes:
             await interaction.followup.send(
@@ -684,6 +704,10 @@ class FailoverSelect(discord.ui.Select):
         self.cog = cog
 
     async def callback(self, interaction: discord.Interaction):
+        # Defer immediately — Redis calls below can exceed the 3-second
+        # component-interaction window, causing 40060 on the final edit.
+        await interaction.response.defer(ephemeral=True)
+
         target = self.values[0]
 
         if target == "CLEAR":
@@ -702,9 +726,9 @@ class FailoverSelect(discord.ui.Select):
                 f"[FAILOVER] Manual override set to '{hostname}' "
                 f"by {interaction.user} ({interaction.user.id})"
             )
-            msg = f"✅ Manual override set: `{hostname}` is now the designated Primary."
+            msg = f"✅ Manual override set: `{hostname}` is now the designated Primary.\nPromotion will take effect within {SYNC_INTERVAL}s."
 
-        await interaction.response.edit_message(content=msg, view=None)
+        await interaction.edit_original_response(content=msg, view=None)
 
 
 async def setup(bot):


### PR DESCRIPTION
## Summary

Three bugs in the `/failover` command that caused the clunky experience during today's incident — the promotion itself succeeded (via MANUAL_KEY → sync_loop), but the Discord side fell apart.

**Bug 1 — 40060 'Interaction already acknowledged' on select**
`FailoverSelect.callback` was doing Redis work *before* calling `interaction.response.edit_message()`. Component interactions have a 3-second window before Discord considers them expired. If the Redis call was slow (up to 5s timeout), `edit_message()` fired after that window closed and got 40060. Fixed by deferring at the top of `callback` and using `edit_original_response()` instead.

**Bug 2 — ValueError crash in `failover_slash`**
The list comprehension `if (now - int(ts_str)) < 300` would raise `ValueError` if any heartbeat timestamp in Redis was malformed. The exception propagated after `defer()` was already called, so discord.py's default error handler tried `response.send_message()` on a deferred interaction — another 40060. Fixed by skipping malformed entries with try/except.

**Bug 3 — No error handler for deferred interactions**
Without `cog_app_command_error`, any exception after `defer()` produced a 40060 error in logs with no user-facing feedback. Added handler that uses `followup.send()` when the interaction is already done.

## Result
- User sees "✅ Manual override set — promotion within 30s" immediately on selection
- Errors surface as clean ephemeral messages instead of silent 40060 log noise
- Malformed Redis heartbeat entries no longer crash the command