### PR TITLE
feat: add /howmany command with warning severity tracking

### DIFF
--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -6,6 +6,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from utils.db import get_warning_stats
+
 logger = logging.getLogger("spc_bot")
 
 
@@ -292,6 +294,82 @@ class AnalyticsCog(commands.Cog):
         embed.add_field(name="Verified", value=f"{stats.get('events_verified', 0)}", inline=True)
 
         embed.set_footer(text=f"IEM Cow | Interval: {sts} to {ets}")
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(
+        name="howmany",
+        description="Show warning counts by type and severity (tornado, severe, flash flood)",
+    )
+    @app_commands.describe(
+        period="Time period to count (default: 24h)",
+    )
+    @app_commands.choices(
+        period=[
+            app_commands.Choice(name="Last 24 hours", value="24h"),
+            app_commands.Choice(name="Last 7 days", value="7d"),
+            app_commands.Choice(name="Last 30 days", value="30d"),
+            app_commands.Choice(name="All time", value="all"),
+        ]
+    )
+    async def how_many(self, interaction: discord.Interaction, period: str = "24h"):
+        await interaction.response.defer()
+
+        now = datetime.now(timezone.utc)
+        since_map = {
+            "24h": now - timedelta(hours=24),
+            "7d": now - timedelta(days=7),
+            "30d": now - timedelta(days=30),
+            "all": None,
+        }
+        since = since_map[period]
+        since_ts = since.timestamp() if since else None
+
+        stats = await get_warning_stats(since=since_ts)
+        if not stats:
+            await interaction.followup.send("No warning data available.")
+            return
+
+        tor = stats["tor"]
+        svr = stats["svr"]
+        ffw = stats["ffw"]
+
+        period_label = {"24h": "24h", "7d": "7 days", "30d": "30 days", "all": "all time"}[period]
+
+        embed = discord.Embed(
+            title=f"📊 Warning Counts — Last {period_label}",
+            color=discord.Color.blue(),
+            timestamp=now,
+        )
+
+        # Tornado
+        tor_val = (
+            f"**Total:** {tor['total']}\n"
+            f"🚨 Emergencies: {tor['emergency']}\n"
+            f"⚠️ PDS: {tor['pds']}\n"
+            f"Standard: {tor['standard']}\n"
+            f"\n🔴 Observed/Confirmed: {tor['observed']}\n"
+            f"📡 Radar Indicated: {tor['radar_indicated']}"
+        )
+        embed.add_field(name="🌪️ Tornado Warnings", value=tor_val, inline=True)
+
+        # Severe Tstorm
+        svr_val = (
+            f"**Total:** {svr['total']}\n"
+            f"🚨 Destructive: {svr['destructive']}\n"
+            f"⚠️ Considerable: {svr['considerable']}\n"
+            f"Standard: {svr['standard']}"
+        )
+        embed.add_field(name="⛈️ Severe Tstorm Warnings", value=svr_val, inline=True)
+
+        # Flash Flood
+        ffw_val = (
+            f"**Total:** {ffw['total']}\n"
+            f"🚨 Emergencies: {ffw['emergency']}\n"
+            f"Standard: {ffw['standard']}"
+        )
+        embed.add_field(name="🌊 Flash Flood Warnings", value=ffw_val, inline=True)
+
+        embed.set_footer(text="SPC Bot Warning Tracker")
         await interaction.followup.send(embed=embed)
 
 

--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -292,6 +292,53 @@ def get_tornado_attributes(
     return confidence, severity
 
 
+def get_warning_severity(event: str, text: str, params: dict = None) -> Optional[str]:
+    """Return the generic severity label for any warning type.
+
+    tornado → 'standard' | 'pds' | 'emergency'
+    severe  → 'standard' | 'considerable' | 'destructive'
+    flash flood → 'standard' | 'emergency'
+    """
+    text_upper = (text or "").upper()
+
+    if event == "Tornado Warning":
+        if "TORNADO EMERGENCY" in text_upper:
+            return "emergency"
+        if "PARTICULARLY DANGEROUS SITUATION" in text_upper:
+            return "pds"
+        if params:
+            t_threat = params.get("tornadoDamageThreat") or []
+            if "CATASTROPHIC" in t_threat:
+                return "emergency"
+            if "CONSIDERABLE" in t_threat:
+                return "pds"
+        return "standard"
+
+    if event == "Severe Thunderstorm Warning":
+        if "THUNDERSTORM DAMAGE THREAT...DESTRUCTIVE" in text_upper:
+            return "destructive"
+        if "THUNDERSTORM DAMAGE THREAT...CONSIDERABLE" in text_upper:
+            return "considerable"
+        if params:
+            s_threat = params.get("thunderstormDamageThreat") or []
+            if "DESTRUCTIVE" in s_threat:
+                return "destructive"
+            if "CONSIDERABLE" in s_threat:
+                return "considerable"
+        return "standard"
+
+    if event == "Flash Flood Warning":
+        if "FLASH FLOOD EMERGENCY" in text_upper:
+            return "emergency"
+        if params:
+            f_threat = params.get("flashFloodDamageThreat") or []
+            if "CATASTROPHIC" in f_threat:
+                return "emergency"
+        return "standard"
+
+    return None
+
+
 def iem_autoplot_url(vtec: dict, valid_time: Optional[str] = None) -> str:
     """Return the IEM Autoplot URL (#208 for VTEC, #217 for SPS)."""
     office = vtec["office"]

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -35,6 +35,7 @@ from cogs.warning_format import (
     _vtec_url,
     build_concise_warning_text,
     get_tornado_attributes,
+    get_warning_severity,
     get_warning_style,
     iem_autoplot_url,
 )
@@ -425,6 +426,7 @@ class WarningsCog(commands.Cog):
                     area_desc = area_m.group(1) if area_m else "affected area"
 
                     tornado_confidence, tornado_severity = get_tornado_attributes(event, raw_text)
+                    severity = get_warning_severity(event, raw_text)
                     await claim.confirm(
                         msg.id,
                         msg.channel.id,
@@ -432,6 +434,7 @@ class WarningsCog(commands.Cog):
                         area=area_desc,
                         tornado_confidence=tornado_confidence,
                         tornado_severity=tornado_severity,
+                        severity=severity,
                     )
                 except discord.Forbidden as e:
                     await self._notify_channel_error(channel, ["send_messages (403 Forbidden)"])
@@ -889,6 +892,7 @@ class WarningsCog(commands.Cog):
                                 tornado_confidence, tornado_severity = get_tornado_attributes(
                                     event, description, params
                                 )
+                                severity = get_warning_severity(event, description, params)
                                 await self.bot.state.add_posted_warning(
                                     issuance_id,
                                     stored_info["message_id"],
@@ -896,6 +900,7 @@ class WarningsCog(commands.Cog):
                                     area=curr_area,
                                     tornado_confidence=tornado_confidence,
                                     tornado_severity=tornado_severity,
+                                    severity=severity,
                                 )
                             finally:
                                 self._in_flight_vtecs.discard(issuance_id)
@@ -956,6 +961,7 @@ class WarningsCog(commands.Cog):
                         tornado_confidence, tornado_severity = get_tornado_attributes(
                             event, description, params
                         )
+                        severity = get_warning_severity(event, description, params)
                         await claim.confirm(
                             msg.id,
                             msg.channel.id,
@@ -963,6 +969,7 @@ class WarningsCog(commands.Cog):
                             area=area_desc,
                             tornado_confidence=tornado_confidence,
                             tornado_severity=tornado_severity,
+                            severity=severity,
                         )
                     except Exception as e:
                         logger.warning(f"Failed to persist {issuance_id}: {e}")

--- a/utils/db.py
+++ b/utils/db.py
@@ -620,6 +620,27 @@ async def remove_posted_product_id(product_id: str):
 # ── Posted warnings ───────────────────────────────────────────────────────────
 
 
+async def get_all_posted_warnings() -> dict:
+    """Get all posted warning mappings: {vtec_id: {'message_id': ..., 'channel_id': ..., 'area': ...}}."""
+    try:
+        async with get_read_db() as db:
+            async with db.execute(
+                "SELECT vtec_id, message_id, channel_id, area FROM posted_warnings"
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return {
+                    row["vtec_id"]: {
+                        "message_id": row["message_id"],
+                        "channel_id": row["channel_id"],
+                        "area": row["area"],
+                    }
+                    for row in rows
+                }
+    except Exception as e:
+        logger.warning(f"get_all_posted_warnings failed: {e}")
+        return {}
+
+
 async def get_warning_stats(
     since: Optional[float] = None,
 ) -> dict:
@@ -761,6 +782,7 @@ async def add_posted_warning(
             tornado_severity,
             severity,
         ),
+        f"add_posted_warning({vtec_id})",
     )
 
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -251,6 +251,7 @@ async def _create_tables(db: aiosqlite.Connection):
         "ALTER TABLE posted_warnings ADD COLUMN area TEXT",
         "ALTER TABLE posted_warnings ADD COLUMN tornado_confidence TEXT",
         "ALTER TABLE posted_warnings ADD COLUMN tornado_severity TEXT",
+        "ALTER TABLE posted_warnings ADD COLUMN severity TEXT",
         "ALTER TABLE dirty_writes ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0",
     ):
         try:
@@ -619,24 +620,88 @@ async def remove_posted_product_id(product_id: str):
 # ── Posted warnings ───────────────────────────────────────────────────────────
 
 
-async def get_all_posted_warnings() -> dict:
-    """Get all posted warning mappings: {vtec_id: {'message_id': ..., 'channel_id': ..., 'area': ...}}."""
+async def get_warning_stats(
+    since: Optional[float] = None,
+) -> dict:
+    """Aggregate posted warning counts by VTEC phenom and severity.
+
+    Returns::
+        {
+            "tor": {"total": N, "emergency": N, "pds": N, "standard": N,
+                    "observed": N, "radar_indicated": N},
+            "svr": {"total": N, "destructive": N, "considerable": N, "standard": N},
+            "ffw": {"total": N, "emergency": N, "standard": N},
+        }
+    """
     try:
         async with get_read_db() as db:
-            async with db.execute(
-                "SELECT vtec_id, message_id, channel_id, area FROM posted_warnings"
-            ) as cursor:
-                rows = await cursor.fetchall()
-                return {
-                    row["vtec_id"]: {
-                        "message_id": row["message_id"],
-                        "channel_id": row["channel_id"],
-                        "area": row["area"],
-                    }
-                    for row in rows
-                }
+            if since:
+                rows = await db.execute_fetchall(
+                    "SELECT vtec_id, tornado_confidence, tornado_severity, severity "
+                    "FROM posted_warnings WHERE posted_at >= ?",
+                    (since,),
+                )
+            else:
+                rows = await db.execute_fetchall(
+                    "SELECT vtec_id, tornado_confidence, tornado_severity, severity "
+                    "FROM posted_warnings"
+                )
+
+            stats = {
+                "tor": {
+                    "total": 0,
+                    "emergency": 0,
+                    "pds": 0,
+                    "standard": 0,
+                    "observed": 0,
+                    "radar_indicated": 0,
+                },
+                "svr": {"total": 0, "destructive": 0, "considerable": 0, "standard": 0},
+                "ffw": {"total": 0, "emergency": 0, "standard": 0},
+            }
+
+            for row in rows:
+                vtec = row[0]
+                confidence = row[1]
+                tor_severity = row[2]
+                severity = row[3]
+
+                parts = vtec.split(".")
+                phenom = parts[1] if len(parts) >= 2 else ""
+
+                if phenom == "TO":
+                    stats["tor"]["total"] += 1
+                    s = severity or tor_severity
+                    if s == "emergency":
+                        stats["tor"]["emergency"] += 1
+                    elif s == "pds":
+                        stats["tor"]["pds"] += 1
+                    else:
+                        stats["tor"]["standard"] += 1
+                    if confidence == "observed":
+                        stats["tor"]["observed"] += 1
+                    elif confidence == "radar_indicated":
+                        stats["tor"]["radar_indicated"] += 1
+
+                elif phenom == "SV":
+                    stats["svr"]["total"] += 1
+                    if severity == "destructive":
+                        stats["svr"]["destructive"] += 1
+                    elif severity == "considerable":
+                        stats["svr"]["considerable"] += 1
+                    else:
+                        stats["svr"]["standard"] += 1
+
+                elif phenom == "FF":
+                    stats["ffw"]["total"] += 1
+                    if severity == "emergency":
+                        stats["ffw"]["emergency"] += 1
+                    else:
+                        stats["ffw"]["standard"] += 1
+
+            return stats
     except Exception as e:
-        logger.warning(f"get_all_posted_warnings failed: {e}")
+        logger.warning(f"get_warning_stats failed: {e}")
         return {}
 
 
@@ -662,6 +727,7 @@ async def add_posted_warning(
     area: str = "",
     tornado_confidence: Optional[str] = None,
     tornado_severity: Optional[str] = None,
+    severity: Optional[str] = None,
 ):
     """Mark a warning as posted. ``vtec_id`` is the VTEC event identity
     (office.phenom.sig.etn), which stays stable across the warning's
@@ -669,18 +735,32 @@ async def add_posted_warning(
 
     For tornado warnings, ``tornado_confidence`` is 'observed' or 'radar_indicated',
     and ``tornado_severity`` is 'standard', 'pds', or 'emergency'.
+
+    ``severity`` stores the generic severity for any warning type:
+    tornado → 'standard'|'pds'|'emergency'
+    severe  → 'standard'|'considerable'|'destructive'
+    flash flood → 'standard'|'emergency'
     """
     await _write(
-        """INSERT INTO posted_warnings (vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity)
-           VALUES (?, ?, ?, ?, ?, ?, ?)
+        """INSERT INTO posted_warnings (vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity, severity)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(vtec_id) DO UPDATE SET
              message_id=excluded.message_id,
              channel_id=excluded.channel_id,
              area=excluded.area,
              tornado_confidence=excluded.tornado_confidence,
-             tornado_severity=excluded.tornado_severity""",
-        (vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity),
-        f"add_posted_warning({vtec_id})",
+             tornado_severity=excluded.tornado_severity,
+             severity=excluded.severity""",
+        (
+            vtec_id,
+            message_id,
+            channel_id,
+            posted_at,
+            area,
+            tornado_confidence,
+            tornado_severity,
+            severity,
+        ),
     )
 
 

--- a/utils/state.py
+++ b/utils/state.py
@@ -329,6 +329,7 @@ class BotState:
         area: str = "",
         tornado_confidence: Optional[str] = None,
         tornado_severity: Optional[str] = None,
+        severity: Optional[str] = None,
     ) -> None:
         from utils import state_store
 
@@ -338,7 +339,14 @@ class BotState:
             "area": area,
         }
         await state_store.add_posted_warning(
-            vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity
+            vtec_id,
+            message_id,
+            channel_id,
+            posted_at,
+            area,
+            tornado_confidence,
+            tornado_severity,
+            severity,
         )
 
     async def add_posted_sounding(self, pkey: str) -> None:
@@ -566,6 +574,7 @@ class PostedWarningClaim:
         area: str = "",
         tornado_confidence: Optional[str] = None,
         tornado_severity: Optional[str] = None,
+        severity: Optional[str] = None,
     ) -> None:
         """Persist the real entry across memory + SQLite + Redis. After
         this call the claim will not roll back on context exit."""
@@ -577,6 +586,7 @@ class PostedWarningClaim:
             area,
             tornado_confidence,
             tornado_severity,
+            severity,
         )
         self._confirmed = True
 

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -782,10 +782,18 @@ async def add_posted_warning(
     area: str = "",
     tornado_confidence: Optional[str] = None,
     tornado_severity: Optional[str] = None,
+    severity: Optional[str] = None,
 ) -> None:
     _cache_invalidate("posted_warnings")
     await sqlite_backend.add_posted_warning(
-        vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity
+        vtec_id,
+        message_id,
+        channel_id,
+        posted_at,
+        area,
+        tornado_confidence,
+        tornado_severity,
+        severity,
     )
     data = {
         "message_id": message_id,
@@ -793,6 +801,7 @@ async def add_posted_warning(
         "area": area,
         "tornado_confidence": tornado_confidence,
         "tornado_severity": tornado_severity,
+        "severity": severity,
     }
     try:
         await _redis_cmd("HSET", _k_posted_warnings(), vtec_id, json.dumps(data))


### PR DESCRIPTION
## Summary

Adds a `/howmany` slash command that shows warning counts by type and severity for configurable time periods (24h/7d/30d/all time).

## Changes

- **New `severity` column** on `posted_warnings` table — stores generic severity for all warning types:
  - Tornado: `standard` / `pds` / `emergency`
  - Severe Tstorm: `standard` / `considerable` / `destructive`
  - Flash Flood: `standard` / `emergency`
- **`get_warning_severity()`** in `warning_format.py` — extracts severity from warning text/params for any type
- **Severity wired through** `PostedWarningClaim.confirm` → `state.add_posted_warning` → `state_store.add_posted_warning` → `db.add_posted_warning`
- **`get_warning_stats()`** in `db.py` — aggregates counts from the DB with severity/confidence breakdowns
- **`/howmany` command** in `analytics.py` — displays counts in a 3-column embed

## Display

```
📊 Warning Counts — Last 24h

🌪️ Tornado Warnings          ⛈️ Severe Tstorm Warnings     🌊 Flash Flood Warnings
Total: 95                     Total: 168                    Total: 50
🚨 Emergencies: 0             🚨 Destructive: 2             🚨 Emergencies: 1
⚠️ PDS: 0                     ⚠️ Considerable: 8            Standard: 49
Standard: 95
🔴 Observed/Confirmed: 12
📡 Radar Indicated: 65
```

## Notes

- Existing DB entries without severity show as `standard` by default. New warnings populate severity going forward.
- The `severity` column is added via ALTER TABLE migration (safe, no data loss).