### PR TITLE
Autopost AI summaries for outlooks, MDs, and soundings

### DIFF
--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -360,6 +360,72 @@ async def ensure_outlook_summary(day: str, raw_text: str = None) -> Any | None:
         return None
 
 
+async def autopost_outlook_summary(channel: discord.abc.Messageable, day: str, delay: float = 0.5):
+    """Wait for outlook summary to be ready and post it as a follow-up message."""
+    try:
+        import asyncio
+
+        await asyncio.sleep(delay)
+        summary = await ensure_outlook_summary(day)
+        if not summary:
+            return
+
+        if isinstance(summary, list) and len(summary) > 0:
+            view = RegionalAnalysisView(day, summary)
+            await channel.send(embed=view._create_embed(), view=view)
+        else:
+            embed = discord.Embed(
+                title=f"🪄 AI Analysis (Day {day} Outlook)",
+                description=str(summary),
+                color=discord.Color.blue(),
+            )
+            await channel.send(embed=embed)
+    except Exception as e:
+        logger.exception(f"Error autoposting outlook summary for Day {day}: {e}")
+
+
+async def autopost_md_summary(channel: discord.abc.Messageable, md_num: str, delay: float = 0.5):
+    """Wait for MD summary to be ready and post it as a follow-up message."""
+    try:
+        import asyncio
+
+        await asyncio.sleep(delay)
+        summary = await ensure_md_summary(md_num)
+        if not summary:
+            return
+
+        embed = discord.Embed(
+            title=f"🪄 AI Summary (MD #{md_num})",
+            description=summary,
+            color=discord.Color.purple(),
+        )
+        await channel.send(embed=embed)
+    except Exception as e:
+        logger.exception(f"Error autoposting MD summary for MD {md_num}: {e}")
+
+
+async def autopost_sounding_summary(
+    channel: discord.abc.Messageable, cache_key: str, delay: float = 0.5
+):
+    """Wait for sounding summary to be ready and post it as a follow-up message."""
+    try:
+        import asyncio
+
+        await asyncio.sleep(delay)
+        summary = await ensure_sounding_summary(cache_key)
+        if not summary:
+            return
+
+        embed = discord.Embed(
+            title="🪄 AI Analysis (Environment)",
+            description=summary,
+            color=discord.Color.teal(),
+        )
+        await channel.send(embed=embed)
+    except Exception as e:
+        logger.exception(f"Error autoposting sounding summary for {cache_key}: {e}")
+
+
 class AISummariesCog(commands.Cog, name="AI Summaries"):
     def __init__(self, bot):
         self.bot = bot

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -681,10 +681,10 @@ class MesoscaleCog(commands.Cog):
             view = MDSummaryView(md_num=str(md_num), raw_text=raw_text or "")
             msg = await channel.send(embeds=[img_embed, text_embed], files=files, view=view)
 
-            # Proactively trigger AI summary generation so it's ready when the button is clicked
-            from cogs.ai_summaries import ensure_md_summary
+            # Proactively trigger AI summary generation and autopost it
+            from cogs.ai_summaries import autopost_md_summary
 
-            t = asyncio.create_task(ensure_md_summary(str(md_num), raw_text=raw_text))
+            t = asyncio.create_task(autopost_md_summary(channel, str(md_num)))
             t.add_done_callback(_log_task_exception)
 
             self.bot.state.posted_mds.add(md_num)
@@ -836,6 +836,20 @@ class MesoscaleCog(commands.Cog):
                     self.bot.state.active_mds.add(md_num)
                     await self.bot.state.add_posted_md(str(md_num))
                     self.bot.state.last_post_times["md"] = datetime.now(timezone.utc)
+
+                    # Autopost AI summary
+                    from cogs.ai_summaries import autopost_md_summary
+
+                    t = asyncio.create_task(autopost_md_summary(channel, str(md_num)))
+                    t.add_done_callback(
+                        lambda t: (
+                            logger.debug(f"[MD {md_num}] AI summary autopost finished")
+                            if not t.exception()
+                            else logger.exception(
+                                f"[MD {md_num}] AI summary autopost failed", exc_info=t.exception()
+                            )
+                        )
+                    )
                     logger.info(f"Posted MD #{md_num}")
                 except Exception as e:
                     logger.exception(f"auto_post_md send failed for #{md_num}: {e}")

--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -160,12 +160,18 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
                 await set_posted_urls(day_key, urls)
                 logger.info(f"[Day {day}] Posted {len(files)} images. URLs: {urls}")
 
-                # Proactively trigger AI summary generation so it's ready when the button is clicked
-                from cogs.ai_summaries import ensure_outlook_summary
+                # Proactively trigger AI summary generation and autopost it
+                from cogs.ai_summaries import autopost_outlook_summary
 
-                t = asyncio.create_task(ensure_outlook_summary(str(day)))
+                t = asyncio.create_task(autopost_outlook_summary(channel, str(day)))
                 t.add_done_callback(
-                    lambda t: logger.debug(f"[Day {day}] Proactive AI summary generation finished")
+                    lambda t: (
+                        logger.debug(f"[Day {day}] AI summary autopost finished")
+                        if not t.exception()
+                        else logger.exception(
+                            f"[Day {day}] AI summary autopost failed", exc_info=t.exception()
+                        )
+                    )
                 )
 
                 # Archive versions for /compare command
@@ -275,6 +281,20 @@ class OutlooksCog(commands.Cog):
                     self.bot.state.last_post_times["day48"] = datetime.now(timezone.utc)
                     self.bot.state.last_posted_urls["day48"] = urls
                     await set_posted_urls("day48", urls)
+
+                    # Autopost AI summary
+                    from cogs.ai_summaries import autopost_outlook_summary
+
+                    t = asyncio.create_task(autopost_outlook_summary(channel, "48"))
+                    t.add_done_callback(
+                        lambda t: (
+                            logger.debug("[Day 48] AI summary autopost finished")
+                            if not t.exception()
+                            else logger.exception(
+                                "[Day 48] AI summary autopost failed", exc_info=t.exception()
+                            )
+                        )
+                    )
                 except Exception as e:
                     logger.exception(f"Failed to send SPC48 post: {e}")
 

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -340,6 +340,7 @@ class SoundingCog(commands.Cog):
                     clean_data=data,
                     channel=channel,
                     type_label="Special Sounding",
+                    autopost_summary=True,
                 )
                 self.bot.state.last_post_times["sounding"] = datetime.now(timezone.utc)
 

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -204,6 +204,7 @@ async def send_sounding_embed(
     messages_to_delete: Optional[list] = None,
     is_acars: bool = False,
     type_label: Optional[str] = None,
+    autopost_summary: bool = False,
 ):
     """Helper to build and send the final sounding post with AI Analysis button."""
     mode_label = "🌙 Dark" if dark_mode else "☀️ Light"
@@ -301,6 +302,24 @@ async def send_sounding_embed(
 
         await target.send(caption, files=[discord.File(png_path)], view=view)
         logger.info(f"[SOUNDING] Posted {station_id} {time_label}")
+
+        # Autopost AI summary if enabled and cache_key was available
+        if autopost_summary and cache_key and clean_data:
+            from cogs.ai_summaries import autopost_sounding_summary
+
+            raw_text = get_sounding_params_text(clean_data)
+            if raw_text:
+                t = asyncio.create_task(autopost_sounding_summary(target, cache_key))
+                t.add_done_callback(
+                    lambda t: (
+                        logger.debug(f"[SOUNDING] AI summary autopost finished for {cache_key}")
+                        if not t.exception()
+                        else logger.exception(
+                            f"[SOUNDING] AI summary autopost failed for {cache_key}",
+                            exc_info=t.exception(),
+                        )
+                    )
+                )
     except Exception as e:
         logger.exception(f"[SOUNDING] Failed to post: {e}")
 

--- a/utils/ai.py
+++ b/utils/ai.py
@@ -103,10 +103,10 @@ async def summarize_sounding(raw_text: str) -> str | None:
 async def summarize_sounding_enhanced(
     raw_text: str,
     location_name: str = "Unknown",
-    outlook_context: list[dict] = None,
-    md_context: list[str] = None,
-    watch_context: list[str] = None,
-    sounding_context: str = None,
+    outlook_context: list[dict] | None = None,
+    md_context: list[str] | None = None,
+    watch_context: list[str] | None = None,
+    sounding_context: str | None = None,
 ) -> str | None:
     """Generates a high-accuracy environmental analysis by cross-referencing
     computed parameters with SPC products and nearby sounding data."""


### PR DESCRIPTION
## Summary
Adds automatic posting of AI-generated summaries as follow-up messages for convective outlooks, mesoscale discussions, and soundings when posted by background auto-posting tasks.

## Changes
- **Outlook summaries**: Posted as paginated regional analysis (preserves existing pagination UI with Previous/Next buttons)
- **MD summaries**: Posted as simple embeds below the discussion graphic
- **Sounding summaries**: Posted as simple embeds below the sounding plot

## Key Points
- Only affects **auto-posting tasks** (background processes)
- Manual user commands (`/spc1`, `/sounding`) retain button-only access for on-demand summaries
- Autopost runs as non-blocking background tasks via `asyncio.create_task()`
- Full error handling: failures are logged but don't interfere with main product posts
- If AI summary generation fails (API errors, token limits, etc.), the product still posts normally

## Files Changed
- `cogs/ai_summaries.py` — Added `autopost_outlook_summary()`, `autopost_md_summary()`, `autopost_sounding_summary()` helpers
- `cogs/outlooks.py` — Updated Day 1-3 and Day 4-8 posting to trigger autopost
- `cogs/mesoscale.py` — Updated both `_post_md_now_inner()` and `auto_post_md()` to trigger autopost
- `cogs/sounding_views.py` — Added `autopost_summary` parameter and autopost logic
- `cogs/sounding.py` — Updated all auto-posting task calls to enable autopost

🤖 Generated with [Claude Code](https://claude.com/claude-code)