### PR TITLE
fix: content-based caching for AI outlook analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.36.3] - 2026-06-06
+
+### Fixed
+- **AI Outlook Caching:** Implemented content-based cache invalidation for SPC outlook summaries. The bot now versions its AI analysis cache based on the hash of the outlook text, ensuring that new outlook issuances at the same URL (e.g., Day 1 updates) immediately trigger a fresh analysis instead of serving stale cached data.
+
 ## [5.36.2] - 2026-06-05
 
 ### Added

--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -155,11 +155,34 @@ class AISummariesCog(commands.Cog, name="AI Summaries"):
             await interaction.response.defer(thinking=True)
 
             from utils.state_store import get_product_cache, set_product_cache, _get_redis_client
+            from utils.change_detection import calculate_hash_bytes
             import datetime
 
             today_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d")
 
-            cache_key = f"ai_summary_outlook_day{day}"
+            # Need to fetch raw text first to determine cache key (versioning)
+            url_map = {
+                "1": "https://www.spc.noaa.gov/products/outlook/day1otlk.html",
+                "2": "https://www.spc.noaa.gov/products/outlook/day2otlk.html",
+                "3": "https://www.spc.noaa.gov/products/outlook/day3otlk.html",
+                "48": "https://www.spc.noaa.gov/products/exper/day4-8/day48prob.html",
+            }
+            url = url_map.get(day)
+            if not url:
+                await interaction.followup.send("Invalid outlook day.", ephemeral=True)
+                return
+
+            from utils.http import http_get_text
+
+            raw_text = await http_get_text(url)
+            if not raw_text:
+                await interaction.followup.send("Failed to fetch outlook text.", ephemeral=True)
+                return
+
+            # Version the cache key based on content hash
+            text_hash = calculate_hash_bytes(raw_text.encode())
+            cache_key = f"ai_summary_outlook_day{day}_{text_hash[:16]}"
+
             summary_raw = await get_product_cache(cache_key)
 
             summary = None
@@ -176,27 +199,13 @@ class AISummariesCog(commands.Cog, name="AI Summaries"):
             else:
                 if redis:
                     await redis.incr(f"ai_api_calls_{today_str}")
-                # Need to generate it
-                url_map = {
-                    "1": "https://www.spc.noaa.gov/products/outlook/day1otlk.html",
-                    "2": "https://www.spc.noaa.gov/products/outlook/day2otlk.html",
-                    "3": "https://www.spc.noaa.gov/products/outlook/day3otlk.html",
-                    "48": "https://www.spc.noaa.gov/products/exper/day4-8/day48prob.html",
-                }
-                url = url_map.get(day)
-                if not url:
-                    await interaction.followup.send("Invalid outlook day.", ephemeral=True)
-                    return
 
-                from utils.http import http_get_text
+                from utils.ai import summarize_outlook
 
-                raw_text = await http_get_text(url)
-                if raw_text:
-                    from utils.ai import summarize_outlook
-
-                    summary = await summarize_outlook(raw_text)
-                    if summary:
-                        await set_product_cache(cache_key, json.dumps(summary), ttl=86400)
+                summary = await summarize_outlook(raw_text)
+                if summary:
+                    # Store with long TTL, it's content-addressed
+                    await set_product_cache(cache_key, json.dumps(summary), ttl=86400 * 7)
 
             if not summary:
                 await interaction.followup.send("Failed to generate AI analysis.", ephemeral=True)

--- a/tests/test_ai_summaries.py
+++ b/tests/test_ai_summaries.py
@@ -1,0 +1,67 @@
+import pytest
+import hashlib
+import json
+from unittest.mock import MagicMock, AsyncMock, patch
+import discord
+
+
+@pytest.mark.asyncio
+async def test_handle_outlook_summary_caching():
+    bot = MagicMock()
+
+    with patch("utils.http.http_get_text", new_callable=AsyncMock) as mock_get_text, patch(
+        "utils.ai.summarize_outlook", new_callable=AsyncMock
+    ) as mock_summarize, patch("utils.ai.generate_morning_briefing", new_callable=AsyncMock), patch(
+        "utils.state_store.get_product_cache", new_callable=AsyncMock
+    ) as mock_get_cache, patch(
+        "utils.state_store.set_product_cache", new_callable=AsyncMock
+    ) as mock_set_cache, patch("utils.state_store._get_redis_client", return_value=None), patch(
+        "utils.change_detection.calculate_hash_bytes"
+    ) as mock_hash:
+        from cogs.ai_summaries import AISummariesCog
+
+        cog = AISummariesCog(bot)
+
+        interaction = AsyncMock(spec=discord.Interaction)
+        interaction.response = AsyncMock()
+        interaction.followup = AsyncMock()
+
+        # Setup mocks
+        mock_get_text.side_effect = ["Content V1", "Content V1", "Content V2"]
+
+        def simple_hash(data):
+            return hashlib.md5(data).hexdigest()
+
+        mock_hash.side_effect = lambda x: simple_hash(x)
+
+        cache = {}
+
+        async def get_cache(key):
+            return cache.get(key)
+
+        async def set_cache(key, val, ttl=None):
+            cache[key] = val
+
+        mock_get_cache.side_effect = get_cache
+        mock_set_cache.side_effect = set_cache
+
+        mock_summarize.side_effect = ["Summary V1", "Summary V2"]
+
+        # 1. First call with Content V1
+        await cog._handle_outlook_summary(interaction, "1")
+        hash1 = simple_hash(b"Content V1")[:16]
+        expected_key1 = f"ai_summary_outlook_day1_{hash1}"
+        assert expected_key1 in cache
+        assert json.loads(cache[expected_key1]) == "Summary V1"
+
+        # 2. Second call with SAME Content V1
+        mock_summarize.reset_mock()
+        await cog._handle_outlook_summary(interaction, "1")
+        mock_summarize.assert_not_called()
+
+        # 3. Third call with Content V2
+        await cog._handle_outlook_summary(interaction, "1")
+        hash2 = simple_hash(b"Content V2")[:16]
+        expected_key2 = f"ai_summary_outlook_day1_{hash2}"
+        assert expected_key2 in cache
+        assert json.loads(cache[expected_key2]) == "Summary V2"


### PR DESCRIPTION
### Summary
The AI outlook analysis previously used a static cache key per day, which caused it to serve stale content if a new outlook update was issued at the same URL (e.g., Day 1 updates). This PR implements content-based caching by hashing the outlook text and incorporating the hash into the cache key.

### Changes
- **Content-Based Caching**: AI analysis for outlooks is now versioned by content hash.
- **Improved Retrieval**: The bot now fetches raw text before checking the cache to ensure the version is current.
- **Increased TTL**: Content-addressed cache entries now have a 7-day TTL.
- **New Tests**: Added `tests/test_ai_summaries.py` to verify caching logic.

### Verification
- [x] Pytest `tests/test_ai_summaries.py` passed.
- [x] Pre-push CI checks (linting, tests) passed.
- [x] Empirical verification of cache miss on content change.