### PR TITLE
chore: bump version to v5.34.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ version numbers follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [5.34.6] — 2026-05-26
+
 ### Fixed
 - **Redis dirty-write reconciler never drained at runtime.** `state_store` enqueues failed Redis writes to a durable SQLite dirty-write queue, but `resync_to_redis()` was only invoked on startup and on promotion — the documented "periodic background retry" did not exist. On a long-lived Primary, a transient Redis blip could strand writes locally until the next restart/promotion, leaving the Standby's Redis silently missing them and risking duplicate posts after a failover. The failover `sync_loop` now drains the queue every cycle while Primary (a cheap no-op when the queue is empty), and the stale module docstring was corrected. (#471)
 - **`recorder_loop` not supervised by the watchdog.** `RecorderCog` was the only task-owning cog without `MANAGED_TASK_NAMES`, so a stopped VAD recorder loop would never be auto-restarted. Added it to the watchdog's managed-task registry. (#471)


### PR DESCRIPTION
Point release rolling up two stability fixes merged to main:

- **#471** — Redis dirty-write reconciler now drains at runtime (failover `sync_loop`); `recorder_loop` added to the watchdog's managed-task registry.
- **#472** — Fixes Mesoscale Discussion double-posting caused by the NWWS-OI and IEMBot feeds racing `post_md_now`; same guard applied preventively to `post_watch_now`.

Promotes the `[Unreleased]` CHANGELOG section to `[5.34.6]`. Version is derived from the git tag at runtime — no source bump.