### PR TITLE
fix: four reliability fixes from Gemini review (split-brain, NWWS blocking, poller pileup, dedup limit)

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -215,10 +215,12 @@ class FailoverCog(commands.Cog):
             logger.warning(f"[FAILOVER] Redis error: {e!r}")
             return None
 
-    async def _write_lease(self) -> None:
+    async def _write_lease(self) -> bool:
         """Unconditional lease write — used only on startup/promotion where
-        we are claiming the key for the first time."""
-        await self._exec("SET", LEASE_KEY, self._identity, "EX", str(HEARTBEAT_TTL))
+        we are claiming the key for the first time. Returns True if Redis
+        confirmed the write; False means Redis was unreachable."""
+        result = await self._exec("SET", LEASE_KEY, self._identity, "EX", str(HEARTBEAT_TTL))
+        return result is not None
 
     async def _renew_lease(self) -> bool:
         """Conditionally renew lease only if we still hold it (C6 fix).
@@ -266,7 +268,10 @@ class FailoverCog(commands.Cog):
         if manual:
             if self._is_our_node(manual):
                 logger.info(f"[FAILOVER] Startup: manual override names us as Primary")
-                await self._write_lease()
+                if not await self._write_lease():
+                    logger.warning("[FAILOVER] Startup (manual): Redis unreachable — cannot write lease; booting as STANDBY")
+                    self.bot.state.is_primary = False
+                    return False
                 self.bot.state.is_primary = True
                 try:
                     await state_store.resync_to_redis()
@@ -291,7 +296,13 @@ class FailoverCog(commands.Cog):
             return False
 
         logger.info(f"[FAILOVER] Startup: claiming lease as Primary ('{self._identity}')")
-        await self._write_lease()
+        if not await self._write_lease():
+            logger.warning(
+                "[FAILOVER] Startup: Redis unreachable — could not write lease; "
+                "booting as STANDBY to avoid split-brain"
+            )
+            self.bot.state.is_primary = False
+            return False
         try:
             await state_store.resync_to_redis()
         except Exception as e:

--- a/cogs/nwws.py
+++ b/cogs/nwws.py
@@ -407,10 +407,10 @@ class NWWSCog(commands.Cog):
                 from datetime import datetime, timezone
                 received_at = datetime.now(timezone.utc)
 
-                try:
-                    await self._process_nwws_message(payload, raw_text, received_at, is_archived)
-                except Exception as e:
-                    logger.exception(f"Error processing message {msg_dict.get('product_id')}: {e}")
+                asyncio.create_task(
+                    self._process_nwws_message(payload, raw_text, received_at, is_archived),
+                    name=f"nwws-{msg_dict.get('product_id', 'unknown')}",
+                )
 
             if messages_drained > 0:
                 logger.debug(f"Drained {messages_drained} messages from Rust NWWS")

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -77,6 +77,7 @@ class WarningsCog(commands.Cog):
         self._cancelled_warnings: set[str] = set()
         self._in_flight_vtecs: set[str] = set()
         self._perm_warned: set[int] = set()
+        self._discover_sem = asyncio.Semaphore(5)
 
     async def cog_load(self):
         # posted_warnings already hydrated by _hydrate_state before cog load
@@ -792,23 +793,40 @@ class WarningsCog(commands.Cog):
             if issuance_id in self.bot.state.posted_warnings:
                 continue
 
+            # Allow NEW, CON, EXT, and UPG to trigger initial discovery posts.
+            # This ensures we catch warnings issued while the bot was down/starting.
+            if vtec_dict["action"] not in ("NEW", "CON", "EXT", "UPG"):
+                continue
+
             self._in_flight_vtecs.add(issuance_id)
+            asyncio.create_task(
+                self._discover_and_post_warning(issuance_id, feature, vtec_dict, event, props),
+                name=f"warn-discover-{issuance_id}",
+            )
 
+        await self._handle_disappeared_warnings(current_vtec_ids, current_vtec_data)
+        self._backoff.success()
+
+    async def _discover_and_post_warning(
+        self,
+        issuance_id: str,
+        feature,
+        vtec_dict: dict,
+        event: str,
+        props,
+    ) -> None:
+        """Post a newly-discovered warning, bounded by _discover_sem for burst control."""
+        async with self._discover_sem:
             try:
-                # Allow NEW, CON, EXT, and UPG to trigger initial discovery posts.
-                # This ensures we catch warnings issued while the bot was down/starting.
-                if vtec_dict["action"] not in ("NEW", "CON", "EXT", "UPG"):
-                    continue
-
                 async with self.bot.state.claim_posted_warning(issuance_id) as claim:
                     try:
                         event_ch = await self._resolve_warning_channel(event, vtec_phenom=vtec_dict.get("phenom"))
                         if event_ch is None:
-                            continue  # claim auto-rolls back
+                            return
                         msg, area_desc = await self._post_warning(feature, event_ch, vtec_dict, event)
                     except discord.HTTPException as e:
                         logger.exception(f"Send failed for {issuance_id}: {e}")
-                        continue  # claim auto-rolls back
+                        return
 
                     self.bot.state.active_warnings[issuance_id] = vtec_dict
                     try:
@@ -825,11 +843,10 @@ class WarningsCog(commands.Cog):
                         )
                     except Exception as e:
                         logger.warning(f"Failed to persist {issuance_id}: {e}")
+            except Exception as e:
+                logger.exception(f"Unhandled error discovering {issuance_id}: {e}")
             finally:
                 self._in_flight_vtecs.discard(issuance_id)
-
-        await self._handle_disappeared_warnings(current_vtec_ids, current_vtec_data)
-        self._backoff.success()
 
     async def _post_warning(
         self,

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -187,6 +187,7 @@ def _make_cog(posted: dict | None = None) -> WarningsCog:
     cog = WarningsCog.__new__(WarningsCog)
     cog._in_flight_vtecs = set()
     cog._perm_warned = set()
+    cog._discover_sem = asyncio.Semaphore(5)
     cog.bot = MagicMock()
     cog.bot.wait_until_ready = AsyncMock()
     cog.bot.state.is_primary = True
@@ -532,6 +533,7 @@ def _make_tick_cog(active=None, posted=None):
     cog = WarningsCog.__new__(WarningsCog)
     cog._in_flight_vtecs = set()
     cog._perm_warned = set()
+    cog._discover_sem = asyncio.Semaphore(5)
     from utils.backoff import TaskBackoff
     cog._backoff = TaskBackoff("auto_poll_warnings")
     cog._validators = {"etag": "", "last_modified": ""}
@@ -602,6 +604,7 @@ async def test_tick_disappeared_warning_triggers_cancellation(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.real_create_task
 async def test_tick_initial_discovery_posts_active_warning_missed_at_startup(monkeypatch):
     """A CON warning in the API but NOT in posted_warnings (bot was down at issuance)
     triggers an initial-discovery post."""
@@ -627,6 +630,10 @@ async def test_tick_initial_discovery_posts_active_warning_missed_at_startup(mon
     monkeypatch.setattr(warnings_mod, "add_significant_event", AsyncMock(), raising=False)
 
     await cog._tick()
+    # Discovery fires as a background task; drain all pending tasks before asserting.
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
 
     channel.send.assert_called_once()
     assert vtec_id in cog.bot.state.posted_warnings

--- a/utils/state.py
+++ b/utils/state.py
@@ -60,7 +60,7 @@ class BoundedFIFOKeys:
 
     __slots__ = ("_d", "_maxlen")
 
-    def __init__(self, maxlen: int = 1000):
+    def __init__(self, maxlen: int = 5000):
         self._d: Dict[str, None] = {}
         self._maxlen = maxlen
 
@@ -138,7 +138,7 @@ class PostingLog:
         # Currently-active VTEC IDs mapping to their latest vtec metadata dict
         self.active_warnings: Dict[str, dict] = {}
         self.posted_reports: Set[str] = set()
-        self.posted_product_ids: BoundedFIFOKeys = BoundedFIFOKeys(maxlen=1000)
+        self.posted_product_ids: BoundedFIFOKeys = BoundedFIFOKeys(maxlen=5000)
         self.posted_soundings: Set[str] = set()
         self.sounding_handled_watches: Set[str] = set()
 


### PR DESCRIPTION
## Summary

Addresses four reliability findings surfaced by Gemini review. All fixes are independent; the critical one (split-brain) is the reason for the PR.

### 🚨 Fix 1 — Startup split-brain (Critical)

**`cogs/failover.py`**

`_write_lease()` previously used an unconditional `SET ... EX` and swallowed any Redis error (via `_exec()` returning `None`). If Redis was unreachable at startup, `startup_lease_check()` called `_write_lease()`, the write silently failed, but the node still returned `True` (Primary). If a standby had already promoted itself during the partition, this created split-brain.

**Fix:** `_write_lease()` now returns `bool` — `True` only when Redis confirms the write. Both call sites in `startup_lease_check()` (regular and manual-override paths) now check the return value and boot as STANDBY if the write fails.

---

### ⚡ Fix 2 — NWWS drain loop head-of-line blocking (High)

**`cogs/nwws.py`**

`_drain_rust_nwws` used bare `await self._process_nwws_message(...)`. During an outbreak, a tornado warning requiring a radar image download and Discord embed would stall the entire Rust queue drain loop for the duration of the network I/O.

**Fix:** Wrapped in `asyncio.create_task(...)` (named, for debuggability). Dedup keys are still claimed synchronously at the top of `_process_nwws_message`, so concurrent tasks processing the same product remain safe.

---

### ⚡ Fix 3 — Warning poller pileup on restart (High)

**`cogs/warnings.py`**

`_tick()` discovered and posted new warnings sequentially. On a cold restart with 50+ active warnings, the loop would block for 100+ seconds (50 × ~2s image + Discord), completely missing subsequent 30-second polling windows.

**Fix:** The per-warning work is extracted into `_discover_and_post_warning()`. The issuance ID is added to `_in_flight_vtecs` synchronously (so inter-tick dedup still holds), then the heavy work is launched as a task bounded by `asyncio.Semaphore(5)`. The `finally` discard stays inside the task. Test updated with `@pytest.mark.real_create_task` so the real task machinery is exercised.

---

### 🪣 Fix 4 — Dedup limit too small for outbreak days (Low effort)

**`utils/state.py`**

`BoundedFIFOKeys(maxlen=1000)` could be exhausted during April/May multi-event outbreaks (SVS, LSR, SPS products easily exceed 1,000/day). A late re-broadcast of an evicted product would post twice. Changed to `5000` in both the class default and the `BotState` instantiation (~500 KB, negligible).

--------

## What's Changed

• fix: startup split-brain — `_write_lease()` returns bool, startup falls back to STANDBY on Redis failure  
• fix: NWWS drain loop now uses `create_task` to unblock queue during image downloads  
• fix: warning poller pileup — discovery posts are semaphore-bounded concurrent tasks  
• fix: raise `BoundedFIFOKeys` maxlen from 1000 → 5000 for outbreak safety

Full Changelog: https://github.com/full-bars/spc-bot/compare/main...fix/gemini-review-findings