### PR TITLE
chore: track pre-push hook in .githooks, fix dev setup

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,108 @@
+#!/bin/bash
+while read local_ref local_sha remote_ref remote_sha; do
+    if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        exit 0
+    fi
+    if echo "$remote_ref" | grep -q "^refs/tags/"; then
+        exit 0
+    fi
+done
+
+echo "Running pre-push checks..."
+cd "$(git rev-parse --show-toplevel)"
+source venv/bin/activate 2>/dev/null || true
+
+# Ensure dev dependencies are present (safe after a venv rebuild that only ran requirements.txt)
+python3 -c "import pytest_asyncio" 2>/dev/null || {
+    echo "Dev dependencies missing — installing requirements-dev.txt..."
+    pip install -r requirements-dev.txt -q
+}
+
+# 0. AI ATTRIBUTION CHECK (CRITICAL)
+echo "Scanning for AI attribution (ZERO TOLERANCE)..."
+ai_patterns=("@Claude" "@Sonnet" "Claude Code" "Generated with Claude" "Co-Authored-By: Claude" "AI-generated" "claude-code" "anthropic.com")
+violation_found=0
+
+for commit in $(git rev-list HEAD @{upstream}..HEAD 2>/dev/null); do
+  msg=$(git log -1 --format=%B "$commit")
+  for pattern in "${ai_patterns[@]}"; do
+    if echo "$msg" | grep -qi "$pattern"; then
+      echo "❌ VIOLATION in commit $(git rev-parse --short $commit): Found '$pattern' in commit message"
+      echo "   Message: $(echo "$msg" | head -1)"
+      echo "   PUSH ABORTED — Remove all AI attribution and try again"
+      violation_found=1
+    fi
+  done
+done
+
+if [ $violation_found -eq 1 ]; then
+  exit 1
+fi
+
+# 1. Formatting check (Python)
+echo "Checking Python formatting (Ruff)..."
+ruff format --check .
+if [ $? -ne 0 ]; then
+    echo "PYTHON FORMATTING ERRORS FOUND — push aborted. Run 'ruff format .' to fix."
+    exit 1
+fi
+
+# 2. Lint check (Python)
+echo "Linting Python (Ruff)..."
+ruff check .
+if [ $? -ne 0 ]; then
+    echo "PYTHON LINT ERRORS FOUND — push aborted."
+    exit 1
+fi
+
+# 3. Formatting check (Rust)
+echo "Checking Rust formatting (cargo fmt)..."
+cargo fmt --check
+if [ $? -ne 0 ]; then
+    echo "RUST FORMATTING ERRORS FOUND — push aborted. Run 'cargo fmt' to fix."
+    exit 1
+fi
+
+# 4. Lint check (Rust)
+echo "Checking Rust linting (Clippy)..."
+cargo clippy -- -D warnings
+if [ $? -ne 0 ]; then
+    echo "RUST LINT ERRORS FOUND — push aborted."
+    exit 1
+fi
+
+# 5. Type checking (mypy)
+echo "Type checking (mypy)..."
+MYPY_BIN=$(command -v mypy || echo "$HOME/.local/bin/mypy")
+if [ ! -x "$MYPY_BIN" ]; then
+    echo "mypy not found — skipping type check"
+else
+    "$MYPY_BIN" --ignore-missing-imports --follow-imports=silent utils/ lib/vtec_parser.py
+    if [ $? -ne 0 ]; then
+        echo "MYPY TYPE ERRORS FOUND — push aborted."
+        exit 1
+    fi
+fi
+
+# 6. Syntax check
+failed=0
+for f in $(git diff --name-only HEAD @{upstream} 2>/dev/null | grep '\.py$'); do
+    if [ -f "$f" ]; then
+        python3 -m py_compile "$f" 2>&1
+        if [ $? -ne 0 ]; then
+            echo "SYNTAX ERROR in $f — push aborted"
+            failed=1
+        fi
+    fi
+done
+[ $failed -ne 0 ] && exit 1
+
+# 7. Tests
+echo "Testing..."
+python -m pytest tests/ -q 2>&1 | tail -3
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo "TESTS FAILED — push aborted"
+    exit 1
+fi
+
+echo "All checks passed."

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -1,54 +1,19 @@
 #!/bin/bash
+# Sets up the git hooks and dev dependencies for this repo.
+# Run once after cloning, and again after a venv rebuild.
+set -e
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HOOKS_DIR="$REPO_ROOT/.git/hooks"
+cd "$REPO_ROOT"
 
-cat > "$HOOKS_DIR/pre-push" << 'HOOK'
-#!/bin/bash
-while read local_ref local_sha remote_ref remote_sha; do
-    if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
-        exit 0
-    fi
-    if echo "$remote_ref" | grep -q "^refs/tags/"; then
-        exit 0
-    fi
-done
+echo "Configuring git hooks..."
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push
 
-echo "Running pre-push checks..."
-cd "$(git rev-parse --show-toplevel)"
-source venv/bin/activate 2>/dev/null || true
-
-# 1. Lint check (Ruff)
-# This catches unused imports, which have caused multiple CI failures recently.
-echo "Linting..."
-ruff check --select=E9,F63,F7,F82,F401 --exclude=venv,lib,cache .
-if [ $? -ne 0 ]; then
-    echo "LINT ERRORS FOUND — push aborted"
-    exit 1
+echo "Installing dev dependencies..."
+if [ -f venv/bin/activate ]; then
+    source venv/bin/activate
 fi
+pip install -r requirements-dev.txt -q
 
-# 2. Syntax check
-failed=0
-for f in $(git diff --name-only HEAD @{upstream} 2>/dev/null | grep '\.py$'); do
-    if [ -f "$f" ]; then
-        python3 -m py_compile "$f" 2>&1
-        if [ $? -ne 0 ]; then
-            echo "SYNTAX ERROR in $f — push aborted"
-            failed=1
-        fi
-    fi
-done
-[ $failed -ne 0 ] && exit 1
-
-# 3. Tests
-echo "Testing..."
-python -m pytest tests/ -q 2>&1 | tail -3
-if [ ${PIPESTATUS[0]} -ne 0 ]; then
-    echo "TESTS FAILED — push aborted"
-    exit 1
-fi
-
-echo "All checks passed."
-HOOK
-
-chmod +x "$HOOKS_DIR/pre-push"
-echo "Hooks installed."
+echo "Done. Hook: .githooks/pre-push | Dev deps: requirements-dev.txt"


### PR DESCRIPTION
## Summary

- The pre-push hook lived only in `.git/hooks/` (untracked) and had silently drifted from `install-hooks.sh`'s inline copy — a venv rebuild or fresh clone would install the old, incomplete hook.
- `install-hooks.sh` didn't install `requirements-dev.txt`, so a venv rebuild that only ran `requirements.txt` caused `pytest-asyncio` to go missing and the test step to fail with 539 errors on next push.

## Changes

**`.githooks/pre-push`** — New tracked file containing the authoritative hook (current content from `.git/hooks/pre-push`, plus a self-heal step that installs `requirements-dev.txt` if `pytest-asyncio` is missing).

**`install-hooks.sh`** — Simplified to two actions: `git config core.hooksPath .githooks` and `pip install -r requirements-dev.txt -q`. No more inline hook that can drift.

## After merging

Anyone who rebuilds their venv only needs to run `./install-hooks.sh` to be fully set up. And if they forget, the hook auto-heals on the next `git push`.

## Test plan

- [ ] Fresh clone: `./install-hooks.sh` → `git push` works with no missing-dep errors
- [ ] Venv rebuild without running install-hooks: `git push` auto-installs dev deps and passes