### PR TITLE
fix: prevent dual NWWS backend conflict on promotion

### DIFF
--- a/cogs/nwws.py
+++ b/cogs/nwws.py
@@ -367,8 +367,18 @@ class NWWSCog(commands.Cog):
         """Immediately attempt to connect to NWWS-OI (called by FailoverCog)."""
         if not self._should_be_connected:
             self._should_be_connected = True
-            if not self.monitor_connection.is_running():
-                self.monitor_connection.start()
+
+        if self._use_rust:
+            if not self._drain_rust_nwws.is_running():
+                self._drain_rust_nwws.start()
+            # If Rust is enabled, monitor_connection (legacy) should NOT run.
+            if self.monitor_connection.is_running():
+                self.monitor_connection.cancel()
+            return
+
+        # Legacy fallback path
+        if not self.monitor_connection.is_running():
+            self.monitor_connection.start()
 
         await self.monitor_connection()
 


### PR DESCRIPTION
This PR resolves a conflict where both the Rust and legacy Python NWWS backends were running simultaneously upon node promotion.

### Problem
When `FailoverCog` promotes a node to Primary, it calls `trigger_connection()` in the NWWS cog. Previously, this function always started the legacy Python `monitor_connection` loop, even if the Rust backend was already active and draining messages. This resulted in dual XMPP connections to the NOAA servers using the same credentials.

### Solution
Updated `trigger_connection()` to respect the state of the Rust backend:
- If `_use_rust` is enabled, it ensures the Rust message drain loop is running and **explicitly cancels** the legacy Python loop if it was active.
- If Rust is NOT enabled, it falls back to the legacy Python connection as before.

Verified with `tests/test_rust_nwws.py` and a full suite run (478 tests passed).