### PR TITLE
fix: surface DB write failures for warning severity/confidence data

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -814,6 +814,19 @@ async def add_posted_warning(
 ) -> bool:
     """Mark a warning as posted. Uses a checked write to surface failures to callers.
 
+    ``vtec_id`` is the VTEC event identity (office.phenom.sig.etn),
+    which stays stable across the warning's lifecycle so it doubles as
+    our dedup key.
+
+    For tornado warnings, ``tornado_confidence`` is 'observed' or
+    'radar_indicated', and ``tornado_severity`` is 'standard', 'pds',
+    or 'emergency'.
+
+    ``severity`` stores the generic severity for any warning type:
+    tornado → 'standard'|'pds'|'emergency'
+    severe  → 'standard'|'considerable'|'destructive'
+    flash flood → 'standard'|'emergency'
+
     Returns True if the DB write succeeded, False if it was silently dropped.
     """
     return await _write_checked(

--- a/utils/db.py
+++ b/utils/db.py
@@ -72,6 +72,33 @@ async def _write(sql: str, params: tuple, op: str) -> None:
         level(f"{op} failed ({_write_failure_count} consecutive): {e}")
 
 
+async def _write_checked(sql: str, params: tuple, op: str) -> bool:
+    """Serialized write that returns ``True`` on success.
+
+    Unlike ``_write``, this does NOT swallow exceptions — callers that
+    need to know about write failures (e.g., severity/confidence tracking)
+    can branch on the return value.
+    """
+    global _write_failure_count
+    try:
+        db = await get_db()
+        async with _LOCK:
+            await db.execute(sql, params)
+            await db.commit()
+        if _write_failure_count:
+            _write_failure_count = 0
+        return True
+    except Exception as e:
+        _write_failure_count += 1
+        level = (
+            logger.error
+            if _write_failure_count >= _WRITE_FAILURE_ALERT_THRESHOLD
+            else logger.warning
+        )
+        level(f"{op} failed ({_write_failure_count} consecutive): {e}")
+        return False
+
+
 async def _write_many(sql: str, rows: Iterable[tuple], op: str) -> None:
     """Serialized batch-write helper."""
     global _write_failure_count
@@ -784,20 +811,12 @@ async def add_posted_warning(
     tornado_severity: Optional[str] = None,
     severity: Optional[str] = None,
     raw_text: Optional[str] = None,
-):
-    """Mark a warning as posted. ``vtec_id`` is the VTEC event identity
-    (office.phenom.sig.etn), which stays stable across the warning's
-    lifecycle so it doubles as our dedup key.
+) -> bool:
+    """Mark a warning as posted. Uses a checked write to surface failures to callers.
 
-    For tornado warnings, ``tornado_confidence`` is 'observed' or 'radar_indicated',
-    and ``tornado_severity`` is 'standard', 'pds', or 'emergency'.
-
-    ``severity`` stores the generic severity for any warning type:
-    tornado → 'standard'|'pds'|'emergency'
-    severe  → 'standard'|'considerable'|'destructive'
-    flash flood → 'standard'|'emergency'
+    Returns True if the DB write succeeded, False if it was silently dropped.
     """
-    await _write(
+    return await _write_checked(
         """INSERT INTO posted_warnings (vtec_id, message_id, channel_id, posted_at, area, tornado_confidence, tornado_severity, severity, raw_text)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(vtec_id) DO UPDATE SET

--- a/utils/state.py
+++ b/utils/state.py
@@ -28,6 +28,8 @@ from collections import deque
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set
 
+logger = logging.getLogger("spc_bot")
+
 
 class RecentLogHandler(logging.Handler):
     """Logging handler that keeps the last N lines in memory."""
@@ -339,7 +341,7 @@ class BotState:
             "channel_id": channel_id,
             "area": area,
         }
-        await state_store.add_posted_warning(
+        ok = await state_store.add_posted_warning(
             vtec_id,
             message_id,
             channel_id,
@@ -350,6 +352,11 @@ class BotState:
             severity,
             raw_text,
         )
+        if not ok and severity:
+            logger.warning(
+                f"DB write failed for {vtec_id}: severity '{severity}' not persisted — "
+                "warning labels on /status may be inaccurate"
+            )
 
     async def add_posted_sounding(self, pkey: str) -> None:
         from utils import state_store

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -784,9 +784,9 @@ async def add_posted_warning(
     tornado_severity: Optional[str] = None,
     severity: Optional[str] = None,
     raw_text: Optional[str] = None,
-) -> None:
+) -> bool:
     _cache_invalidate("posted_warnings")
-    await sqlite_backend.add_posted_warning(
+    ok = await sqlite_backend.add_posted_warning(
         vtec_id,
         message_id,
         channel_id,
@@ -821,6 +821,8 @@ async def add_posted_warning(
                 tornado_severity,
             ),
         )
+
+    return ok
 
 
 async def remove_posted_warning(vtec_id: str) -> None:


### PR DESCRIPTION
## Summary

The `_write` helper in `utils/db.py` swallows all exceptions to allow graceful degradation, but this silently drops severity/confidence data for warnings. This causes the `/status` warning labels (SVRD/SVRC/TORE/etc.) to be inaccurate when DB writes fail.

## Changes

- Add `_write_checked()` helper in `utils/db.py` that returns `True` on success, `False` on failure
- Use it in `add_posted_warning()` instead of `_write()`
- Propagate the bool through `state_store.add_posted_warning()` → `BotState.add_posted_warning()`
- Log a specific warning when severity data write fails, alerting operators

## Why this matters

When the DB can't accept writes (disk full, lock contention, schema drift), the bot continues operating but loses the severity tagging. The `/status` command then shows misleading counts (e.g., 0 SVRD for the day even if Destructive warnings were issued). The warning log helps operators identify this divergence vs. a true NWS data failure.

## Verification

- ✅ All 539 tests pass
- ✅ No mypy errors on typed code paths