### PR TITLE
feat: store raw_text in posted_warnings + NWS API backfill for severity

### DIFF
--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -437,6 +437,7 @@ class WarningsCog(commands.Cog):
                         tornado_confidence=tornado_confidence,
                         tornado_severity=tornado_severity,
                         severity=severity,
+                        raw_text=raw_text,
                     )
                 except discord.Forbidden as e:
                     await self._notify_channel_error(channel, ["send_messages (403 Forbidden)"])
@@ -908,6 +909,7 @@ class WarningsCog(commands.Cog):
                                     tornado_confidence=tornado_confidence,
                                     tornado_severity=tornado_severity,
                                     severity=severity,
+                                    raw_text=description,
                                 )
                             finally:
                                 self._in_flight_vtecs.discard(issuance_id)
@@ -981,6 +983,7 @@ class WarningsCog(commands.Cog):
                             tornado_confidence=tornado_confidence,
                             tornado_severity=tornado_severity,
                             severity=severity,
+                            raw_text=description,
                         )
                     except Exception as e:
                         logger.warning(f"Failed to persist {issuance_id}: {e}")

--- a/main.py
+++ b/main.py
@@ -302,6 +302,14 @@ async def setup_hook():
     if should_run_primary:
         for ext in ALL_EXTENSIONS:
             await bot.load_extension(ext)
+
+        # Backfill warning severity for existing warnings
+        try:
+            from utils.db import backfill_warning_severity
+
+            asyncio.create_task(backfill_warning_severity(days=7))
+        except Exception as e:
+            logger.warning(f"Startup backfill skipped: {e}")
     else:
         logger.info("Running as STANDBY — cogs suppressed until promoted")
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -881,8 +881,6 @@ async def backfill_warning_severity(days: int = 7):
         f"&limit=500&start={start}&end={end}"
     )
 
-    from utils.http import _get_next_url
-
     url = base_url
     updated = 0
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -252,6 +252,7 @@ async def _create_tables(db: aiosqlite.Connection):
         "ALTER TABLE posted_warnings ADD COLUMN tornado_confidence TEXT",
         "ALTER TABLE posted_warnings ADD COLUMN tornado_severity TEXT",
         "ALTER TABLE posted_warnings ADD COLUMN severity TEXT",
+        "ALTER TABLE posted_warnings ADD COLUMN raw_text TEXT",
         "ALTER TABLE dirty_writes ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0",
     ):
         try:
@@ -780,6 +781,7 @@ async def add_posted_warning(
     tornado_confidence: Optional[str] = None,
     tornado_severity: Optional[str] = None,
     severity: Optional[str] = None,
+    raw_text: Optional[str] = None,
 ):
     """Mark a warning as posted. ``vtec_id`` is the VTEC event identity
     (office.phenom.sig.etn), which stays stable across the warning's
@@ -794,15 +796,16 @@ async def add_posted_warning(
     flash flood → 'standard'|'emergency'
     """
     await _write(
-        """INSERT INTO posted_warnings (vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity, severity)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """INSERT INTO posted_warnings (vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity, severity, raw_text)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(vtec_id) DO UPDATE SET
              message_id=excluded.message_id,
              channel_id=excluded.channel_id,
              area=excluded.area,
              tornado_confidence=excluded.tornado_confidence,
              tornado_severity=excluded.tornado_severity,
-             severity=excluded.severity""",
+             severity=excluded.severity,
+             raw_text=excluded.raw_text""",
         (
             vtec_id,
             message_id,
@@ -812,6 +815,7 @@ async def add_posted_warning(
             tornado_confidence,
             tornado_severity,
             severity,
+            raw_text,
         ),
         f"add_posted_warning({vtec_id})",
     )
@@ -840,6 +844,92 @@ async def prune_posted_warnings(max_size: int = 500):
         (max_size,),
         "prune_posted_warnings",
     )
+
+
+async def backfill_warning_severity(days: int = 7):
+    """Fetch expired warnings from NWS API and backfill severity + raw_text for
+    rows where raw_text is NULL. Runs once on startup."""
+    from cogs.warning_format import get_warning_severity
+    from utils.http import http_get_bytes
+
+    try:
+        async with get_read_db() as db:
+            rows = await db.execute_fetchall(
+                "SELECT vtec_id FROM posted_warnings WHERE raw_text IS NULL",
+            )
+    except Exception:
+        logger.warning("[BACKFILL] Could not query posted_warnings (migrating?)")
+        return
+
+    vtec_ids = {r[0] for r in rows}
+    if not vtec_ids:
+        logger.info("[BACKFILL] No warnings need backfill")
+        return
+
+    logger.info(f"[BACKFILL] {len(vtec_ids)} warnings need severity backfill")
+
+    import json
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    start = (now - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    base_url = (
+        "https://api.weather.gov/alerts?"
+        f"status=expired&event=Tornado%20Warning,Severe%20Thunderstorm%20Warning,Flash%20Flood%20Warning"
+        f"&limit=500&start={start}&end={end}"
+    )
+
+    from utils.http import _get_next_url
+
+    url = base_url
+    updated = 0
+
+    while url and vtec_ids:
+        content, status = await http_get_bytes(url, retries=2, timeout=30)
+        if not content or status != 200:
+            logger.warning(f"[BACKFILL] NWS API returned {status}")
+            break
+
+        data = json.loads(content)
+        features = data.get("features", [])
+        logger.info(f"[BACKFILL] Processing {len(features)} warnings (pagination)...")
+
+        for f in features:
+            props = f.get("properties", {})
+            params = (props.get("parameters") or {}) or {}
+            vtec_list = params.get("VTEC") or []
+            if not vtec_list:
+                continue
+
+            # VTEC: /O.{action}.{office}.{phenom}.{sig}.{etn}
+            parts = vtec_list[0].split(".")
+            if len(parts) < 6:
+                continue
+            vtec_id = f"{parts[2]}.{parts[3]}.{parts[4]}.{parts[5]}"
+
+            if vtec_id not in vtec_ids:
+                continue
+
+            event = props.get("event", "")
+            description = props.get("description", "") or ""
+            severity = get_warning_severity(event, description, params)
+            if event:
+                await _write(
+                    "UPDATE posted_warnings SET severity = ?, raw_text = ? WHERE vtec_id = ?",
+                    (severity, description[:5000], vtec_id),
+                    f"backfill({vtec_id})",
+                )
+                updated += 1
+                vtec_ids.discard(vtec_id)
+
+        # Next page (NWS API uses pagination.next in response)
+        url = data.get("pagination", {}).get("next")
+
+    logger.info(f"[BACKFILL] Updated {updated} warnings with severity")
+    if vtec_ids:
+        logger.info(f"[BACKFILL] {len(vtec_ids)} warnings unmatched in NWS response")
 
 
 # ── Soundings ─────────────────────────────────────────────────────────────────

--- a/utils/state.py
+++ b/utils/state.py
@@ -330,6 +330,7 @@ class BotState:
         tornado_confidence: Optional[str] = None,
         tornado_severity: Optional[str] = None,
         severity: Optional[str] = None,
+        raw_text: Optional[str] = None,
     ) -> None:
         from utils import state_store
 
@@ -347,6 +348,7 @@ class BotState:
             tornado_confidence,
             tornado_severity,
             severity,
+            raw_text,
         )
 
     async def add_posted_sounding(self, pkey: str) -> None:
@@ -575,6 +577,7 @@ class PostedWarningClaim:
         tornado_confidence: Optional[str] = None,
         tornado_severity: Optional[str] = None,
         severity: Optional[str] = None,
+        raw_text: Optional[str] = None,
     ) -> None:
         """Persist the real entry across memory + SQLite + Redis. After
         this call the claim will not roll back on context exit."""
@@ -587,6 +590,7 @@ class PostedWarningClaim:
             tornado_confidence,
             tornado_severity,
             severity,
+            raw_text,
         )
         self._confirmed = True
 

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -783,6 +783,7 @@ async def add_posted_warning(
     tornado_confidence: Optional[str] = None,
     tornado_severity: Optional[str] = None,
     severity: Optional[str] = None,
+    raw_text: Optional[str] = None,
 ) -> None:
     _cache_invalidate("posted_warnings")
     await sqlite_backend.add_posted_warning(
@@ -794,6 +795,7 @@ async def add_posted_warning(
         tornado_confidence,
         tornado_severity,
         severity,
+        raw_text,
     )
     data = {
         "message_id": message_id,


### PR DESCRIPTION
## Summary

Stores the full warning text (raw_text) in posted_warnings for future severity re-parsing, and backfills existing warnings from the NWS API expired alerts feed.

## Forward Path (5 files)
- **Migration**: Adds `raw_text` column to `posted_warnings` (safe ALTER TABLE)
- **Write chain**: `raw_text` threaded through `state.py` → `state_store.py` → `db.py`
- **Call sites**: All three post paths (iembot, NWS initial, NWS update) now store description/raw_text

## Backfill (`backfill_warning_severity`)
- Queries NWS API expired alerts cursor for last 7 days
- Matches by VTEC ID to existing `posted_warnings` rows where `raw_text IS NULL`
- Re-parses severity from full warning text using `get_warning_severity()`
- Updates `severity` and `raw_text` columns
- Runs once on primary startup (fire-and-forget async task)
- Handles pagination for large response sets

## Why existing data was broken
The `get_tornado_attributes` / `get_warning_severity` functions check `event == "Tornado Warning"` to detect PDS/emergency, but NWS API labels CON/UPG actions as `"Severe Weather Statement"` — the event correction requires VTEC. The backfill fetches each warning's text fresh and re-parses with the corrected event name.