### PR TITLE
docs(deps): link upstream xmpp-rs#172 in the XMPP ignore comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,7 +66,9 @@ updates:
       # non-compliant peer in the NWWS-OI MUC ("TropiTracker NWWS Ingest"
       # broadcasts "[object Object]" as text in its presence) triggers an
       # infinite reconnect loop with zero ingestion. tokio-xmpp 4 tolerates it.
-      # Do not re-raise until upstream makes stanza parse errors non-fatal.
+      # Do not re-raise until upstream makes stanza parse errors non-fatal:
+      #   https://gitlab.com/xmpp-rs/xmpp-rs/-/issues/172
+      # When that issue is resolved, lift this ignore and re-attempt the bump.
       - dependency-name: "tokio-xmpp"
         versions: [">=5"]
       - dependency-name: "xmpp-parsers"


### PR DESCRIPTION
Adds the upstream tripwire to the `cargo` ignore comment in `.github/dependabot.yml`.

The tokio-xmpp 5.x stack is pinned (see #464 / #465). This records *what to watch* directly at the pin site: when **https://gitlab.com/xmpp-rs/xmpp-rs/-/issues/172** (non-fatal stanza parse errors) is resolved, lift the ignore and re-attempt the migration. Comment-only change.