### PR TITLE
fix: Cross-reference SPC website to prevent early NWS API glitch cancellations

### DIFF
--- a/cogs/watch_fetch.py
+++ b/cogs/watch_fetch.py
@@ -33,6 +33,17 @@ _TORNADO_WATCH_RE = re.compile(r"Tornado Watch Number", re.IGNORECASE)
 _nws_last_parsed: Optional[Dict[str, dict]] = None
 
 
+async def get_spc_active_watch_numbers() -> Optional[set]:
+    """Scrapes the SPC watch index to get a set of authoritative active watch numbers."""
+    spc_html = await http_get_text(SPC_WATCH_INDEX_URL)
+    if not spc_html:
+        return None
+    valid_etns = set()
+    for wm in _WW_HREF_RE.finditer(spc_html):
+        valid_etns.add(wm.group(1).zfill(4))
+    return valid_etns
+
+
 async def fetch_active_watches_nws() -> Optional[Dict[str, dict]]:
     """
     Fetch active SPC watches from the NWS Alerts API.

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -435,6 +435,7 @@ class WatchesCog(commands.Cog):
             now_utc = datetime.now(timezone.utc)
 
             # ── Cancellations ──────────────────────────────────────────────
+            spc_active_watches = None
             for watch_num, info in list(self.bot.state.active_watches.items()):
                 wtype = info["type"] if isinstance(info, dict) else info
                 expires = info.get("expires") if isinstance(info, dict) else None
@@ -444,6 +445,19 @@ class WatchesCog(commands.Cog):
 
                 if not (expired_by_time or (missing_from_api and nws_watches)):
                     continue
+
+                # Double check SPC website to prevent NWS API glitch cancellations
+                if missing_from_api and not expired_by_time:
+                    if spc_active_watches is None:
+                        from cogs.watch_fetch import get_spc_active_watch_numbers
+
+                        spc_active_watches = await get_spc_active_watch_numbers()
+
+                    if spc_active_watches is not None and watch_num in spc_active_watches:
+                        logger.warning(
+                            f"NWS API dropped watch #{watch_num} but it is still active on SPC. Ignoring NWS glitch."
+                        )
+                        continue
 
                 self.bot.state.active_watches.pop(watch_num, None)
                 reason = "expired" if expired_by_time else "no longer active"

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -288,6 +288,7 @@ async def test_post_watch_now_dedup_skips_already_posted():
     cog._pending_tasks = set()
     cog._watch_inflight = set()
     cog.bot = bot
+    cog._watches_backoff = MagicMock()
 
     await cog.post_watch_now("0102", {"type": "SVR", "expires": None, "affected_zones": []})
 
@@ -304,6 +305,7 @@ async def test_post_watch_now_sends_and_marks_posted():
     cog._pending_tasks = set()
     cog._watch_inflight = set()
     cog.bot = bot
+    cog._watches_backoff = MagicMock()
 
     # Configure the mock state to actually add to the set when add_posted_watch is called
     # to maintain the behavior of the existing test assertion.
@@ -336,6 +338,7 @@ async def test_post_watch_now_no_channel_returns_early():
     cog._pending_tasks = set()
     cog._watch_inflight = set()
     cog.bot = bot
+    cog._watches_backoff = MagicMock()
 
     await cog.post_watch_now("0102", {"type": "SVR", "expires": None, "affected_zones": []})
 
@@ -360,6 +363,7 @@ async def test_post_watch_now_dispatches_to_sounding_cog():
     cog._pending_tasks = set()
     cog._watch_inflight = set()
     cog.bot = bot
+    cog._watches_backoff = MagicMock()
 
     with patch(
         "cogs.watches.fetch_watch_details", AsyncMock(return_value=(None, None, None, False))
@@ -382,6 +386,7 @@ async def test_post_watch_now_concurrent_calls_post_once():
     cog._pending_tasks = set()
     cog._watch_inflight = set()
     cog.bot = bot
+    cog._watches_backoff = MagicMock()
 
     async def _mock_add(wn):
         bot.state.posted_watches.add(wn)
@@ -405,3 +410,60 @@ async def test_post_watch_now_concurrent_calls_post_once():
         )
 
     channel.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_post_watches_fallback_keeps_glitched_watch_alive():
+    """If NWS API drops an active watch but returns others, it checks SPC. If SPC has it, it doesn't cancel."""
+    from cogs.watches import WatchesCog
+
+    bot, channel = _make_watch_bot()
+    bot.state.is_primary = True
+    bot.state.active_watches = {"0336": {"type": "TORNADO", "expires": None, "affected_zones": []}}
+    bot.state.posted_watches = {"0337"}  # so it doesn't try to post a new one
+
+    cog = WatchesCog.__new__(WatchesCog)
+    cog._pending_tasks = set()
+    cog._watch_inflight = set()
+    cog.bot = bot
+    cog._watches_backoff = MagicMock()
+
+    # NWS API returns 0337 but drops 0336
+    nws_mock = {"0337": {"type": "SVR", "expires": None, "affected_zones": []}}
+
+    with patch("cogs.watches.fetch_active_watches_nws", AsyncMock(return_value=nws_mock)), patch(
+        "cogs.watch_fetch.get_spc_active_watch_numbers", AsyncMock(return_value={"0336", "0337"})
+    ):
+        await WatchesCog.auto_post_watches.coro(cog)
+
+    # Should STILL be in active watches!
+    assert "0336" in bot.state.active_watches
+    channel.send.assert_not_called()  # No cancellation message sent
+
+
+@pytest.mark.asyncio
+async def test_auto_post_watches_cancels_when_missing_from_both():
+    """If NWS API drops a watch AND it's missing from SPC, it cancels."""
+    from cogs.watches import WatchesCog
+
+    bot, channel = _make_watch_bot()
+    bot.state.is_primary = True
+    bot.state.active_watches = {"0336": {"type": "TORNADO", "expires": None, "affected_zones": []}}
+    bot.state.posted_watches = {"0337"}  # so it doesn't try to post a new one
+
+    cog = WatchesCog.__new__(WatchesCog)
+    cog._pending_tasks = set()
+    cog._watch_inflight = set()
+    cog.bot = bot
+    cog._watches_backoff = MagicMock()
+
+    nws_mock = {"0337": {"type": "SVR", "expires": None, "affected_zones": []}}
+
+    with patch("cogs.watches.fetch_active_watches_nws", AsyncMock(return_value=nws_mock)), patch(
+        "cogs.watch_fetch.get_spc_active_watch_numbers", AsyncMock(return_value={"0337"})
+    ):  # 0336 missing
+        await WatchesCog.auto_post_watches.coro(cog)
+
+    # Should be REMOVED from active watches!
+    assert "0336" not in bot.state.active_watches
+    channel.send.assert_called_once()  # Cancellation message sent


### PR DESCRIPTION
Resolves an issue where the bot prematurely cancelled watches if they temporarily dropped from the NWS active alerts API.