### PR TITLE
fix: make PNS and Environmental views persistent across restarts

### DIFF
--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -34,21 +34,41 @@ _PNS_NARR_DATE_RE = re.compile(rf"({_PNS_MONTHS_STR})\w*\s+(\d{{1,2}})\s*,\s*(\d
 
 
 class PNSView(discord.ui.View):
-    def __init__(self, raw_text: str):
-        super().__init__(timeout=86400)  # Long timeout for persistent posts
-        self.raw_text = raw_text
+    def __init__(self):
+        super().__init__(timeout=None)
 
-    @discord.ui.button(label="📜 View Full Text", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(
+        label="📜 View Full Text", style=discord.ButtonStyle.secondary, custom_id="pns:view_text"
+    )
     async def view_text(self, interaction: discord.Interaction, button: discord.ui.Button):
-        # Split text if it exceeds 2000 chars (unlikely for most, but just in case)
-        if len(self.raw_text) > 1950:
-            parts = [self.raw_text[i : i + 1950] for i in range(0, len(self.raw_text), 1950)]
+        # Extract product_id from footer
+        # Footer text: "{office} PNS | {product_id}"
+        if not interaction.message.embeds:
+            return
+        footer = interaction.message.embeds[0].footer.text
+        if not footer or "|" not in footer:
+            return
+        product_id = footer.split("|")[-1].strip()
+
+        from utils.events_db import get_significant_event_raw_text
+
+        raw_text = await get_significant_event_raw_text(f"IEM:PNS:{product_id}")
+        if not raw_text:
+            await interaction.response.send_message(
+                "Raw text not found in database for this event.", ephemeral=True
+            )
+            return
+
+        # Split text if it exceeds 2000 chars
+        if len(raw_text) > 1950:
+            parts = [raw_text[i : i + 1950] for i in range(0, len(raw_text), 1950)]
             for i, p in enumerate(parts):
-                await interaction.response.send_message(
-                    f"```\n{p}\n```", ephemeral=True
-                ) if i == 0 else await interaction.followup.send(f"```\n{p}\n```", ephemeral=True)
+                if i == 0:
+                    await interaction.response.send_message(f"```\n{p}\n```", ephemeral=True)
+                else:
+                    await interaction.followup.send(f"```\n{p}\n```", ephemeral=True)
         else:
-            await interaction.response.send_message(f"```\n{self.raw_text}\n```", ephemeral=True)
+            await interaction.response.send_message(f"```\n{raw_text}\n```", ephemeral=True)
 
 
 class ReportsCog(commands.Cog):
@@ -57,6 +77,9 @@ class ReportsCog(commands.Cog):
         self.posted_surveys: set[str] = set()
         self._surveys_loaded = False
         self.poll_lsrs.start()
+
+    async def cog_load(self):
+        self.bot.add_view(PNSView())
 
     def cog_unload(self):
         self.poll_lsrs.cancel()
@@ -304,7 +327,7 @@ class ReportsCog(commands.Cog):
             f"[<t:{int(pns_ts)}:R>]"
         )
 
-        view = PNSView(raw_text)
+        view = PNSView()
         embed = discord.Embed(
             description=desc, color=discord.Color.teal(), timestamp=datetime.now(timezone.utc)
         )

--- a/cogs/warning_ui.py
+++ b/cogs/warning_ui.py
@@ -18,9 +18,8 @@ logger = logging.getLogger("spc_bot")
 
 
 class EnvironmentalView(discord.ui.View):
-    def __init__(self, event_id: str):
+    def __init__(self):
         super().__init__(timeout=None)  # Persistent
-        self.event_id = event_id
 
     @discord.ui.button(
         label="View Environmental Evolution",
@@ -31,12 +30,20 @@ class EnvironmentalView(discord.ui.View):
     async def view_env(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer(ephemeral=True)
 
+        # Extract event_id from footer (format: "VTEC ... | {event_id}")
+        if not interaction.message.embeds:
+            return
+        footer = interaction.message.embeds[0].footer.text
+        if not footer or "|" not in footer:
+            return
+        event_id = footer.split("|")[-1].strip()
+
         from utils.events_db import get_events_db
 
         db = await get_events_db()
         async with db.execute(
             "SELECT gif_path, srh_0_1, location FROM significant_events WHERE event_id = ?",
-            (self.event_id,),
+            (event_id,),
         ) as cur:
             row = await cur.fetchone()
 

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -85,6 +85,9 @@ class WarningsCog(commands.Cog):
         logger.debug(
             f"cog_load: {len(self.bot.state.posted_warnings)} posted warning(s) already in state"
         )
+        from cogs.warning_ui import EnvironmentalView
+
+        self.bot.add_view(EnvironmentalView())
 
         self.auto_poll_warnings.start()
         self.prune_posted_warnings_loop.start()
@@ -325,7 +328,7 @@ class WarningsCog(commands.Cog):
                 # Add Environmental Button for Tornado Warnings
                 view = None
                 if event == "Tornado Warning" and event_id:
-                    view = EnvironmentalView(event_id)
+                    view = EnvironmentalView()
 
                 # Download IEM Autoplot image (only if we have a real ETN, or it's an SPS)
                 files = []

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -156,6 +156,33 @@ async def add_significant_event(
         logger.warning(f"add_significant_event({event_id}) failed: {e}")
 
 
+async def get_significant_event_raw_text(event_id: str) -> Optional[str]:
+    """Retrieve raw text for a significant event by its ID."""
+    db = await get_events_db()
+    try:
+        async with db.execute(
+            "SELECT raw_text FROM significant_events WHERE event_id = ?", (event_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            return row["raw_text"] if row else None
+    except Exception as e:
+        logger.warning(f"get_significant_event_raw_text({event_id}) failed: {e}")
+        return None
+
+
+async def get_significant_event_by_vtec(vtec_id: str) -> Optional[aiosqlite.Row]:
+    """Retrieve a significant event record by its VTEC ID."""
+    db = await get_events_db()
+    try:
+        async with db.execute(
+            "SELECT * FROM significant_events WHERE vtec_id = ?", (vtec_id,)
+        ) as cur:
+            return await cur.fetchone()
+    except Exception as e:
+        logger.warning(f"get_significant_event_by_vtec({vtec_id}) failed: {e}")
+        return None
+
+
 async def update_event_environment(event_id: str, gif_path: str, srh_0_1: float) -> None:
     """Add environmental data to an existing event."""
     db = await get_events_db()


### PR DESCRIPTION
This PR fixes the issue where "View Full Text" and "View Environmental Evolution" buttons on alert embeds would stop working after a bot restart.

### Changes:
- **`utils/events_db.py`**: Added `get_significant_event_raw_text` and `get_significant_event_by_vtec` helper functions.
- **`cogs/reports.py`**: Refactored `PNSView` to be persistent (`timeout=None`, static `custom_id`). It now extracts the product ID from the message footer and fetches raw text from the database. Added `cog_load` to register the view on startup.
- **`cogs/warning_ui.py`**: Refactored `EnvironmentalView` to be persistent. It now extracts the event ID from the message footer.
- **`cogs/warnings.py`**: Added `cog_load` to register `EnvironmentalView` on startup and updated instantiation to no longer require passing an event ID.

These changes ensure that all long-lived alert buttons remain functional across restarts, deployments, and failover events.