### PR TITLE
fix: offload render_tornado_track to thread executor at both call sites

### DIFF
--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -418,7 +418,8 @@ class ReportsCog(commands.Cog):
                 paths = await fetch_dat_track_geometry(guid)
                 if paths:
                     out_path = os.path.join("cache", f"track_{guid}.png")
-                    render_tornado_track(paths, out_path)
+                    loop = asyncio.get_running_loop()
+                    await loop.run_in_executor(None, render_tornado_track, paths, out_path)
                     if os.path.exists(out_path):
                         file_to_send = discord.File(out_path, filename=f"track_{guid}.png")
 

--- a/cogs/warning_ui.py
+++ b/cogs/warning_ui.py
@@ -3,6 +3,7 @@
 Includes environmental evolution viewer, tornado photo carousel, and
 tornado dashboard (summary + card navigation modes).
 """
+import asyncio
 import logging
 import os
 from datetime import datetime, timedelta, timezone
@@ -195,7 +196,8 @@ class TornadoDashboardView(discord.ui.View):
         try:
             paths = await fetch_dat_track_geometry(guid)
             if paths:
-                render_tornado_track(paths, png_path)
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, render_tornado_track, paths, png_path)
                 if os.path.exists(png_path):
                     return f"attachment://track_{guid}.png", discord.File(png_path, filename=f"track_{guid}.png")
         except Exception as err:


### PR DESCRIPTION
`render_tornado_track` (`utils/map_utils.py`) is a synchronous function that performs cartopy OSM tile downloads and a 120-DPI matplotlib render. It was called directly (no executor) at two sites, stalling the entire asyncio event loop — heartbeat, dedup, Redis — for several seconds per call during a tornado outbreak.

**Fixed call sites:**
- `cogs/warning_ui.py:198` — `_try_get_track_map` (tornado dashboard)
- `cogs/reports.py:421` — PNS damage survey embed builder

Both are now wrapped with `await loop.run_in_executor(None, render_tornado_track, paths, out_path)`.

Also added `import asyncio` to `warning_ui.py` which didn't have it.