### PR TITLE
fix: gate warning routing commands behind manage_guild; document missing .env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ GUILD_ID=your_guild_id
 # LOG_FILE=spc_bot.log
 # MANUAL_CACHE_FILE=posted_records.json
 # AUTO_CACHE_FILE=auto_posted_records.json
+# DEV_CHANNEL_ID=your_dev_channel_id (defaults to HEALTH_CHANNEL_ID then SPC_CHANNEL_ID)
+# NWWS_FIREHOSE_LOG=nwws_firehose.log (relative to CACHE_DIR)
 
 # Redis — shared state + leader election (required for HA)
 # Self-hosted Redis 7+. Configure either REDIS_URL (preferred) or the

--- a/cogs/warning_channels.py
+++ b/cogs/warning_channels.py
@@ -63,6 +63,7 @@ class DisableWarningsView(discord.ui.View):
 class WarningChannelsCog(commands.Cog):
 
     @app_commands.command(name="enablewarnings", description="Route a warning type to a specific channel")
+    @app_commands.default_permissions(manage_guild=True)
     @app_commands.describe(
         warning_type="Warning product type to configure",
         channel="Channel where these warnings will be posted",
@@ -109,6 +110,7 @@ class WarningChannelsCog(commands.Cog):
         await interaction.followup.send(embed=embed, ephemeral=True)
 
     @app_commands.command(name="disablewarnings", description="Stop posting a warning type")
+    @app_commands.default_permissions(manage_guild=True)
     async def disable_warnings(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
 


### PR DESCRIPTION
**`cogs/warning_channels.py` — missing permission gate**
`/enablewarnings` and `/disablewarnings` had no `default_permissions` decorator, so any guild member could re-route or disable warning alerts. Added `@app_commands.default_permissions(manage_guild=True)` to both commands.

**`.env.example` — undocumented vars**
`DEV_CHANNEL_ID` and `NWWS_FIREHOSE_LOG` are both read by `config.py` but were absent from `.env.example`. Added them with their default behavior documented.