### PR TITLE
Fix AI summary grouping for auto-posted soundings

### DIFF
--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -411,9 +411,9 @@ async def autopost_md_summary(channel: discord.abc.Messageable, md_num: str, del
 
 
 async def autopost_sounding_summary(
-    channel: discord.abc.Messageable, cache_key: str, delay: float = 0.5
+    sounding_msg: discord.Message, cache_key: str, sounding_label: str = None, delay: float = 0.5
 ):
-    """Wait for sounding summary to be ready and post it as a follow-up message."""
+    """Wait for sounding summary to be ready and post it as a reply to the sounding message."""
     try:
         import asyncio
         from utils.state_store import set_product_cache
@@ -426,12 +426,16 @@ async def autopost_sounding_summary(
             )
             return
 
+        title = "🪄 AI Analysis (Environment)"
+        if sounding_label:
+            title = f"{title}\n{sounding_label}"
+
         embed = discord.Embed(
-            title="🪄 AI Analysis (Environment)",
+            title=title,
             description=summary,
             color=discord.Color.teal(),
         )
-        msg = await channel.send(embed=embed)
+        msg = await sounding_msg.reply(embed=embed)
         # Store message ID so button clicks know it was already posted
         await set_product_cache(f"sounding_summary_message_{cache_key}", str(msg.id))
     except Exception as e:

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -300,7 +300,7 @@ async def send_sounding_embed(
                         )
                     )
 
-        await target.send(caption, files=[discord.File(png_path)], view=view)
+        sounding_msg = await target.send(caption, files=[discord.File(png_path)], view=view)
         logger.info(f"[SOUNDING] Posted {station_id} {time_label}")
 
         # Autopost AI summary if enabled and cache_key was available
@@ -309,7 +309,10 @@ async def send_sounding_embed(
 
             raw_text = get_sounding_params_text(clean_data)
             if raw_text:
-                t = asyncio.create_task(autopost_sounding_summary(target, cache_key))
+                sounding_label = f"{label} — {time_label}"
+                t = asyncio.create_task(
+                    autopost_sounding_summary(sounding_msg, cache_key, sounding_label)
+                )
                 t.add_done_callback(
                     lambda t: (
                         logger.debug(f"[SOUNDING] AI summary autopost finished for {cache_key}")


### PR DESCRIPTION
## Summary
Fix grouping confusion when multiple soundings post simultaneously with AI summaries.

## Changes
- Post AI summaries as **threaded replies** to sounding messages
- Include sounding identifier in summary title (Station name and valid time)
- Example: '🪄 AI Analysis (Environment)\nMKE — 06-11-2026 12z'

## What This Fixes
When multiple soundings post at the same time, their AI summaries would appear together in the channel, making it unclear which summary refers to which sounding. Now each summary is posted as a reply to its corresponding sounding message, and includes the sounding details in the title.

## Testing
✅ All pre-commit checks passed
✅ 488 tests passed