### PR TITLE
fix: track and delete time-range selection message in /download sites flow

### DIFF
--- a/cogs/radar/__init__.py
+++ b/cogs/radar/__init__.py
@@ -114,7 +114,8 @@ class RadarCog(commands.Cog):
                 description="Sites: **{}**\nSelect a time range:".format(", ".join(radar_sites)),
                 color=0x0000FF,
             )
-            await interaction.followup.send(embed=embed, view=view)
+            msg = await interaction.followup.send(embed=embed, view=view, wait=True)
+            view.messages_to_delete.append(msg)
             return
 
         # Both sites and time — go straight to download


### PR DESCRIPTION
## Bug

When `/download` was invoked with site codes but no time preset (e.g. `/download sites:KDTX KCLE KBUF`), the bot sent a followup embed showing `TimeRangeView` but immediately discarded the returned message object because `followup.send()` was called without `wait=True`. The message was never appended to `messages_to_delete`, so it persisted in the channel even after all uploads completed successfully.

Confirmed via logs at 01:36–01:37 UTC: all 6 upload parts completed cleanly, but no deletion occurred for the "AWS NEXRAD Data Downloader / Sites: KDTX, KCLE, KBUF / Select a time range" embed.

## Root Cause

`__init__.py` lines 104–118 (`download_slash`, sites-but-no-time branch):

```python
# Before
await interaction.followup.send(embed=embed, view=view)
return
```

`followup.send()` without `wait=True` returns `None`, so the message was untrackable. Even if it had returned a message, it was never added to `view.messages_to_delete`.

## Fix

```python
# After
msg = await interaction.followup.send(embed=embed, view=view, wait=True)
view.messages_to_delete.append(msg)
return
```

`wait=True` makes the call wait for Discord to confirm the message and return the `Message` object. Appending it to `view.messages_to_delete` ensures it gets deleted in the `download_and_zip` cleanup loop along with all other UI messages.

## Test plan
- [ ] Run `/download sites:KDTX` and confirm the time-range embed is deleted after download completes
- [ ] Run `/download sites:KDTX KCLE` (multi-site) and confirm same
- [ ] Run `/download` (no args, interactive flow) and confirm unchanged behavior
- [ ] Run `/download sites:KDTX time:Last 1 hour` (direct download path) and confirm unchanged behavior