### PR TITLE
fix(failover): drain Redis dirty-write reconciler at runtime; supervise recorder_loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ version numbers follow [SemVer](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- **Redis dirty-write reconciler never drained at runtime.** `state_store` enqueues failed Redis writes to a durable SQLite dirty-write queue, but `resync_to_redis()` was only invoked on startup and on promotion — the documented "periodic background retry" did not exist. On a long-lived Primary, a transient Redis blip could strand writes locally until the next restart/promotion, leaving the Standby's Redis silently missing them and risking duplicate posts after a failover. The failover `sync_loop` now drains the queue every cycle while Primary (a cheap no-op when the queue is empty), and the stale module docstring was corrected.
-- **`recorder_loop` not supervised by the watchdog.** `RecorderCog` was the only task-owning cog without `MANAGED_TASK_NAMES`, so a stopped VAD recorder loop would never be auto-restarted. Added it to the watchdog's managed-task registry.
+- **Redis dirty-write reconciler never drained at runtime.** `state_store` enqueues failed Redis writes to a durable SQLite dirty-write queue, but `resync_to_redis()` was only invoked on startup and on promotion — the documented "periodic background retry" did not exist. On a long-lived Primary, a transient Redis blip could strand writes locally until the next restart/promotion, leaving the Standby's Redis silently missing them and risking duplicate posts after a failover. The failover `sync_loop` now drains the queue every cycle while Primary (a cheap no-op when the queue is empty), and the stale module docstring was corrected. (#471)
+- **`recorder_loop` not supervised by the watchdog.** `RecorderCog` was the only task-owning cog without `MANAGED_TASK_NAMES`, so a stopped VAD recorder loop would never be auto-restarted. Added it to the watchdog's managed-task registry. (#471)
 
 ## [5.34.5] — 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Redis dirty-write reconciler never drained at runtime.** `state_store` enqueues failed Redis writes to a durable SQLite dirty-write queue, but `resync_to_redis()` was only invoked on startup and on promotion — the documented "periodic background retry" did not exist. On a long-lived Primary, a transient Redis blip could strand writes locally until the next restart/promotion, leaving the Standby's Redis silently missing them and risking duplicate posts after a failover. The failover `sync_loop` now drains the queue every cycle while Primary (a cheap no-op when the queue is empty), and the stale module docstring was corrected.
+- **`recorder_loop` not supervised by the watchdog.** `RecorderCog` was the only task-owning cog without `MANAGED_TASK_NAMES`, so a stopped VAD recorder loop would never be auto-restarted. Added it to the watchdog's managed-task registry.
+
 ## [5.34.5] — 2026-05-26
 
 ### Fixed

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -351,10 +351,34 @@ class FailoverCog(commands.Cog):
 
             if self.bot.state.is_primary:
                 await self._primary_cycle()
+                # Drain any writes that failed to reach Redis since the last
+                # cycle. Without this, a transient Redis blip on a long-lived
+                # Primary strands dirty writes in SQLite until the next
+                # restart/promotion — the Standby's Redis silently misses them
+                # and could re-post already-handled items after a failover.
+                # Re-check is_primary: _primary_cycle may have just demoted us.
+                if self.bot.state.is_primary:
+                    await self._drain_dirty_writes()
             else:
                 await self._standby_cycle()
         except Exception as e:
             logger.exception(f"[FAILOVER] Sync loop error: {e}")
+
+    async def _drain_dirty_writes(self) -> None:
+        """Replay writes that failed to reach Redis while we hold the lease.
+
+        resync_to_redis() is a cheap no-op (a single SQLite SELECT) when the
+        dirty queue is empty, and short-circuits on the first _RedisUnavailable
+        during an outage, so it is safe to call every sync cycle. Errors are
+        swallowed here — sync_loop's outer handler is the backstop.
+        """
+        try:
+            result = await state_store.resync_to_redis()
+            drained = result.get("dirty", 0)
+            if drained:
+                logger.info(f"[FAILOVER] Reconciler drained {drained} pending write(s) to Redis")
+        except Exception as e:
+            logger.warning(f"[FAILOVER] Dirty-write drain failed: {e}")
 
     async def _primary_cycle(self) -> None:
         holder = await self._read_lease_holder()

--- a/cogs/recorder.py
+++ b/cogs/recorder.py
@@ -62,6 +62,8 @@ class VADRecordingMission:
 
 
 class RecorderCog(commands.Cog):
+    MANAGED_TASK_NAMES = [("recorder_loop", "recorder_loop")]
+
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.active_missions: Dict[str, VADRecordingMission] = {}

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -259,6 +259,61 @@ class TestFailoverResilience:
         cog._promote.assert_awaited_once()
 
 
+# ── Reconciler drain ──────────────────────────────────────────────────────────
+
+
+class TestReconcilerDrain:
+    @pytest.mark.asyncio
+    async def test_sync_loop_drains_dirty_writes_when_primary(self, monkeypatch):
+        """A healthy Primary should drain the dirty-write queue each cycle."""
+        bot = _make_bot(is_primary=True)
+        cog = FailoverCog(bot)
+        cog._identity = "P:test-node:abc"
+
+        monkeypatch.setattr(cog, "_exec", _stub_exec({"HSET": 1, "GET": None}))
+        monkeypatch.setattr(cog, "_primary_cycle", AsyncMock())
+        resync = AsyncMock(return_value={"dirty": 2})
+        monkeypatch.setattr(failover_module.state_store, "resync_to_redis", resync)
+
+        await cog.sync_loop()
+
+        resync.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_drain_when_primary_cycle_demotes(self, monkeypatch):
+        """If _primary_cycle demotes us mid-cycle, we must not drain as Primary."""
+        bot = _make_bot(is_primary=True)
+        cog = FailoverCog(bot)
+        cog._identity = "P:test-node:abc"
+
+        async def _demote_side_effect():
+            bot.state.is_primary = False
+
+        monkeypatch.setattr(cog, "_exec", _stub_exec({"HSET": 1, "GET": None}))
+        monkeypatch.setattr(cog, "_primary_cycle", AsyncMock(side_effect=_demote_side_effect))
+        resync = AsyncMock(return_value={"dirty": 0})
+        monkeypatch.setattr(failover_module.state_store, "resync_to_redis", resync)
+
+        await cog.sync_loop()
+
+        resync.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_drain_swallows_resync_errors(self, monkeypatch):
+        """A failed resync must not propagate out of the drain helper."""
+        bot = _make_bot(is_primary=True)
+        cog = FailoverCog(bot)
+
+        monkeypatch.setattr(
+            failover_module.state_store,
+            "resync_to_redis",
+            AsyncMock(side_effect=RuntimeError("redis exploded")),
+        )
+
+        # Should not raise.
+        await cog._drain_dirty_writes()
+
+
 # ── Lease safety (Lua scripts) ────────────────────────────────────────────────
 
 

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -52,11 +52,16 @@ Semantics
   best-effort. If Redis fails, the key is enqueued for reconciliation.
 
 - RECONCILER: when a write to Redis fails but SQLite succeeded, the
-  key is added to a dirty set. A background task (started lazily on
-  first failure) periodically retries those writes until Redis ACKs.
+  op is appended to a durable dirty-write queue in SQLite. The failover
+  sync loop drains this queue (via resync_to_redis()) on every cycle
+  while this node is Primary, retrying each op until Redis ACKs; ops
+  that keep failing non-transiently are moved to a dead-letter table
+  after _MAX_REPLAY_RETRIES.
 
-- On process start, a full-resync pass ensures everything Redis is
-  missing gets pushed.
+- On process start and on promotion to Primary, a resync pass also
+  drains the queue, so a node never takes over with writes still
+  stranded locally (which would let the new Primary re-post items the
+  old Primary already handled).
 
 Connection
 ==========


### PR DESCRIPTION
## Summary

Two stability/self-healing fixes found during a codebase review.

### 1. The Redis dirty-write reconciler was never drained at runtime

`utils/state_store.py` enqueues failed Redis writes to a durable SQLite dirty-write queue and its docstring described *"a background task (started lazily on first failure) [that] periodically retries those writes until Redis ACKs."* **That task did not exist.** `resync_to_redis()` was only ever called from:

- `startup_lease_check()` (boot), and
- `_do_promote()` (promotion).

The `sync_loop`'s `_primary_cycle()` renews the lease every ~30s but never touched the dirty queue.

**Consequence:** on a long-lived Primary (normal state — multi-day uptimes), a *transient* Redis write blip enqueues the op to SQLite and it stays there until the next restart or promotion. The Primary keeps working (read-through cache + SQLite are fine), so it's invisible — but the **Standby's Redis never receives those keys**, so after a failover the new Primary can re-post items the old Primary already handled (the exact "risk of duplicate posts" the `main.py` hydration comments warn about).

**Fix:** `sync_loop` now drains the queue via `resync_to_redis()` every cycle while Primary. It's a cheap no-op (one indexed SQLite `SELECT` returning zero rows) when the queue is empty, and short-circuits on the first `_RedisUnavailable` during an outage. Re-checks `is_primary` after `_primary_cycle()` in case it just demoted us. The stale docstring is corrected to describe the real mechanism.

### 2. `recorder_loop` was unsupervised by the watchdog

`RecorderCog` was the only task-owning cog lacking `MANAGED_TASK_NAMES`, so the `main.py` watchdog never supervised or auto-restarted `recorder_loop`. If it ever stopped, active VAD recording missions would stall silently. Added it to the managed-task registry (one line), consistent with every other cog.

## Tests

- 3 new tests in `test_failover_coverage.py`: drain fires on a healthy Primary, drain is skipped when `_primary_cycle` demotes mid-cycle, and the drain helper swallows resync errors.
- Full suite: **476 passed** (was 473).
- `ruff check` (CI select) + `ruff format --check` clean.

## Notes

This came out of a broader review. The headline conclusion on the Rust side: **there are no worthwhile remaining Rust-acceleration candidates** — the 8 shipped phases already cover the CPU-bound surface and everything else is I/O-bound. Several other agent-flagged "issues" (unguarded HTTP awaits, loops dying silently, failover split-brain at startup) were verified as **already handled** and are not included here.