### PR TITLE
fix: SVR/FFW severity labels always None, tick crashes on phenom KeyError

### DIFF
--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -306,9 +306,17 @@ def get_warning_severity(event: str, text: str, params: dict = None) -> Optional
     # Strip display suffixes like "(PDS)", "(Emergency)" so base name matches
     base_event = event.split(" (")[0].split(" — ")[0].split(" – ")[0]
 
-    # Map display variants to base event names
+    # Map display variants to base event names.
+    # Styled SVR/FFW names already encode the severity, so fast-path return them.
+    # TOR stays as a normalization (text check below handles emergency/pds/standard).
     if base_event in ("Tornado Warning", "Tornado Emergency"):
         base_event = "Tornado Warning"
+    elif base_event == "CONSIDERABLE Severe Tstorm Warning":
+        return "considerable"
+    elif base_event == "DESTRUCTIVE Severe Tstorm Warning":
+        return "destructive"
+    elif base_event == "Flash Flood Emergency":
+        return "emergency"
 
     if base_event == "Tornado Warning":
         if "TORNADO EMERGENCY" in text_upper:

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -660,8 +660,17 @@ class WarningsCog(commands.Cog):
         action_verb = "cancels" if reason == "Cancelled" else "expires"
         area_str = f" for {area}" if area else ""
 
-        # Build a cancellation vtec dict with CAN/EXP action for the URL
+        # Build a cancellation vtec dict with CAN/EXP action for the URL.
+        # Reconstruct from vtec_id if vtec is None — this happens when the NWWS
+        # handler pops the warning from active_warnings between when the tick
+        # snapshots the disappeared set and when we get here.
         cancel_vtec = dict(vtec or {})
+        if not cancel_vtec.get("phenom") and vtec_id.count(".") == 3:
+            office_, phenom_, sig_, etn_ = vtec_id.split(".")
+            cancel_vtec.setdefault("office", office_)
+            cancel_vtec.setdefault("phenom", phenom_)
+            cancel_vtec.setdefault("sig", sig_)
+            cancel_vtec.setdefault("etn", etn_)
         cancel_vtec["action"] = "CAN" if reason == "Cancelled" else "EXP"
         if not cancel_vtec.get("start"):
             now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary

- **Bug 1 (SVR/FFW severity):** `get_warning_severity()` received styled display names from `get_warning_style()` (e.g. `"CONSIDERABLE Severe Tstorm Warning"`, `"Flash Flood Emergency"`) but only normalized TOR variants. SVR and FFW styled names fell through to `return None`, so `severity` was never written to the DB and `/status` always showed `0 SVRC / 0 SVRD / 0 FFE` regardless of what was issued.
- **Bug 2 (tick KeyError):** `_handle_cancellation()` crashed with `KeyError: 'phenom'` when the NWWS handler popped a warning from `active_warnings` between the tick snapshotting the `disappeared` set and iterating it (TOCTOU race at top-of-hour mass expiry). The entire tick loop aborted mid-batch, dropping expiration notices for remaining warnings that cycle.

## Changes

**`cogs/warning_format.py` — `get_warning_severity()`:** Add fast-path returns for `"CONSIDERABLE Severe Tstorm Warning"`, `"DESTRUCTIVE Severe Tstorm Warning"`, and `"Flash Flood Emergency"`. These display names already encode the severity tier, so there's no need to re-derive from text/params.

**`cogs/warnings.py` — `_handle_cancellation()`:** When `vtec_context` is `None` (race condition), reconstruct the missing VTEC fields (`office`, `phenom`, `sig`, `etn`) from the `vtec_id` string (always `"OFFICE.PHENOM.SIG.ETN"` format). This lets the cancellation notice still post with a correct URL instead of crashing.

## Test plan

- [ ] Confirm `/status` shows non-zero SVRC/SVRD/FFE counts during active considerable/destructive SVR or flash flood emergency events
- [ ] Monitor logs over a top-of-hour expiry window — `Tick failed: 'phenom'` should no longer appear
- [ ] 539 existing tests pass (no regressions)