### PR TITLE
fix: retry HTTP 500 in http_get_json; add init lock to get_events_db

### DIFF
--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -33,6 +33,7 @@ _SYNC_PATH = os.path.join(_SYNC_DIR, "events.db")
 
 _db: Optional[aiosqlite.Connection] = None
 _db_dirty: bool = False
+_LOCK = asyncio.Lock()
 
 
 def _mark_dirty():
@@ -44,15 +45,18 @@ async def get_events_db() -> aiosqlite.Connection:
     global _db
     if _db is not None:
         return _db
-    os.makedirs(os.path.dirname(_EVENTS_DB_PATH), exist_ok=True)
-    conn = await aiosqlite.connect(_EVENTS_DB_PATH)
-    conn.row_factory = aiosqlite.Row
-    await conn.execute("PRAGMA journal_mode=WAL")
-    await conn.execute("PRAGMA busy_timeout=5000")
-    await _create_tables(conn)
-    await conn.commit()
-    _db = conn
-    logger.info(f"Connected to {_EVENTS_DB_PATH}")
+    async with _LOCK:
+        if _db is not None:
+            return _db
+        os.makedirs(os.path.dirname(_EVENTS_DB_PATH), exist_ok=True)
+        conn = await aiosqlite.connect(_EVENTS_DB_PATH)
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute("PRAGMA busy_timeout=5000")
+        await _create_tables(conn)
+        await conn.commit()
+        _db = conn
+        logger.info(f"Connected to {_EVENTS_DB_PATH}")
     return _db
 
 

--- a/utils/http.py
+++ b/utils/http.py
@@ -361,7 +361,7 @@ async def http_get_json(url: str, retries: int = 1, timeout: int = TIMEOUT_STAND
     async def _do_request():
         session = await ensure_session()
         async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout)) as r:
-            if r.status in (429, 502, 503, 504):
+            if r.status in (429, 500, 502, 503, 504):
                 raise aiohttp.ClientResponseError(
                     r.request_info, r.history, status=r.status, message="Server returned retryable error"
                 )


### PR DESCRIPTION
Two reliability fixes for failure modes under load.

**`utils/http.py:368` — HTTP 500 not retried**
`http_get_json` raised `ClientResponseError` (triggering tenacity retries) for 429/502/503/504, but any other non-200 including 500 hit `circuit_breaker.record_failure(); return None` — a normal return inside the tenacity-wrapped function, so no retry fired. `http_get_bytes_conditional` uses `raise_for_status()` and does retry 500s. Added 500 to the retryable set to make both helpers consistent.

**`utils/events_db.py:43` — singleton init has no lock**
Two concurrent first-callers both saw `_db is None`, both called `await aiosqlite.connect()`, and one connection was orphaned (WAL write connection leak). Mirrored the double-checked locking pattern from `utils/db.py` (`_LOCK` + check-inside-lock).