### PR TITLE
fix: quick wins — /md tuple unpack, View env return, nwws reconnect, PIL close, untrack bot_state.db

### DIFF
--- a/cogs/nwws.py
+++ b/cogs/nwws.py
@@ -181,10 +181,8 @@ class NWWSClient(ClientXMPP):
                 await asyncio.sleep(30)
         except asyncio.CancelledError:
             logger.debug("NWWS ping loop cancelled")
-
-        # Enable auto-reconnect at the slixmpp level
-        self.reconnect = True
-        self.use_ipv6 = False
+            self.reconnect = True
+            self.use_ipv6 = False
 
     def disconnect(self, reconnect=False, wait=False):
         if self._ping_task is not None:
@@ -293,7 +291,7 @@ class NWWSClient(ClientXMPP):
         # Route to processing
         nwws_cog = self.bot.get_cog("NWWSCog")
         if nwws_cog:
-            asyncio.create_task(nwws_cog._process_nwws_message(payload, raw_text, received_at, is_archived))
+            self.bot.loop.create_task(nwws_cog._process_nwws_message(payload, raw_text, received_at, is_archived))
 
 class NWWSCog(commands.Cog):
     MANAGED_TASK_NAMES = [("monitor_connection", "nwws_connection")]

--- a/cogs/recorder.py
+++ b/cogs/recorder.py
@@ -284,10 +284,14 @@ class RecorderCog(commands.Cog):
     @staticmethod
     def _make_gif_worker(frame_paths, gif_path):
         frames = [Image.open(f) for f in frame_paths]
-        frames[0].save(
-            gif_path, format="GIF", append_images=frames[1:],
-            save_all=True, duration=200, loop=0
-        )
+        try:
+            frames[0].save(
+                gif_path, format="GIF", append_images=frames[1:],
+                save_all=True, duration=200, loop=0
+            )
+        finally:
+            for frame in frames:
+                frame.close()
 
     @staticmethod
     def _calc_srh_worker(mission_dir, files):

--- a/cogs/status.py
+++ b/cogs/status.py
@@ -922,8 +922,8 @@ class StatusCog(commands.Cog):
         logger.info("[/md] Command invoked (always fresh)")
         try:
             # We'll use a local fetch that doesn't mess with the auto-poster's cache
-            md_numbers = await fetch_latest_md_numbers(fresh=True)
-            logger.info(f"[/md] Fetched {len(md_numbers)} MD numbers")
+            md_numbers, _ = await fetch_latest_md_numbers(fresh=True)
+            logger.info(f"[/md] Fetched {len(md_numbers) if md_numbers else 0} MD numbers")
         except Exception as e:
             logger.error(f"[/md] fetch_latest_md_numbers failed: {e}")
             await interaction.followup.send("Failed to fetch MD index.")

--- a/cogs/warning_ui.py
+++ b/cogs/warning_ui.py
@@ -33,17 +33,19 @@ class EnvironmentalView(discord.ui.View):
             row = await cur.fetchone()
 
         if not row or not row["gif_path"]:
-            # Check if there is an active mission
             recorder = interaction.client.get_cog("RecorderCog")
             if recorder:
-                # We'd need a way to check active missions by event_id
-                # For now, a generic message
                 await interaction.followup.send(
                     "Environmental data is still being recorded or was not captured for this event. "
                     "Try again in 90 minutes.",
-                    ephemeral=True
+                    ephemeral=True,
                 )
-                return
+            else:
+                await interaction.followup.send(
+                    "No environmental data was captured for this event.",
+                    ephemeral=True,
+                )
+            return
 
         # Post the GIF
         gif_path = row["gif_path"]


### PR DESCRIPTION
Fixes 5 isolated high-confidence bugs found in the 2026-05-25 codebase review.

**`/md` slash command broken** (`cogs/status.py:925`)
`fetch_latest_md_numbers` returns `(list, bool)` but the caller never unpacked it — `len()` always returned 2, `if not md_numbers` was always falsy, and iterating yielded the list and the bool. Fixed with `md_numbers, _ = await fetch_latest_md_numbers(fresh=True)`.

**"View Environment" button TypeError** (`cogs/warning_ui.py:35`)
When `row` was `None` and no `RecorderCog` was loaded, execution fell through the guard to `row["gif_path"]` → `TypeError`, leaving the interaction hung. Added `else` branch with a user-facing message and unconditional `return`.

**nwws.py reconnect flags fire on every ping-loop exit** (`cogs/nwws.py:185`)
`self.reconnect = True` / `self.use_ipv6 = False` were at the `try` level, running on normal exit, `CancelledError`, and exceptions alike. After an intentional standby demotion this kept slixmpp reconnecting. Indented into `except asyncio.CancelledError`.

**`asyncio.create_task` in sync slixmpp callback** (`cogs/nwws.py:296`)
Changed to `self.bot.loop.create_task` to guarantee the task lands on discord.py's event loop, matching the pattern already used in `_start_ping_task`.

**PIL Image handles leaked in GIF worker** (`cogs/recorder.py:286`)
`frames = [Image.open(f) for f in frame_paths]` opened ~18 handles per recording mission and never closed them. Wrapped `.save()` in `try/finally` with `frame.close()`.

**`bot_state.db` was git-tracked** despite `.gitignore`. Removed with `git rm --cached`.