### PR TITLE
chore: small cleanups (redis-cmd, BoundedFIFO, to_dict, process-uuid, gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ CLAUDE.md
 .coverage
 progress.md
 target/
+bot_state.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ version numbers follow [SemVer](https://semver.org/).
 ### Fixed
 - **Promotion rollback could deadlock on `_role_lock`.** If a cog failed to load during `_do_promote()`, the rollback path called `await self._demote()` — which tries to acquire `_role_lock`. The lock was already held by the enclosing `_promote()` and `asyncio.Lock` is not reentrant, so the task would hang indefinitely with `state.is_primary=True` and cogs unloaded, leaving the node stuck until process restart. Rollback now calls `_do_demote()` directly (the lock is already held by the caller). Added a regression test that exercises the real lock through the public `_promote()` entry point with `asyncio.wait_for(timeout=2.0)` — the previous tests only mocked `_demote` so they couldn't catch this.
 
+### Changed
+- **Small cleanups across `utils/` and `cogs/failover.py`.** `utils/state_store.py:_redis_cmd()` no longer stringifies its arguments — redis-py handles ints/floats/bytes natively, so the coercion was lossy if non-text payloads were ever passed through. `utils/state.py:BoundedFIFOKeys.append()` replaces the eviction `while` loop with an `if` (only one entry can be added per call, so only one eviction is ever needed). `utils/state.py:BotState.to_dict()` now uses `.get("expires")` consistently in the watch-serialization branch instead of mixing subscript and `.get`. `cogs/failover.py:_PROCESS_UUID` is now a per-instance `self._process_uuid` reassigned in `FailoverCog.__init__`, and `_node_identity` became a method — so `importlib.reload(cogs.failover)` during tests yields a fresh identity instead of reusing a stale module-level constant. `.gitignore` now excludes `bot_state.db` so a transient 0-byte file at the repo root can't sneak into CI state.
+
 ## [5.32.2] — 2026-05-20
 
 ### Fixed

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -101,22 +101,16 @@ def _require_failover_token() -> str:
     return FAILOVER_TOKEN
 
 
-_PROCESS_UUID = uuid.uuid4().hex[:8]
-
-
-def _node_identity(is_primary: bool) -> str:
-    """Per-process lease value: role:hostname:uuid."""
-    role = "P" if is_primary else "S"
-    return f"{role}:{socket.gethostname()}:{_PROCESS_UUID}"
-
-
 class FailoverCog(commands.Cog):
     MANAGED_TASK_NAMES = [("sync_loop", "sync_loop")]
 
     def __init__(self, bot):
         self.bot = bot
         self._primary_failures = 0
-        self._identity = _node_identity(bot.state.is_primary)
+        # Fresh per-instance UUID so importlib.reload() during tests yields
+        # a new identity rather than reusing a stale module-level constant.
+        self._process_uuid = uuid.uuid4().hex[:8]
+        self._identity = self._node_identity(bot.state.is_primary)
         self._cog_load_monotonic: float | None = None
         # Serializes _promote/_demote so a manual override and a lease-expiry
         # firing in the same sync_loop tick cannot race each other.
@@ -125,6 +119,11 @@ class FailoverCog(commands.Cog):
         # from utils.state_store so lease operations stay independent of the
         # shared pool's health.
         self._redis: aioredis.Redis | None = None
+
+    def _node_identity(self, is_primary: bool) -> str:
+        """Per-instance lease value: role:hostname:uuid."""
+        role = "P" if is_primary else "S"
+        return f"{role}:{socket.gethostname()}:{self._process_uuid}"
 
     def _build_redis(self) -> aioredis.Redis:
         # Use ELECTION_REDIS_URL if set (standby nodes point this at the primary's
@@ -425,7 +424,7 @@ class FailoverCog(commands.Cog):
         self.bot.state.is_primary = True
         self.bot.state.failover_count += 1
         # Update identity so the next heartbeat HSET announces us as Primary ("P:").
-        self._identity = _node_identity(True)
+        self._identity = self._node_identity(True)
         await self._cleanup_own_stale_entries()
 
         from utils.events_db import restore_from_sync, set_syncthing_folder_mode  # noqa: PLC0415
@@ -553,7 +552,7 @@ class FailoverCog(commands.Cog):
     async def _do_demote(self) -> None:
         logger.info("[FAILOVER] Demoting to STANDBY")
         self.bot.state.is_primary = False
-        self._identity = _node_identity(False)
+        self._identity = self._node_identity(False)
         from utils.events_db import set_syncthing_folder_mode  # noqa: PLC0415
         await set_syncthing_folder_mode("receiveonly")
         failed = []

--- a/utils/state.py
+++ b/utils/state.py
@@ -68,13 +68,14 @@ class BoundedFIFOKeys:
         if key in self._d:
             return
         self._d[key] = None
-        while len(self._d) > self._maxlen:
-            # Evict oldest (dicts preserve insertion order; first key is oldest)
+        if len(self._d) > self._maxlen:
+            # Evict oldest (dicts preserve insertion order; first key is oldest).
+            # Only one entry can be added per call, so a single eviction suffices.
             try:
                 oldest = next(iter(self._d))
+                del self._d[oldest]
             except StopIteration:
-                break
-            del self._d[oldest]
+                pass
 
     def extend(self, keys) -> None:
         for k in keys:
@@ -475,7 +476,7 @@ class BotState:
             "active_watches": {
                 k: {
                     "type": v.get("type"),
-                    "expires": v["expires"].isoformat() if v.get("expires") else None,
+                    "expires": v.get("expires").isoformat() if v.get("expires") else None,
                     "affected_zones": v.get("affected_zones", []),
                 }
                 for k, v in self.active_watches.copy().items()

--- a/utils/state.py
+++ b/utils/state.py
@@ -476,7 +476,7 @@ class BotState:
             "active_watches": {
                 k: {
                     "type": v.get("type"),
-                    "expires": v.get("expires").isoformat() if v.get("expires") else None,
+                    "expires": exp.isoformat() if (exp := v.get("expires")) else None,
                     "affected_zones": v.get("affected_zones", []),
                 }
                 for k, v in self.active_watches.copy().items()

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -178,9 +178,8 @@ async def _redis_cmd(*args: Any) -> Any:
 
     client = _get_redis_client()
     cmd_name = str(args[0]).upper()
-    cmd_args = [str(a) for a in args[1:]]
     try:
-        return await client.execute_command(cmd_name, *cmd_args)
+        return await client.execute_command(cmd_name, *args[1:])
     except (
         redis_exc.ConnectionError,
         redis_exc.TimeoutError,


### PR DESCRIPTION
## Summary
Five small, independent cleanups across `utils/` and `cogs/failover.py`:

- **`utils/state_store.py:_redis_cmd()`** — stop stringifying args. redis-py handles ints/floats/bytes natively, so the coercion was lossy for any non-text payloads. None-rejection check is preserved.
- **`utils/state.py:BoundedFIFOKeys.append()`** — replace eviction `while` loop with `if`. Only one entry is added per call, so only one eviction is ever needed. `try/except StopIteration` retained as cheap defensive guard.
- **`utils/state.py:BotState.to_dict()`** — use `v.get("expires")` consistently in the watch-serialization branch instead of mixing subscript + `.get`.
- **`cogs/failover.py`** — move `_PROCESS_UUID` into `FailoverCog.__init__` as `self._process_uuid`, and convert `_node_identity` to a method. `importlib.reload(cogs.failover)` during tests now yields a fresh identity instead of reusing a stale module-level constant. All three call sites updated (`__init__`, `_do_promote`, `_do_demote`).
- **`.gitignore`** — add `bot_state.db` so a transient 0-byte file at the repo root can't sneak into CI state.

## Test plan
- [x] Full pytest suite green (448 passed)
- [x] Pre-push hook (lint + syntax + tests) green
- [ ] No regression in failover identity strings on a live deploy (manual smoke after merge)