### PR TITLE
fix: resolve AI summary failure for Day 3 outlook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.37.3] - 2026-06-08
+
+### Fixed
+- **AI Summary Reliability:** Improved AI summary generation for SPC Outlooks (Days 1-3) by switching to plain-text sources, bypassing HTML-only cache busters and ensuring cleaner input for the Gemini model. Implemented robust HTML tag stripping and case-insensitive `<pre>` tag handling for all scraped weather products.
+
 ## [5.37.2] - 2026-06-08
 
 ### Fixed

--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any
 import discord
 from discord import app_commands
@@ -94,10 +95,18 @@ async def ensure_md_summary(md_num: str, raw_text: str = None) -> str | None:
                 # Fallback to fetching from SPC
                 url = f"https://www.spc.noaa.gov/products/md/md{str(md_num).zfill(4)}.html"
                 html = await http_get_text(url)
-                if html and "<pre>" in html:
-                    raw_text = html.split("<pre>")[1].split("</pre>")[0]
+                if html:
+                    if "<pre>" in html.lower():
+                        parts = re.split(r"<pre[^>]*>", html, flags=re.IGNORECASE)
+                        if len(parts) > 1:
+                            raw_text = parts[1].split("</pre>")[0]
+                        else:
+                            raw_text = html
+                    else:
+                        raw_text = html
 
         if raw_text:
+            raw_text = re.sub(r"<[^>]*>", "", raw_text).strip()
             from utils.ai import summarize_md
 
             summary = await summarize_md(raw_text)
@@ -288,22 +297,35 @@ async def ensure_outlook_summary(day: str, raw_text: str = None) -> Any | None:
         # 1. Fetch raw text if not provided (to determine cache key)
         if not raw_text:
             url_map = {
-                "1": "https://www.spc.noaa.gov/products/outlook/day1otlk.html",
-                "2": "https://www.spc.noaa.gov/products/outlook/day2otlk.html",
-                "3": "https://www.spc.noaa.gov/products/outlook/day3otlk.html",
+                "1": "https://www.spc.noaa.gov/products/outlook/day1otlk.txt",
+                "2": "https://www.spc.noaa.gov/products/outlook/day2otlk.txt",
+                "3": "https://www.spc.noaa.gov/products/outlook/day3otlk.txt",
                 "48": "https://www.spc.noaa.gov/products/exper/day4-8/",
             }
             url = url_map.get(day)
             if not url:
                 return None
             html = await http_get_text(url)
-            if html and "<pre>" in html:
-                raw_text = html.split("<pre>")[1].split("</pre>")[0]
+            if not html:
+                return None
+
+            if url.endswith(".txt"):
+                raw_text = html
+            elif "<pre>" in html.lower():
+                # Case-insensitive split for <pre>
+                parts = re.split(r"<pre[^>]*>", html, flags=re.IGNORECASE)
+                if len(parts) > 1:
+                    raw_text = parts[1].split("</pre>")[0]
+                else:
+                    raw_text = html
             else:
                 raw_text = html
 
         if not raw_text:
             return None
+
+        # Strip remaining HTML tags for cleaner AI input
+        raw_text = re.sub(r"<[^>]*>", "", raw_text).strip()
 
         # 2. Version the cache key based on content hash
         text_hash = calculate_hash_bytes(raw_text.encode())

--- a/tests/test_ai_summaries.py
+++ b/tests/test_ai_summaries.py
@@ -65,3 +65,52 @@ async def test_handle_outlook_summary_caching():
         expected_key2 = f"ai_summary_outlook_day1_{hash2}"
         assert expected_key2 in cache
         assert json.loads(cache[expected_key2]) == "Summary V2"
+
+
+@pytest.mark.asyncio
+async def test_ensure_outlook_summary_day3_txt():
+    """Verify Day 3 uses .txt URL and strips HTML tags."""
+    with patch("cogs.ai_summaries.http_get_text", new_callable=AsyncMock) as mock_get_text, patch(
+        "utils.ai.summarize_outlook", new_callable=AsyncMock
+    ) as mock_summarize, patch("utils.state_store.get_product_cache", return_value=None), patch(
+        "utils.state_store.set_product_cache", new_callable=AsyncMock
+    ), patch("utils.state_store._get_redis_client", return_value=None):
+        from cogs.ai_summaries import ensure_outlook_summary
+
+        # Mock Day 3 .txt content (no HTML)
+        txt_content = "ZCZC SPCSWODY3 ALL\n...TEXT...\n$$"
+        mock_get_text.return_value = txt_content
+        mock_summarize.return_value = [{"region": "Test", "hazards_mode": "None"}]
+
+        summary = await ensure_outlook_summary("3")
+
+        # Verify it called the .txt URL
+        mock_get_text.assert_called_with("https://www.spc.noaa.gov/products/outlook/day3otlk.txt")
+        # Verify summarize_outlook was called with the raw text
+        mock_summarize.assert_called_with("ZCZC SPCSWODY3 ALL\n...TEXT...\n$$")
+        assert summary[0]["region"] == "Test"
+
+
+@pytest.mark.asyncio
+async def test_ensure_outlook_summary_html_stripping():
+    """Verify HTML stripping for HTML products like Day 4-8."""
+    with patch("cogs.ai_summaries.http_get_text", new_callable=AsyncMock) as mock_get_text, patch(
+        "utils.ai.summarize_outlook", new_callable=AsyncMock
+    ) as mock_summarize, patch("utils.state_store.get_product_cache", return_value=None), patch(
+        "utils.state_store.set_product_cache", new_callable=AsyncMock
+    ), patch("utils.state_store._get_redis_client", return_value=None):
+        from cogs.ai_summaries import ensure_outlook_summary
+
+        # Mock Day 4-8 HTML content
+        html_content = "<html><pre>ZCZC ALL\n...TEXT...<a href='link'>ARCHIVE</a></pre></html>"
+        mock_get_text.return_value = html_content
+        mock_summarize.return_value = [{"region": "Test", "hazards_mode": "None"}]
+
+        await ensure_outlook_summary("48")
+
+        # Verify it called the directory URL
+        mock_get_text.assert_called_with("https://www.spc.noaa.gov/products/exper/day4-8/")
+        # Verify summarize_outlook was called with STRIPPED text
+        # Splitting by <pre> gives "ZCZC ALL\n...TEXT...<a href='link'>ARCHIVE</a>"
+        # Stripping tags gives "ZCZC ALL\n...TEXT...ARCHIVE"
+        mock_summarize.assert_called_with("ZCZC ALL\n...TEXT...ARCHIVE")


### PR DESCRIPTION
### Description
This PR resolves the failure of AI summary generation for SPC Day 3 outlooks.

### Root Cause
1. **HTML Parsing Complexity:** Scraping HTML outlook pages was prone to failure if tags changed or if additional HTML content (like archive links) was updated, busting the content-hash based cache unnecessarily.
2. **AI Confusion:** Embedding HTML tags (`<a>`, `<script>`) inside the prompt occasionally confused the Gemini model, leading to malformed or empty JSON responses.
3. **Cache Busting:** Minor HTML-only changes (like issuance timestamps in archive links) caused frequent cache misses, leading to unnecessary API calls and potential rate limiting.

### Changes
- **Switched to .txt sources** for Day 1, Day 2, and Day 3 outlooks. These are clean, plain-text products without HTML noise.
- **Implemented robust HTML tag stripping** for all scraped weather products (including MDs and Day 4-8 outlooks) to ensure the AI only sees relevant technical text.
- **Added case-insensitive `<pre>` tag handling** for better compatibility with varying SPC page formats.
- **Improved cache stability** by using the clean text for content hashing.

### Verification
- Added `test_ensure_outlook_summary_day3_txt` to verify the `.txt` source transition.
- Added `test_ensure_outlook_summary_html_stripping` to verify HTML tag removal for legacy HTML sources.
- Verified all 488 tests pass.
- Manually verified Day 3 text fetching and stripping with a reproduction script.
