### PR TITLE
fix: SET NX at start of _do_promote prevents split-brain on lease expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Split-brain prevention in `_do_promote`.** If two standbys raced to promote after the lease expired, both ran the full promotion sequence — set `is_primary=True` locally, invalidated caches, then both wrote the lease unconditionally (last-writer-wins). For one heartbeat window both nodes thought they owned primary and could post to Discord. Now the *first* action in `_do_promote` is an atomic `SET ... NX EX HEARTBEAT_TTL`. The NX loser aborts cleanly — no `is_primary=True`, no cache invalidation, no cog load, stays a clean standby. The redundant `_write_lease()` call further down was removed since the lease is already claimed. Manual override flows pass `force=True` through `_promote(force=True)` → `_do_promote(force=True)`, which uses an unconditional `SET` so an operator can still forcibly take the lease from a held primary. 4 new tests in `TestPromoteSplitBrainPrevention` pin the contract, including a two-cog concurrent race against a shared in-memory Redis.
+
 ### Added
 - **Fault-injection coverage for `_do_promote` side-effects.** Four new tests in `TestPromoteSideEffectFaultInjection` pin the contract that failures in `mirror_to_sqlite()`, `_rehydrate_bot_state()`, and `resync_to_redis()` during promotion are non-fatal — the bot still loads all cogs, syncs the slash command tree, and ends up `is_primary=True`. The `resync_to_redis()` failure path additionally asserts a `critical=True` operator alert is dispatched (dirty writes from the standby period may have been lost). Worst-case test exercises all three failing simultaneously. Locks in current behavior so a future refactor can't accidentally make any of these failures strand a node mid-promotion.
 

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -319,7 +319,10 @@ class FailoverCog(commands.Cog):
                 if self._is_our_node(manual_primary):
                     if not self.bot.state.is_primary:
                         logger.warning(f"[FAILOVER] Manual override: promoting '{self._identity}'")
-                        await self._promote()
+                        # force=True so the conditional SET NX in _do_promote
+                        # is bypassed — an operator's explicit override must
+                        # be able to take the lease from a currently-held node.
+                        await self._promote(force=True)
                 else:
                     if self.bot.state.is_primary:
                         logger.warning(f"[FAILOVER] Manual override: demoting to standby (target: '{manual_primary}')")
@@ -416,18 +419,52 @@ class FailoverCog(commands.Cog):
 
     # ── Promotion / demotion ──────────────────────────────────────────────
 
-    async def _promote(self) -> None:
+    async def _promote(self, force: bool = False) -> None:
         async with self._role_lock:
             if self.bot.state.is_primary:
                 return  # already primary — idempotent
-            await self._do_promote()
+            await self._do_promote(force=force)
 
-    async def _do_promote(self) -> None:
-        logger.warning("[FAILOVER] !!! PROMOTING TO PRIMARY !!!")
+    async def _do_promote(self, force: bool = False) -> None:
+        # ── Split-brain prevention ────────────────────────────────────────
+        # Claim the lease atomically BEFORE mutating any state. If two
+        # standbys race to promote after the lease expires, the SET NX loser
+        # aborts here — no `is_primary=True`, no cache invalidation, no cog
+        # load — and stays a clean standby. `force=True` (manual override)
+        # bypasses NX so an operator can forcibly take the lease from a
+        # currently-held primary.
+        promoting_identity = self._node_identity(True)
+        if force:
+            await self._exec(
+                "SET", LEASE_KEY, promoting_identity, "EX", str(HEARTBEAT_TTL)
+            )
+            logger.warning("[FAILOVER] !!! PROMOTING TO PRIMARY (forced) !!!")
+        else:
+            claim_result = await self._exec(
+                "SET", LEASE_KEY, promoting_identity, "NX", "EX", str(HEARTBEAT_TTL)
+            )
+            if claim_result != "OK":
+                # NX failed — either another node holds the lease, or Redis
+                # is unavailable. In both cases, the safe action is to
+                # remain a standby. Try to identify the holder for the log.
+                holder = await self._read_lease_holder()
+                if holder:
+                    logger.warning(
+                        f"[FAILOVER] Promotion aborted — lease held by {holder!r}. "
+                        f"Remaining standby."
+                    )
+                else:
+                    logger.warning(
+                        "[FAILOVER] Promotion aborted — could not claim lease "
+                        "(Redis unavailable or contended). Remaining standby."
+                    )
+                return
+            logger.warning("[FAILOVER] !!! PROMOTING TO PRIMARY !!!")
+
         self.bot.state.is_primary = True
         self.bot.state.failover_count += 1
         # Update identity so the next heartbeat HSET announces us as Primary ("P:").
-        self._identity = self._node_identity(True)
+        self._identity = promoting_identity
         await self._cleanup_own_stale_entries()
 
         from utils.events_db import restore_from_sync, set_syncthing_folder_mode  # noqa: PLC0415
@@ -449,7 +486,9 @@ class FailoverCog(commands.Cog):
             logger.warning(f"[FAILOVER] Could not promote Redis replica: {e}")
 
         state_store.invalidate_all_caches()
-        await self._write_lease()
+        # Lease was already claimed atomically at the top of this method —
+        # no second _write_lease() call needed (and writing it again here
+        # would overwrite our own value pointlessly).
 
         try:
             await state_store.mirror_to_sqlite()

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -348,6 +348,10 @@ def _stub_do_promote_prereqs(monkeypatch, cog):
     monkeypatch.setattr(cog, "_write_lease", AsyncMock())
     monkeypatch.setattr(cog, "_rehydrate_bot_state", AsyncMock())
 
+    # SET NX at the top of _do_promote returns "OK" so these tests exercise
+    # the cog-load path (without the stub the network call aborts promotion).
+    monkeypatch.setattr(cog, "_exec", _stub_exec({"SET": "OK"}))
+
     import utils.state_store as state_store
     monkeypatch.setattr(state_store, "invalidate_all_caches", MagicMock())
     monkeypatch.setattr(state_store, "mirror_to_sqlite", AsyncMock())
@@ -543,6 +547,9 @@ def _stub_for_full_promotion(monkeypatch, cog):
     monkeypatch.setattr(cog, "_build_local_redis",
                         MagicMock(side_effect=Exception("skip redis flip")))
     monkeypatch.setattr(cog, "_write_lease", AsyncMock())
+    # SET NX at top of _do_promote returns "OK" so these tests can exercise
+    # the post-claim side-effect paths.
+    monkeypatch.setattr(cog, "_exec", _stub_exec({"SET": "OK"}))
 
     import utils.events_db as events_db
     monkeypatch.setattr(events_db, "restore_from_sync", MagicMock())
@@ -665,3 +672,146 @@ class TestPromoteSideEffectFaultInjection:
         assert bot.state.is_primary is True
         assert bot.load_extension.await_count == 2
         bot.tree.sync.assert_awaited_once()
+
+
+# ── Split-brain prevention: atomic lease claim at _do_promote start ──────────
+#
+# These tests pin the contract that `_do_promote()` MUST claim the lease as
+# its first action (via `SET ... NX EX HEARTBEAT_TTL`) before mutating any
+# in-process state. If two standbys promote concurrently, the NX loser must
+# abort cleanly — no `is_primary=True`, no cache invalidation, no cog load.
+# The `force=True` path (manual override) bypasses NX so an operator can
+# forcibly take the lease from any currently-held node.
+
+class TestPromoteSplitBrainPrevention:
+
+    @pytest.mark.asyncio
+    async def test_nx_loser_aborts_promotion_cleanly(self, monkeypatch):
+        """If SET NX returns None (lease held), the cog must NOT mutate
+        is_primary, must NOT invalidate caches, must NOT load any cogs."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+        _stub_do_promote_prereqs(monkeypatch, cog)
+        # Override the prereq stub: SET returns None (NX failed),
+        # GET (subsequent holder lookup) returns the other node's identity.
+        monkeypatch.setattr(cog, "_exec", _stub_exec({
+            "SET": None,
+            "GET": "P:other-node:beef",
+        }))
+
+        import utils.state_store as state_store
+        invalidate = MagicMock()
+        monkeypatch.setattr(state_store, "invalidate_all_caches", invalidate)
+        monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", ["cog_a"])
+        bot.load_extension = AsyncMock()
+
+        await cog._do_promote()
+
+        assert bot.state.is_primary is False, \
+            "NX loser must not flip is_primary"
+        invalidate.assert_not_called()
+        bot.load_extension.assert_not_awaited()
+        bot.tree.sync.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_nx_winner_completes_promotion(self, monkeypatch):
+        """If SET NX returns 'OK', the cog promotes normally."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+        _stub_do_promote_prereqs(monkeypatch, cog)  # already stubs SET → "OK"
+
+        monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", ["cog_a", "cog_b"])
+        bot.load_extension = AsyncMock()
+
+        await cog._do_promote()
+
+        assert bot.state.is_primary is True
+        assert bot.load_extension.await_count == 2
+        bot.tree.sync.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_force_true_bypasses_nx_and_takes_lease(self, monkeypatch):
+        """With force=True the lease write is unconditional (no NX) — the
+        manual override path must be able to claim from a held primary."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+        _stub_do_promote_prereqs(monkeypatch, cog)
+
+        # Record every SET call so we can assert NX was NOT used.
+        set_calls = []
+
+        async def _record(*args):
+            if str(args[0]).upper() == "SET":
+                set_calls.append(tuple(str(a).upper() for a in args[1:]))
+                return "OK"
+            return None
+
+        monkeypatch.setattr(cog, "_exec", AsyncMock(side_effect=_record))
+        monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", ["cog_a"])
+        bot.load_extension = AsyncMock()
+
+        await cog._do_promote(force=True)
+
+        assert bot.state.is_primary is True
+        # At least one SET on LEASE_KEY happened, and the first one (the claim)
+        # did NOT include NX as an argument.
+        lease_sets = [
+            args for args in set_calls
+            if any(a == failover_module.LEASE_KEY.upper() for a in args)
+        ]
+        assert lease_sets, "force=True must still write the lease"
+        assert "NX" not in lease_sets[0], \
+            f"force=True must NOT use NX; got {lease_sets[0]}"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_promote_only_one_winner(self, monkeypatch):
+        """Two cogs sharing one shared 'redis' (a dict) — only one of them
+        must end up primary. This is the actual split-brain scenario the
+        SET NX prevents."""
+        bot_a = _make_bot(is_primary=False)
+        bot_b = _make_bot(is_primary=False)
+        cog_a = FailoverCog(bot_a)
+        cog_b = FailoverCog(bot_b)
+        # Give the cogs distinct identities — otherwise both look like the
+        # same node, NX wouldn't distinguish them anyway.
+        cog_a._process_uuid = "aaa"
+        cog_b._process_uuid = "bbb"
+        _stub_do_promote_prereqs(monkeypatch, cog_a)
+        _stub_do_promote_prereqs(monkeypatch, cog_b)
+
+        # Shared in-memory "redis" — only the first SET NX wins.
+        shared: dict[str, str] = {}
+
+        def _make_exec(cog):
+            async def _exec(*args):
+                cmd = str(args[0]).upper()
+                if cmd == "SET":
+                    key = str(args[1])
+                    val = str(args[2])
+                    use_nx = any(str(a).upper() == "NX" for a in args[3:])
+                    if use_nx and key in shared:
+                        return None
+                    shared[key] = val
+                    return "OK"
+                if cmd == "GET":
+                    return shared.get(str(args[1]))
+                return None
+            return AsyncMock(side_effect=_exec)
+
+        monkeypatch.setattr(cog_a, "_exec", _make_exec(cog_a))
+        monkeypatch.setattr(cog_b, "_exec", _make_exec(cog_b))
+
+        monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", ["cog_x"])
+        bot_a.load_extension = AsyncMock()
+        bot_b.load_extension = AsyncMock()
+
+        # Race them. asyncio.gather schedules both before either runs to
+        # completion — the SET NX inside _do_promote is the contention point.
+        await asyncio.gather(cog_a._do_promote(), cog_b._do_promote())
+
+        winners = [b.state.is_primary for b in (bot_a, bot_b)]
+        assert winners.count(True) == 1, \
+            f"exactly one cog must win the lease; got is_primary={winners}"
+        # Only the winner should have loaded cogs.
+        assert (bot_a.load_extension.await_count == 1) ^ \
+               (bot_b.load_extension.await_count == 1)


### PR DESCRIPTION
## Summary
Workstream A, steps 2 & 3 of 3 — combined because A1 alone would break manual override.

### The split-brain
If two standbys race to promote after natural lease expiry, both ran the full promotion sequence: set `is_primary=True` locally, invalidate caches, *then* both wrote the lease unconditionally (last-writer-wins). For one heartbeat window both nodes thought they owned primary and could post to Discord.

### The fix
The *first* action in `_do_promote` is now an atomic `SET ... NX EX HEARTBEAT_TTL`. The NX loser aborts cleanly:
- no `is_primary=True`
- no cache invalidation
- no cog load
- stays a clean standby with a clear log line naming the holder

The redundant `_write_lease()` call further down was removed since the lease is already claimed at the top.

### Manual override still works (force=True)
Without `force=True`, the manual override flow would also hit the NX gate and refuse to take the lease from the current primary — defeating the override's purpose. So `_promote(force=True)` → `_do_promote(force=True)` uses an unconditional `SET`. The single existing manual-override caller in `sync_loop` was flipped accordingly.

### Tests
4 new tests in `TestPromoteSplitBrainPrevention`:
- `test_nx_loser_aborts_promotion_cleanly`
- `test_nx_winner_completes_promotion`
- `test_force_true_bypasses_nx_and_takes_lease`
- `test_concurrent_promote_only_one_winner` — two cogs sharing an in-memory `dict`-backed Redis stub, raced via `asyncio.gather`. Sanity-checked by temporarily removing the `NX` argument — the test correctly fails (both cogs end up primary).

Builds on #439's fault-injection coverage so refactors of this path are safer going forward.

## Test plan
- [x] `pytest tests/test_failover_coverage.py` — 20 pass (16 existing + 4 new)
- [x] Full suite: 475 pass
- [x] Race test verified to fail when SET NX is removed