### PR TITLE
chore(deps): pin XMPP crate stack to 4.x; stop Dependabot re-raising tokio-xmpp 5.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,21 @@ updates:
     labels:
       - dependencies
       - rust
+    ignore:
+      # The XMPP crate stack is pinned to the 4.x line. The coordinated bump to
+      # tokio-xmpp 5.0 / xmpp-parsers 0.22 / minidom 0.18 was attempted and
+      # reverted (issue #464, PR #465). tokio-xmpp 5.0's strict xso parser
+      # treats any un-parseable incoming stanza as a FATAL stream error, and a
+      # non-compliant peer in the NWWS-OI MUC ("TropiTracker NWWS Ingest"
+      # broadcasts "[object Object]" as text in its presence) triggers an
+      # infinite reconnect loop with zero ingestion. tokio-xmpp 4 tolerates it.
+      # Do not re-raise until upstream makes stanza parse errors non-fatal.
+      - dependency-name: "tokio-xmpp"
+        versions: [">=5"]
+      - dependency-name: "xmpp-parsers"
+        versions: [">=0.22"]
+      - dependency-name: "minidom"
+        versions: [">=0.17"]
 
   # Base images in the Dockerfile
   - package-ecosystem: docker


### PR DESCRIPTION
Adds a `cargo` ignore block in `.github/dependabot.yml` for the XMPP crate stack so Dependabot stops re-opening the coupled bump every week.

### Why
The migration to **tokio-xmpp 5.0 / xmpp-parsers 0.22 / minidom 0.18** (issue #464, PR #465) was implemented, passed CI, but failed live verification on the primary and was reverted. tokio-xmpp 5.0's high-level `Client` uses xso 0.3 strict deserialization and escalates **any** un-parseable incoming stanza to a fatal stream error. A non-compliant peer in the NWWS-OI MUC (`TropiTracker NWWS Ingest` broadcasts `[object Object]` as stray text in its presence) makes the stream tear down and autoreconnect every ~1–2s — **zero ingestion**. tokio-xmpp 4 silently tolerates this, which is why prod runs fine on v4.

There's no security advisory forcing the bump, and the failure mode would recur with *any* future non-compliant peer in the room (not just this one). Full diagnosis is on #464 / #465.

### What
```yaml
ignore:
  - dependency-name: "tokio-xmpp"
    versions: [">=5"]
  - dependency-name: "xmpp-parsers"
    versions: [">=0.22"]
  - dependency-name: "minidom"
    versions: [">=0.17"]
```
Mirrors the existing `actions/upload-artifact` ignore pattern (documented inline). Lift these once upstream makes stanza parse errors non-fatal.