### PR TITLE
feat: auto-post WPC surface fronts every 3h to Weather Chat

### DIFF
--- a/cogs/fronts.py
+++ b/cogs/fronts.py
@@ -1,18 +1,27 @@
 # cogs/fronts.py
+import hashlib
 import logging
+from datetime import datetime, timezone
 
 import discord
-from discord.ext import commands
+from discord.ext import commands, tasks
+
+from utils.http import http_get_bytes
+from utils.state_store import set_state
 
 logger = logging.getLogger("spc_bot.fronts")
 
 FRONTS_IMAGE_URL = "https://www.wpc.ncep.noaa.gov/sfc/usfntsfc21wbg.gif"
 FRONTS_PAGE_URL = "https://www.wpc.ncep.noaa.gov/#page=frt"
+WEATHER_CHAT_CHANNEL_ID = 1016454846326513876
 
 
 class FrontsCog(commands.Cog):
+    MANAGED_TASK_NAMES = [("fronts_loop", "fronts_loop")]
+
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.fronts_loop.start()
 
     @discord.app_commands.command(
         name="fronts",
@@ -31,6 +40,53 @@ class FrontsCog(commands.Cog):
         embed.set_footer(text="Source: WPC (wpc.ncep.noaa.gov)")
 
         await interaction.followup.send(embed=embed)
+
+    @tasks.loop(hours=3)
+    async def fronts_loop(self):
+        try:
+            await self.bot.wait_until_ready()
+            if not self.bot.state.is_primary:
+                return
+
+            channel = self.bot.get_channel(WEATHER_CHAT_CHANNEL_ID)
+            if not channel:
+                logger.warning("Weather Chat channel not found for fronts_loop")
+                return
+
+            try:
+                image_data = await http_get_bytes(FRONTS_IMAGE_URL, timeout=15)
+            except Exception as e:
+                logger.warning(f"Failed to fetch fronts image: {e}")
+                return
+
+            current_hash = hashlib.sha256(image_data).hexdigest()
+            last_hash = self.bot.state.last_fronts_hash
+
+            if current_hash == last_hash:
+                logger.debug("Fronts image unchanged — skipping post")
+                return
+
+            embed = discord.Embed(
+                title="WPC Surface Fronts",
+                description="Latest surface fronts analysis from the Weather Prediction Center",
+                url=FRONTS_PAGE_URL,
+                color=discord.Color.blue(),
+                timestamp=datetime.now(timezone.utc),
+            )
+            embed.set_image(url=FRONTS_IMAGE_URL)
+            embed.set_footer(text="Source: WPC (wpc.ncep.noaa.gov)")
+
+            await channel.send(embed=embed)
+            self.bot.state.last_fronts_hash = current_hash
+            await set_state("last_fronts_hash", current_hash)
+            logger.info("Posted updated WPC surface fronts")
+
+        except Exception as e:
+            logger.exception(f"Fronts loop error: {e}")
+
+    @fronts_loop.before_loop
+    async def before_fronts_loop(self):
+        await self.bot.wait_until_ready()
 
 
 async def setup(bot: commands.Bot):

--- a/main.py
+++ b/main.py
@@ -105,6 +105,7 @@ async def _hydrate_state():
         "posted_product_ids",
         "posted_soundings",
         "sounding_handled_watches",
+        "last_fronts_hash",
     )
     results = await asyncio.gather(
         get_all_hashes("auto"),
@@ -122,6 +123,7 @@ async def _hydrate_state():
         get_posted_product_ids(),
         get_posted_soundings(),
         get_sounding_handled_watches(),
+        get_state("last_fronts_hash"),
         return_exceptions=True,
     )
 
@@ -154,6 +156,7 @@ async def _hydrate_state():
         db_product_ids,
         db_soundings,
         db_handled_watches,
+        last_fronts_hash,
     ) = results
 
     if isinstance(db_product_ids, (set, list)):
@@ -174,6 +177,10 @@ async def _hydrate_state():
             logger.debug(f"[DB] Restored last botstalk seqnum {last_botstalk}")
         except ValueError:
             logger.warning(f"[DB] Invalid botstalk seqnum {last_botstalk!r}, resetting to 0")
+
+    if isinstance(last_fronts_hash, str):
+        bot.state.last_fronts_hash = last_fronts_hash
+        logger.debug(f"[DB] Restored last fronts hash {last_fronts_hash}")
 
     if isinstance(db_warnings, dict):
         bot.state.posted_warnings.update(db_warnings)

--- a/utils/state.py
+++ b/utils/state.py
@@ -225,6 +225,7 @@ class BotState:
         # independently from the spcchat seqnum so a stall in one feed
         # can't make us replay the other on restart.
         self.iembot_botstalk_last_seqnum: int = 0
+        self.last_fronts_hash: Optional[str] = None
         self.bot_start_time: Optional[datetime] = None
 
         # Failover & Sync Stats


### PR DESCRIPTION
Add background task to Weather Chat (1016454846326513876) that fetches WPC surface fronts image every 3 hours and posts when it updates.

Uses SHA-256 hash to detect changes (same deduplication logic as other products).

- New task loop: fronts_loop (runs every 3h, primary only)
- State tracking: last_fronts_hash persisted to Redis/DB
- Included in watchdog supervision via MANAGED_TASK_NAMES