### PR TITLE
fix: cleanup batch — module-level import, cancelled set cap, migration safety, dead return

### DIFF
--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -33,6 +33,7 @@ from cogs.warning_format import (
     _download_warning_image,
     _vtec_unix_ts,
     _vtec_url,
+    _WARNING_STYLE,
     build_concise_warning_text,
     get_tornado_attributes,
     get_warning_severity,
@@ -772,6 +773,9 @@ class WarningsCog(commands.Cog):
                 logger.info(
                     f"Pruned {removed} posted_warnings entries (cap={self.POSTED_WARNINGS_MAX})"
                 )
+            if len(self._cancelled_warnings) > 10000:
+                self._cancelled_warnings.clear()
+                logger.debug("Cleared _cancelled_warnings set (size > 10000)")
         except Exception as e:
             logger.exception(f"prune_posted_warnings_loop failed: {e}")
 
@@ -876,7 +880,6 @@ class WarningsCog(commands.Cog):
 
         current_vtec_data = {}
         current_vtec_ids = set()
-        from cogs.warning_format import _WARNING_STYLE
 
         for feature in alert_response.features:
             props = feature.properties

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -130,7 +130,10 @@ async def _create_tables(db: aiosqlite.Connection) -> None:
         ("gif_path", "TEXT"),
         ("srh_0_1", "REAL"),
     ]:
-        existing = {row["name"] for row in await db.execute_fetchall("PRAGMA table_info(significant_events)")}
+        existing = {
+            row["name"]
+            for row in await db.execute_fetchall("PRAGMA table_info(significant_events)")
+        }
         if col not in existing:
             await db.execute(f"ALTER TABLE significant_events ADD COLUMN {col} {ctype}")
 

--- a/utils/events_db.py
+++ b/utils/events_db.py
@@ -130,10 +130,9 @@ async def _create_tables(db: aiosqlite.Connection) -> None:
         ("gif_path", "TEXT"),
         ("srh_0_1", "REAL"),
     ]:
-        try:
+        existing = {row["name"] for row in await db.execute_fetchall("PRAGMA table_info(significant_events)")}
+        if col not in existing:
             await db.execute(f"ALTER TABLE significant_events ADD COLUMN {col} {ctype}")
-        except Exception:
-            pass
 
 
 # ── Writes ───────────────────────────────────────────────────────────────────

--- a/utils/state_store.py
+++ b/utils/state_store.py
@@ -823,8 +823,6 @@ async def add_posted_warning(
         )
     return ok
 
-    return ok
-
 
 async def remove_posted_warning(vtec_id: str) -> None:
     """Roll back an `add_posted_warning` write across SQLite + Redis."""


### PR DESCRIPTION
## Summary

Four small cleanups from the codebase audit:

1. **`_WARNING_STYLE` hoisted to module level** — was re-imported inside `_tick()` every 30 seconds
2. **`_cancelled_warnings` capped at 10k** — pruned in the existing hourly maintenance loop
3. **Migration handler uses PRAGMA table_info** — replaces bare `except Exception: pass` in events_db migrations
4. **Duplicate `return ok` removed** — dead code in `state_store.add_posted_warning()` left over from the DB write surfacing PR (#542)