### PR TITLE
fix: avoid _role_lock deadlock in _do_promote cog-load rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Promotion rollback could deadlock on `_role_lock`.** If a cog failed to load during `_do_promote()`, the rollback path called `await self._demote()` — which tries to acquire `_role_lock`. The lock was already held by the enclosing `_promote()` and `asyncio.Lock` is not reentrant, so the task would hang indefinitely with `state.is_primary=True` and cogs unloaded, leaving the node stuck until process restart. Rollback now calls `_do_demote()` directly (the lock is already held by the caller). Added a regression test that exercises the real lock through the public `_promote()` entry point with `asyncio.wait_for(timeout=2.0)` — the previous tests only mocked `_demote` so they couldn't catch this.
+
 ## [5.32.2] — 2026-05-20
 
 ### Fixed

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -493,8 +493,11 @@ class FailoverCog(commands.Cog):
                     except Exception as rollback_err:
                         logger.error(f"[FAILOVER] Rollback failure on {loaded}: {rollback_err}")
                 
-                # Signal demotion and exit
-                await self._demote()
+                # Signal demotion and exit. Call _do_demote() directly —
+                # _demote() would re-acquire _role_lock which is already held
+                # by the enclosing _promote(), and asyncio.Lock is not
+                # reentrant (would deadlock the task indefinitely).
+                await self._do_demote()
                 return
 
         nwws = self.bot.get_cog("NWWSCog")

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -8,6 +8,7 @@ These tests verify the core outcomes of the HA state machine:
   4. Lease safety: atomic Lua release/renewal paths.
 """
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -381,8 +382,11 @@ class TestPromoteFaultInjection:
 
         bot.load_extension = AsyncMock(side_effect=_load)
         bot.unload_extension = AsyncMock()
+        # _do_promote calls _do_demote() directly (not _demote()) to avoid
+        # re-acquiring the non-reentrant _role_lock — see the deadlock
+        # regression test below.
         demote_mock = AsyncMock()
-        monkeypatch.setattr(cog, "_demote", demote_mock)
+        monkeypatch.setattr(cog, "_do_demote", demote_mock)
 
         await cog._do_promote()
 
@@ -419,7 +423,7 @@ class TestPromoteFaultInjection:
 
         bot.unload_extension = AsyncMock(side_effect=_unload)
         demote_mock = AsyncMock()
-        monkeypatch.setattr(cog, "_demote", demote_mock)
+        monkeypatch.setattr(cog, "_do_demote", demote_mock)
 
         await cog._do_promote()
 
@@ -442,7 +446,7 @@ class TestPromoteFaultInjection:
         bot.unload_extension = AsyncMock()
         bot.get_cog = MagicMock(return_value=None)  # no NWWSCog to trigger
         demote_mock = AsyncMock()
-        monkeypatch.setattr(cog, "_demote", demote_mock)
+        monkeypatch.setattr(cog, "_do_demote", demote_mock)
 
         await cog._do_promote()
 
@@ -465,9 +469,52 @@ class TestPromoteFaultInjection:
         bot.load_extension = AsyncMock(side_effect=RuntimeError("first cog dies"))
         bot.unload_extension = AsyncMock()
         demote_mock = AsyncMock()
-        monkeypatch.setattr(cog, "_demote", demote_mock)
+        monkeypatch.setattr(cog, "_do_demote", demote_mock)
 
         await cog._do_promote()
 
         bot.unload_extension.assert_not_awaited()
         demote_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_promote_rollback_does_not_deadlock_on_role_lock(self, monkeypatch):
+        """Regression: _do_promote's cog-load rollback must NOT re-acquire
+        _role_lock, because the lock is already held by _promote() and
+        asyncio.Lock is not reentrant. Going through the public _promote()
+        entry point with a real lock would deadlock forever if rollback
+        called _demote() (which also acquires the lock).
+
+        We bound the test with wait_for; a timeout fails loudly rather than
+        hanging the test session."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+        _stub_do_promote_prereqs(monkeypatch, cog)
+
+        fake_exts = ["cog_a", "cog_boom"]
+        monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", fake_exts)
+
+        async def _load(ext):
+            if ext == "cog_boom":
+                raise RuntimeError("trigger rollback")
+
+        bot.load_extension = AsyncMock(side_effect=_load)
+        bot.unload_extension = AsyncMock()
+        # Do NOT mock _do_demote here — we want the real demote path to run
+        # so it acquires/releases state appropriately. But stub the extension
+        # unload-loop side of _do_demote to keep the test isolated.
+        from discord.ext.commands import ExtensionNotLoaded
+        bot.unload_extension = AsyncMock(side_effect=ExtensionNotLoaded("noop"))
+
+        # Real lock semantics — must complete within 2 seconds.
+        try:
+            await asyncio.wait_for(cog._promote(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pytest.fail(
+                "_promote() rollback deadlocked on _role_lock — the rollback "
+                "path must call _do_demote() directly (lock already held), "
+                "not _demote() which tries to re-acquire the same lock."
+            )
+
+        # After rollback the node should be back in standby state.
+        assert bot.state.is_primary is False, \
+            "rollback must leave the node demoted, not stuck as primary"


### PR DESCRIPTION
## Summary
- `_do_promote()` rollback path called `await self._demote()` on cog-load failure, which tries to re-acquire `_role_lock` — already held by the enclosing `_promote()`. `asyncio.Lock` is not reentrant, so the task hung indefinitely with `is_primary=True` and cogs unloaded, stuck until process restart.
- Rollback now calls `_do_demote()` directly (lock already held by caller).
- Added a regression test that drives the public `_promote()` entry point with a real lock and bounds with `asyncio.wait_for(timeout=2.0)`. The existing fault-injection tests (#419) only mocked `_demote`, so they couldn't catch this — verified by temporarily reverting the fix: the new test fails with `_promote() rollback deadlocked on _role_lock`, passes with the fix.

## Test plan
- [x] `pytest tests/test_failover_coverage.py::TestPromoteFaultInjection` — all 5 pass (4 existing updated to mock `_do_demote` instead of `_demote`; 1 new regression test)
- [x] Full suite: 449 passed
- [x] Manually verified the new test fails when reverted to the buggy `_demote()` call