### PR TITLE
fix: retry Discord file sends on Linux ECONNRESET (errno 104)

### DIFF
--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -132,22 +132,35 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
         cache_key = f"hodo_{site}_{now_str}"
         view = HodographPlotView(cache_key)
 
-    try:
-        if view:
-            await interaction.followup.send(
-                content=f"**{site}** VWP Hodograph", file=discord.File(output_path), view=view
-            )
-        else:
-            await interaction.followup.send(
-                content=f"**{site}** VWP Hodograph",
-                file=discord.File(output_path),
-            )
+    sent = False
+    for attempt in range(2):
+        try:
+            if view:
+                await interaction.followup.send(
+                    content=f"**{site}** VWP Hodograph",
+                    file=discord.File(output_path),
+                    view=view,
+                )
+            else:
+                await interaction.followup.send(
+                    content=f"**{site}** VWP Hodograph",
+                    file=discord.File(output_path),
+                )
+            sent = True
+            break
+        except discord.NotFound:
+            logger.warning(f"[HODO] Failed to send final hodograph for {site}: Interaction expired")
+            break
+        except OSError as conn_err:
+            if attempt == 0:
+                logger.warning(f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}")
+                await asyncio.sleep(1)
+            else:
+                logger.error(f"[HODO] Retry also failed for {site}: {conn_err}")
 
-        # Fire-and-forget: cache raw_text + prefetch AI summary
-        if params and cache_key:
-            asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
-    except discord.NotFound:
-        logger.warning(f"[HODO] Failed to send final hodograph for {site}: Interaction expired")
+    # Fire-and-forget: cache raw_text + prefetch AI summary
+    if sent and params and cache_key:
+        asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
 
 
 class RadarSuggestionView(discord.ui.View):

--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -153,7 +153,9 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
             break
         except OSError as conn_err:
             if attempt == 0:
-                logger.warning(f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}")
+                logger.warning(
+                    f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}"
+                )
                 await asyncio.sleep(1)
             else:
                 logger.error(f"[HODO] Retry also failed for {site}: {conn_err}")

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -307,7 +307,20 @@ async def send_sounding_embed(
                             )
                         )
 
-        sounding_msg = await target.send(caption, files=[discord.File(png_path)], view=view)
+        for _attempt in range(2):
+            try:
+                sounding_msg = await target.send(
+                    caption, files=[discord.File(png_path)], view=view
+                )
+                break
+            except OSError as _e:
+                if _attempt == 0:
+                    logger.warning(
+                        f"[SOUNDING] Connection error sending {station_id}, retrying: {_e}"
+                    )
+                    await asyncio.sleep(1)
+                else:
+                    raise
         logger.info(f"[SOUNDING] Posted {station_id} {time_label}")
 
         # Autopost AI summary if enabled and cache_key was available

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -309,9 +309,7 @@ async def send_sounding_embed(
 
         for _attempt in range(2):
             try:
-                sounding_msg = await target.send(
-                    caption, files=[discord.File(png_path)], view=view
-                )
+                sounding_msg = await target.send(caption, files=[discord.File(png_path)], view=view)
                 break
             except OSError as _e:
                 if _attempt == 0:

--- a/deploy.sh
+++ b/deploy.sh
@@ -338,6 +338,7 @@ WorkingDirectory=${INSTALL_DIR}
 ExecStart=${VENV_DIR}/bin/python main.py
 Restart=on-failure
 RestartSec=10
+TimeoutStopSec=15
 StandardOutput=journal
 StandardError=journal
 EnvironmentFile=${ENV_FILE}


### PR DESCRIPTION
## Summary

- discord.py's OSError retry only covers errno 54 (macOS) and 10054 (Windows) — Linux ECONNRESET is errno 104 and was unhandled, causing hodograph and sounding file uploads to crash instead of retry when Discord drops an idle keep-alive connection
- Added a one-retry loop with 1s backoff in `hodograph.py` and `sounding_views.py` as defense-in-depth (the real fix requires patching the venv — see note below)
- Added `TimeoutStopSec=15` to `deploy.sh` service template so systemd doesn't wait the 90s default before SIGKILL when `bot.close()` hangs on the Discord WebSocket close handshake

## Root cause

`discord/http.py:783` and `discord/webhook/async_.py:229` both have:
```python
if tries < 4 and e.errno in (54, 10054):
```
Linux errno 104 (`ECONNRESET`) is missing. Patched in the venv:
```
(54, 10054) → (54, 104, 10054)
```
in both files. **This patch will be lost on `pip install --upgrade discord.py`** — needs re-applying after upgrades until we file upstream.

## Test plan

- [ ] Run `/hodograph KMVX` — should deliver image on first or second attempt without unhandled error
- [ ] Trigger an auto-sounding post — should deliver image without `[Errno 104]` crash
- [ ] `sudo systemctl restart spcbot` — should complete in <15s instead of ~90s