### PR TITLE
fix: move dedup state writes after channel.send in reports and mesoscale

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -605,7 +605,6 @@ class MesoscaleCog(commands.Cog):
         channel = self.bot.get_channel(SPC_CHANNEL_ID)
         if not channel:
             return
-        self.bot.state.posted_mds.add(md_num)
         logger.info(f"iembot-triggered post for #{md_num}")
         image_url, summary, from_cache, raw_text = await fetch_md_details(md_num)
         if raw_text:
@@ -627,6 +626,7 @@ class MesoscaleCog(commands.Cog):
         text_embed.set_footer(text="SPC MD Monitor")
         try:
             msg = await channel.send(embeds=[img_embed, text_embed], files=files)
+            self.bot.state.posted_mds.add(md_num)
             self.bot.state.active_mds.add(md_num)
             await self.bot.state.add_posted_md(str(md_num))
             self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -194,13 +194,9 @@ class ReportsCog(commands.Cog):
             )
             embed.set_footer(text=f"{office} LSR | {coords}")
 
-            # --- Persist State Before Sending ---
-            await self.bot.state.add_posted_report(product_id)
-
             # Log significant events to DB
             event_upper = event_type.upper()
             if "TORNADO" in event_upper:
-                # Mark unwarned tornadoes with lead_time=-1 (distinct from NULL/"still calculating")
                 await add_significant_event(
                     event_id=f"IEM:LSR:{product_id}",
                     event_type="Tornado",
@@ -210,11 +206,12 @@ class ReportsCog(commands.Cog):
                     timestamp=lsr_ts,
                     source=office,
                     raw_text=remarks,
-                    lead_time=-1,  # ← Sentinel value: explicitly UNWARNED
+                    lead_time=-1,
                 )
                 logger.info(f"[REPORTS] Recorded UNWARNED tornado: {location} at {time_str}")
 
             await channel.send(embed=embed)
+            await self.bot.state.add_posted_report(product_id)
 
     async def _handle_pns(self, product_id: str, raw_text: str):
         # Public Information Statement - Damage Survey

--- a/tests/test_mesoscale.py
+++ b/tests/test_mesoscale.py
@@ -251,8 +251,8 @@ async def test_post_md_now_no_channel_returns_early():
 
 
 @pytest.mark.asyncio
-async def test_post_md_now_marks_posted_before_send():
-    """MD is marked as posted immediately to prevent concurrent duplicate posts."""
+async def test_post_md_now_does_not_mark_posted_on_send_failure():
+    """If channel.send raises, MD must NOT be added to posted_mds so it can be retried."""
     bot, channel = _make_bot_for_post()
     channel.send.side_effect = Exception("failed")
     cog = MesoscaleCog.__new__(MesoscaleCog)
@@ -261,7 +261,7 @@ async def test_post_md_now_marks_posted_before_send():
     with patch("cogs.mesoscale.fetch_md_details", AsyncMock(return_value=("img", "sum", True, "/path"))):
         await cog.post_md_now("0398")  # must not raise
 
-    assert "0398" in bot.state.posted_mds
+    assert "0398" not in bot.state.posted_mds
 
 
 # ── fetch_latest_md_numbers — IEM fallback parse path ────────────────────────


### PR DESCRIPTION
Fixes the "mark-posted-before-send" anti-pattern in two cogs, which silently drops posts permanently when `channel.send` fails (403, 429, network error).

**`cogs/reports.py:198`** — `add_posted_report(product_id)` was called before `channel.send(embed=embed)`. If the send raised, the LSR was permanently marked as posted and never retried. Moved to after the send.

**`cogs/mesoscale.py:608`** — `self.bot.state.posted_mds.add(md_num)` ran before the fetch + `channel.send`. A send failure silently lost the MD with no retry. Moved `posted_mds.add` inside the `try` block after the successful send, alongside the existing `active_mds.add` and `add_posted_md` calls.

The NWS warnings cog already uses a `claim_posted_warning` context manager with rollback as the correct pattern. These two paths now match that intent: dedup state is only committed after a successful send.