### PR TITLE
fix: close race window in post_warning_now dedup

### DIFF
--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -344,17 +344,22 @@ class WarningsCog(commands.Cog):
         if vtec_id in self._in_flight_vtecs:
             return
 
+        self._in_flight_vtecs.add(vtec_id)
+
         # Check product_id again after potential await context switches
         if product_id in self.bot.state.posted_product_ids:
+            self._in_flight_vtecs.discard(vtec_id)
             return
-
-        self._in_flight_vtecs.add(vtec_id)
 
         # Claim dedup keys BEFORE any awaits so concurrent tasks hitting
         # the same path see the state immediately. For updates the
         # posted_warnings entry already exists, so the claim no-ops on
         # enter/exit — but claim.confirm() still updates persistence.
-        await self.bot.state.add_posted_product_id(product_id)
+        try:
+            await self.bot.state.add_posted_product_id(product_id)
+        except Exception:
+            self._in_flight_vtecs.discard(vtec_id)
+            raise
 
         try:
             async with self.bot.state.claim_posted_warning(vtec_id) as claim:


### PR DESCRIPTION
## Summary

Move `_in_flight_vtecs.add()` before the first `await` so a concurrent task sees the reservation immediately. The gap between checking and adding was protected by the GIL, but any `await` between them would allow a second task to slip through.

## Before

    check in_flight_vtecs → check product_id → add in_flight_vtecs → await

## After

    check in_flight_vtecs → add in_flight_vtecs → check product_id → await

Also adds cleanup of `_in_flight_vtecs` on the dead-end product-id early return and on exceptions from `add_posted_product_id`.