### PR TITLE
fix: surface swallowed exceptions in failover Redis cleanup and sounding metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Improved observability for silent exception handlers.** Redis connection cleanup in `FailoverCog` now logs a warning (with traceback) if `aclose()` raises instead of silently discarding the error. Sounding source-metadata extraction in `sounding_views.py` now emits a debug-level log on failure instead of swallowing it.
+
 ## [5.34.2] — 2026-05-20
 
 ### Fixed

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -187,7 +187,7 @@ class FailoverCog(commands.Cog):
             try:
                 await self._redis.aclose()
             except Exception:
-                pass
+                logger.warning("Failed to close Redis connection", exc_info=True)
             self._redis = None
 
     def _is_our_node(self, target: str) -> bool:

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -193,8 +193,8 @@ async def _send_sounding_embed(
                 source = clean_data["site_info"].get("source", "")
                 if source:
                     source_str = f" | Source: {source}"
-        except (KeyError, AttributeError, TypeError):
-            pass
+        except (KeyError, AttributeError, TypeError) as e:
+            logger.debug(f"Failed to extract sounding source metadata: {e}")
 
     caption = "**RAOB Sounding \u2014 {}**\nValid: {} | {} mode{}{}".format(
         label, time_label, mode_label, source_str, fallback_note


### PR DESCRIPTION
## Summary

- `FailoverCog` Redis `aclose()` now logs `WARNING` with traceback instead of silently passing — connection-pool leaks become visible in prod logs
- `sounding_views.py` source-metadata extraction emits `DEBUG` log on failure instead of swallowing it

## Test plan
- [ ] CI green
- [ ] Confirm no new log noise under normal operation (these only fire on actual errors)
