### PR TITLE
feat: Add dedicated SURVEYS_CHANNEL_ID for PNS and DAT routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ GUILD_ID=your_guild_id
 # SVR_CHANNEL_ID=your_severe_tstorm_channel_id
 # FFW_CHANNEL_ID=your_flash_flood_channel_id
 # SPS_CHANNEL_ID=your_special_weather_stmt_channel_id
+# SURVEYS_CHANNEL_ID=your_damage_survey_channel_id
 # HEALTH_CHANNEL_ID=your_health_channel_id (defaults to SPC_CHANNEL_ID)
 # SOUNDING_CHANNEL_ID=your_sounding_channel_id (defaults to SPC_CHANNEL_ID)
 # CACHE_DIR=cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ version numbers follow [SemVer](https://semver.org/).
 - **`/compare` Command.** Compare any two SPC convective outlooks (categorical or individual hazard probabilities) side-by-side or calculate differences. Supports Day 1, Day 2, Day 3, and Day 4-8 outlooks, featuring an API fallback for real-time products when no archived version exists, and support for the `'all'` product option. (#490)
 - **`/historical` Command.** Retrieve historical convective outlook images (categorical and hazards) from the SPC archive (2004–present). Allows selecting specific issuance times dynamically from a dropdown menu if the requested time is unavailable, and supports the `'all'` product option to fetch all hazards in one command. (#491)
 - **Rust VAD S3 Fetcher.** Added a high-performance Rust-based VAD (Velocity Azimuth Display) S3 fetcher in `spc_rust_core` using the `reqwest` library. Acts as a fast-path fallback for real-time radar data, bypassing Python's `aioboto3` overhead and reducing S3 fetch latency from ~742ms to ~260ms. (#487)
+- **SURVEYS_CHANNEL_ID Configuration.** Added dedicated channel routing for Damage Survey PNS (tornado rating) posts and DAT toolkit plots via a new `SURVEYS_CHANNEL_ID` environment variable.
 
 ### Performance
 - **Read connection pooling for events database.** Implemented a read-only connection pool (size 5) for `utils/events_db.py`, allowing concurrent slash command reads without blocking background writes. (#484)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,12 @@ The following variables are required or optional in `.env`:
 | `GUILD_ID` | The Discord Server (Guild) ID where the bot should register its commands. |
 | `SPC_CHANNEL_ID` | Receives all severe weather alerts — SPC outlooks (Days 1–3), Day 4–8 outlooks, mesoscale discussions, watch alerts and cancellations, and bot health alerts from the watchdog |
 | `MODELS_CHANNEL_ID` | Receives model/forecast graphics — SCP twice-daily posts, CSU-MLP daily forecasts, and NCAR WxNext2 daily forecasts |
-| `WARNINGS_CHANNEL_ID` | (Optional) Receives real-time NWS warning embeds (TOR, SVR, FFW, SPS) and damage survey posts. Defaults to `SPC_CHANNEL_ID` if not set. Overridden by per-type channels if set. |
+| `WARNINGS_CHANNEL_ID` | (Optional) Receives real-time NWS warning embeds (TOR, SVR, FFW, SPS) and local storm reports. Defaults to `SPC_CHANNEL_ID` if not set. Overridden by per-type channels if set. |
 | `TOR_CHANNEL_ID` | (Optional) Tornado warning posts. Defaults to `WARNINGS_CHANNEL_ID` if not set. Configurable at runtime via `/enablewarnings`. |
 | `SVR_CHANNEL_ID` | (Optional) Severe thunderstorm warning posts. Defaults to `WARNINGS_CHANNEL_ID` if not set. Configurable at runtime via `/enablewarnings`. |
 | `FFW_CHANNEL_ID` | (Optional) Flash flood warning posts. Defaults to `WARNINGS_CHANNEL_ID` if not set. Configurable at runtime via `/enablewarnings`. |
 | `SPS_CHANNEL_ID` | (Optional) Special weather statement posts. Defaults to `WARNINGS_CHANNEL_ID` if not set. Configurable at runtime via `/enablewarnings`. |
+| `SURVEYS_CHANNEL_ID` | (Optional) Damage survey and DAT posts (tornado ratings). Defaults to `WARNINGS_CHANNEL_ID` if not set. |
 | `SOUNDING_CHANNEL_ID` | (Optional) Receives auto-posted sounding plots near active watches. Defaults to `SPC_CHANNEL_ID` if not set. |
 | `HEALTH_CHANNEL_ID` | (Optional) Receives bot health alerts (watchdog degraded, task failures). Defaults to `SPC_CHANNEL_ID` if not set. |
 | `DEV_CHANNEL_ID` | (Optional) Receives watchdog probe-degradation alerts (2/3 warning and session-reset confirmation). Defaults to `HEALTH_CHANNEL_ID` if not set. |

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 import discord
 from discord.ext import commands, tasks
 
-from config import WARNINGS_CHANNEL_ID
+from config import WARNINGS_CHANNEL_ID, SURVEYS_CHANNEL_ID
 from utils.http import http_get_bytes
 from utils.state_store import (
     add_significant_event,
@@ -259,7 +259,7 @@ class ReportsCog(commands.Cog):
         if "DAMAGE SURVEY" not in raw_text.upper():
             return
 
-        channel = self.bot.get_channel(WARNINGS_CHANNEL_ID)
+        channel = self.bot.get_channel(SURVEYS_CHANNEL_ID)
         if not channel:
             return
 
@@ -446,7 +446,7 @@ class ReportsCog(commands.Cog):
             if not options:
                 return
 
-            channel = self.bot.get_channel(WARNINGS_CHANNEL_ID)
+            channel = self.bot.get_channel(SURVEYS_CHANNEL_ID)
             if not channel:
                 return
 

--- a/config.py
+++ b/config.py
@@ -98,6 +98,9 @@ CONFIG = {
     "svr_channel_id": _optional_int("SVR_CHANNEL_ID", "WARNINGS_CHANNEL_ID", "SPC_CHANNEL_ID"),
     "ffw_channel_id": _optional_int("FFW_CHANNEL_ID", "WARNINGS_CHANNEL_ID", "SPC_CHANNEL_ID"),
     "sps_channel_id": _optional_int("SPS_CHANNEL_ID", "WARNINGS_CHANNEL_ID", "SPC_CHANNEL_ID"),
+    "surveys_channel_id": _optional_int(
+        "SURVEYS_CHANNEL_ID", "WARNINGS_CHANNEL_ID", "SPC_CHANNEL_ID"
+    ),
     "dev_channel_id": _optional_int("DEV_CHANNEL_ID", "HEALTH_CHANNEL_ID", "SPC_CHANNEL_ID"),
     "manual_cache_file": os.getenv("MANUAL_CACHE_FILE", "posted_records.json"),
     "auto_cache_file": os.getenv("AUTO_CACHE_FILE", "auto_posted_records.json"),
@@ -120,6 +123,7 @@ TOR_CHANNEL_ID = CONFIG["tor_channel_id"]
 SVR_CHANNEL_ID = CONFIG["svr_channel_id"]
 FFW_CHANNEL_ID = CONFIG["ffw_channel_id"]
 SPS_CHANNEL_ID = CONFIG["sps_channel_id"]
+SURVEYS_CHANNEL_ID = CONFIG["surveys_channel_id"]
 DEV_CHANNEL_ID = CONFIG["dev_channel_id"]
 MANUAL_CACHE_FILE = os.path.join(CONFIG["cache_file_dir"], CONFIG["manual_cache_file"])
 AUTO_CACHE_FILE = os.path.join(CONFIG["cache_file_dir"], CONFIG["auto_cache_file"])

--- a/wiki/pages/Alerting-Authority-&-NWWS-OI.md
+++ b/wiki/pages/Alerting-Authority-&-NWWS-OI.md
@@ -35,6 +35,7 @@ Warning products can be routed to dedicated Discord channels based on event type
 | `SVR_CHANNEL_ID` | Severe Thunderstorm Warnings |
 | `FFW_CHANNEL_ID` | Flash Flood Warnings |
 | `SPS_CHANNEL_ID` | Special Weather Statements |
+| `SURVEYS_CHANNEL_ID` | Damage Survey PNS and DAT toolkit plots |
 
 ### Routing Fallback Chain
 

--- a/wiki/pages/Configuration-Guide.md
+++ b/wiki/pages/Configuration-Guide.md
@@ -24,6 +24,7 @@ SPCBot is configured via a `.env` file in the project root. Below is a comprehen
 | `SVR_CHANNEL_ID` | Dedicated channel for Severe Thunderstorm Warning (SVR) posts. | `WARNINGS_CHANNEL_ID` |
 | `FFW_CHANNEL_ID` | Dedicated channel for Flash Flood Warning (FFW) posts. | `WARNINGS_CHANNEL_ID` |
 | `SPS_CHANNEL_ID` | Dedicated channel for Special Weather Statement (SPS) posts. | `WARNINGS_CHANNEL_ID` |
+| `SURVEYS_CHANNEL_ID` | Dedicated channel for Damage Survey PNS (tornado ratings) and DAT plots. | `WARNINGS_CHANNEL_ID` |
 | `HEALTH_CHANNEL_ID` | Channel for health alerts and watchdog notifications. | `SPC_CHANNEL_ID` |
 | `SOUNDING_CHANNEL_ID` | Channel for automated sounding posts. | `SPC_CHANNEL_ID` |
 | `DEV_CHANNEL_ID` | Channel for developer/admin operational alerts. | `HEALTH_CHANNEL_ID`, then `SPC_CHANNEL_ID` |


### PR DESCRIPTION
Separates damage survey posts (tornado ratings) and DAT plots from the general warnings channel into their own dedicated configuration.