### PR TITLE
fix: correct LCL extraction and autopost sounding summaries

### DIFF
--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -411,7 +411,14 @@ async def autopost_md_summary(channel: discord.abc.Messageable, md_num: str, del
 
 
 async def autopost_sounding_summary(
-    sounding_msg: discord.Message, cache_key: str, sounding_label: str = None, delay: float = 0.5
+    sounding_msg: discord.Message,
+    cache_key: str,
+    sounding_label: str = None,
+    delay: float = 0.5,
+    raw_text: str = None,
+    lat: float = None,
+    lon: float = None,
+    location_name: str = "Unknown",
 ):
     """Wait for sounding summary to be ready and post it as a reply to the sounding message."""
     try:
@@ -419,7 +426,13 @@ async def autopost_sounding_summary(
         from utils.state_store import set_product_cache
 
         await asyncio.sleep(delay)
-        summary = await ensure_sounding_summary(cache_key)
+        summary = await ensure_sounding_summary(
+            cache_key,
+            raw_text=raw_text,
+            lat=lat,
+            lon=lon,
+            location_name=location_name,
+        )
         if not summary:
             logger.warning(
                 f"[Sounding {cache_key}] AI summary returned None (text fetch or API call failed)"

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -146,9 +146,9 @@ def get_sounding_params_text(clean_data: dict) -> Optional[str]:
         summary += f"DCAPE: {_fmt_val(thermo.get('dcape'), 'J/kg')} | "
         summary += f"MUECAPE: {_fmt_val(thermo.get('mu_ecape'), 'J/kg')}\n"
 
-        # LCL/LFC heights (in pressure coordinates - lower pressure = higher altitude)
-        summary += f"SB LCL Pressure: {_fmt_val(thermo.get('sb_lcl_z'), 'hPa')} | "
-        summary += f"SB LFC Pressure: {_fmt_val(thermo.get('sb_lfc_z'), 'hPa')}\n"
+        # LCL/LFC in pressure coordinates (higher pressure value = closer to surface = favorable for surface convection)
+        summary += f"SB LCL Pressure: {_fmt_val(thermo.get('sb_lcl_p'), 'hPa')} | "
+        summary += f"SB LFC Pressure: {_fmt_val(thermo.get('sb_lfc_p'), 'hPa')}\n"
 
         # Lapse rates
         summary += f"Lapse Rate (0-3km): {_fmt_val(thermo.get('lr_03km'), 'K/km')} | "

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -310,8 +310,18 @@ async def send_sounding_embed(
             raw_text = get_sounding_params_text(clean_data)
             if raw_text:
                 sounding_label = f"{label} — {time_label}"
+                lat = float(clean_data["site_info"]["site-latlon"][0])
+                lon = float(clean_data["site_info"]["site-latlon"][1])
                 t = asyncio.create_task(
-                    autopost_sounding_summary(sounding_msg, cache_key, sounding_label)
+                    autopost_sounding_summary(
+                        sounding_msg,
+                        cache_key,
+                        sounding_label,
+                        raw_text=raw_text,
+                        lat=lat,
+                        lon=lon,
+                        location_name=label,
+                    )
                 )
                 t.add_done_callback(
                     lambda t: (


### PR DESCRIPTION
## Summary
Fixes critical regression in AI sounding analysis accuracy and autopost race condition.

## Changes
1. **LCL parameter regression fix**: Changed from `sb_lcl_z` (height) to `sb_lcl_p` (pressure)
   - Commit 2a57dce relabeled the height as pressure without changing the variable
   - This caused ACARS summaries to report nonsensical values (e.g., "1500 hPa" for 1500m height)
   - AI then misinterpreted as stable environment even during active severe watches
   
2. **Autopost race condition fix**: Now pass raw_text and context directly to autopost task
   - Previous implementation had autopost fail silently when prefetch hadn't completed
   - `ensure_sounding_summary()` requires raw_text to generate summary if cache is empty
   - Now provides all necessary parameters (raw_text, lat, lon, location_name) upfront

## Test Plan
- [x] All pre-push checks passed (tests, linting, type checking)
- [ ] Verify next ACARS sounding correctly reports LCL pressure
- [ ] Verify AI summary auto-posts without manual button click
- [ ] Check that Omaha ACARS in SVR watch now shows accurate severe potential