### PR TITLE
fix: Day 4-8 AI Analysis 404 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.37.2] - 2026-06-08
+
+### Fixed
+- **Day 4-8 AI Analysis:** Fixed a 404 error when fetching the Day 4-8 outlook text by updating the source URL to the correct directory index. Added HTML tag stripping for cleaner AI prompt construction.
+
 ## [5.37.1] - 2026-06-07
 
 ### Added

--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -291,12 +291,16 @@ async def ensure_outlook_summary(day: str, raw_text: str = None) -> Any | None:
                 "1": "https://www.spc.noaa.gov/products/outlook/day1otlk.html",
                 "2": "https://www.spc.noaa.gov/products/outlook/day2otlk.html",
                 "3": "https://www.spc.noaa.gov/products/outlook/day3otlk.html",
-                "48": "https://www.spc.noaa.gov/products/exper/day4-8/day48prob.html",
+                "48": "https://www.spc.noaa.gov/products/exper/day4-8/",
             }
             url = url_map.get(day)
             if not url:
                 return None
-            raw_text = await http_get_text(url)
+            html = await http_get_text(url)
+            if html and "<pre>" in html:
+                raw_text = html.split("<pre>")[1].split("</pre>")[0]
+            else:
+                raw_text = html
 
         if not raw_text:
             return None


### PR DESCRIPTION
This PR fixes a 404 error when fetching the Day 4-8 SPC outlook text for AI analysis.

### Changes:
- **Corrected URL:** Updated the Day 4-8 text source from `day48prob.html` (404) to the correct directory index `https://www.spc.noaa.gov/products/exper/day4-8/`.
- **Improved Parsing:** Added `<pre>` tag stripping to the outlook fetcher to ensure clean text is sent to the Gemini API, matching the logic used for Mesoscale Discussions.

Verified with a reproduction script that regional risk analysis is now generated correctly for Day 4-8 products.