### PR TITLE
fix: safe VTEC dict access in iem_autoplot_url, _vtec_url, and build_concise_warning_text

### DIFF
--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -360,10 +360,10 @@ def get_warning_severity(event: str, text: str, params: dict = None) -> Optional
 
 def iem_autoplot_url(vtec: dict, valid_time: Optional[str] = None) -> str:
     """Return the IEM Autoplot URL (#208 for VTEC, #217 for SPS)."""
-    office = vtec["office"]
-    phenom = vtec["phenom"]
-    sig = vtec["sig"]
-    etn = vtec["etn"]
+    office = vtec.get("office", "")
+    phenom = vtec.get("phenom", "")
+    sig = vtec.get("sig", "")
+    etn = vtec.get("etn", "")
 
     year = datetime.now(timezone.utc).year
     start = vtec.get("start") or ""
@@ -416,10 +416,10 @@ def iem_autoplot_url(vtec: dict, valid_time: Optional[str] = None) -> str:
         office = office[1:]
 
     # SPS (Special Weather Statements) use Autoplot 217 which requires the PID
-    if phenom == "SPS" and "-" in vtec["vtec_id"]:
+    if phenom == "SPS" and "-" in vtec.get("vtec_id", ""):
         return (
             f"https://mesonet.agron.iastate.edu/plotting/auto/plot/217/"
-            f"pid:{vtec['vtec_id']}::segnum:0.png"
+            f"pid:{vtec.get('vtec_id', '')}::segnum:0.png"
         )
 
     etn_padded = etn.zfill(4)  # Zero-pad to 4 digits
@@ -458,8 +458,8 @@ def _vtec_url(vtec: dict) -> str:
 
     action = vtec.get("action", "NEW")
     office = vtec.get("office", "")
-    phenom = vtec["phenom"]
-    sig = vtec["sig"]
+    phenom = vtec.get("phenom", "")
+    sig = vtec.get("sig", "")
     etn = int(vtec.get("etn", "0") or "0")
     return (
         f"https://mesonet.agron.iastate.edu/vtec/f/"
@@ -592,7 +592,7 @@ def build_concise_warning_text(
             {narrative}
             [<t:unix_ts:R>]
     """
-    office = vtec["office"]
+    office = vtec.get("office", "")
     if office.startswith("K") and len(office) == 4:
         office = office[1:]
 
@@ -605,7 +605,7 @@ def build_concise_warning_text(
         "EXT": "extends time of",
         "UPG": "upgrades",
     }
-    action_verb = action_map.get(vtec["action"], "updates")
+    action_verb = action_map.get(vtec.get("action", "NEW"), "updates")
     if is_update:
         action_verb = "updates"
 


### PR DESCRIPTION
## Summary

Replace bare `vtec['key']` with `vtec.get('key', default)` in three functions in `cogs/warning_format.py` to prevent `KeyError` crashes on malformed/partial VTEC dicts — same class of bug as the `_vtec_url` phenom bug fixed in `c764b22`.

## Functions fixed

- **`iem_autoplot_url()`**: `office`, `phenom`, `sig`, `etn`, `vtec_id`
- **`_vtec_url()`**: `phenom`, `sig` (action, office, etn already safe)
- **`build_concise_warning_text()`**: `office`, `action`

## Motivation

These functions are called from `post_warning_now()`, `_tick()`, `_discover_and_post_warning()`, and `_handle_cancellation()` — all paths where `vtec` dicts can arrive with missing fields (e.g., when reconstructed from `vtec_id` strings or during races between the NWWS handler and NWS API poll). A crash in any of these silently loses the entire warning via broad `except` blocks upstream.

## Verification

- ✅ Ruff lint passes
- ✅ mypy type check passes
- ✅ Rust clippy passes
- ✅ All 539 tests pass