### PR TITLE
fix: /sounding stalls on availability check when IEM has no data

### DIFF
--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -132,22 +132,35 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
         cache_key = f"hodo_{site}_{now_str}"
         view = HodographPlotView(cache_key)
 
-    try:
-        if view:
-            await interaction.followup.send(
-                content=f"**{site}** VWP Hodograph", file=discord.File(output_path), view=view
-            )
-        else:
-            await interaction.followup.send(
-                content=f"**{site}** VWP Hodograph",
-                file=discord.File(output_path),
-            )
+    sent = False
+    for attempt in range(2):
+        try:
+            if view:
+                await interaction.followup.send(
+                    content=f"**{site}** VWP Hodograph",
+                    file=discord.File(output_path),
+                    view=view,
+                )
+            else:
+                await interaction.followup.send(
+                    content=f"**{site}** VWP Hodograph",
+                    file=discord.File(output_path),
+                )
+            sent = True
+            break
+        except discord.NotFound:
+            logger.warning(f"[HODO] Failed to send final hodograph for {site}: Interaction expired")
+            break
+        except OSError as conn_err:
+            if attempt == 0:
+                logger.warning(f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}")
+                await asyncio.sleep(1)
+            else:
+                logger.error(f"[HODO] Retry also failed for {site}: {conn_err}")
 
-        # Fire-and-forget: cache raw_text + prefetch AI summary
-        if params and cache_key:
-            asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
-    except discord.NotFound:
-        logger.warning(f"[HODO] Failed to send final hodograph for {site}: Interaction expired")
+    # Fire-and-forget: cache raw_text + prefetch AI summary
+    if sent and params and cache_key:
+        asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
 
 
 class RadarSuggestionView(discord.ui.View):

--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -153,7 +153,9 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
             break
         except OSError as conn_err:
             if attempt == 0:
-                logger.warning(f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}")
+                logger.warning(
+                    f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}"
+                )
                 await asyncio.sleep(1)
             else:
                 logger.error(f"[HODO] Retry also failed for {site}: {conn_err}")

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -1057,7 +1057,10 @@ class SoundingCog(commands.Cog):
         acars_task = asyncio.create_task(get_acars_profiles_near(lat, lon, max_dist_km=400))
         verified = await filter_stations_with_data(candidates)
         acars_profiles = await acars_task
-        nearest = verified[:3]
+        # Fall back to unverified nearest stations if availability check found nothing.
+        # Sources may be temporarily unavailable — still offer the picker so the
+        # user can attempt a fetch (post_sounding handles the "no data" case).
+        nearest = (verified or candidates)[:3]
 
         if not nearest and not acars_profiles:
             error_embed = discord.Embed(

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -1067,7 +1067,11 @@ async def get_available_sounding_times(
 
     # 2. Try Wyoming Probe for standard hours (00z/12z)
     # This is needed for international stations like SBSM that aren't in IEM.
-    # We check standard hours in the requested window.
+    # US/Canada domestic stations (K/P/C prefix) are fully covered by IEM — skip
+    # the probe for them to avoid slow full-chain fetches when IEM has no data.
+    if station_id and (station_id[0].upper() in ("K", "P", "C") or station_id.isdigit()):
+        return []
+
     probe_times = get_recent_sounding_times(n=max(2, (hours_back // 12) + 1))
 
     # Filter probe times to only those within hours_back

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -1203,12 +1203,21 @@ async def fetch_sounding(
     if hour in ("00", "12"):
         logger.debug(f"[SOUNDING] Fetching Wyoming for {station_id} {hour}z")
         try:
-            wyo_data = await loop.run_in_executor(
-                None, lambda: spy.get_obs_data(station_id, year, month, day, hour)
+            # SounderPy retries Wyoming up to 10 times internally — cap it so
+            # we can fall through to IEM when Wyoming is unreachable.
+            wyo_data = await asyncio.wait_for(
+                loop.run_in_executor(
+                    None, lambda: spy.get_obs_data(station_id, year, month, day, hour)
+                ),
+                timeout=20.0,
             )
             if validate_sounding_data(wyo_data):
                 logger.debug(f"[SOUNDING] Wyoming success for {station_id} {hour}z")
                 return wyo_data
+        except asyncio.TimeoutError:
+            logger.debug(
+                f"[SOUNDING] Wyoming timed out for {station_id} {hour}z, falling through to IEM"
+            )
         except Exception as e:
             logger.debug(f"[SOUNDING] Wyoming failed for {station_id} {hour}z: {e}")
 

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -307,7 +307,20 @@ async def send_sounding_embed(
                             )
                         )
 
-        sounding_msg = await target.send(caption, files=[discord.File(png_path)], view=view)
+        for _attempt in range(2):
+            try:
+                sounding_msg = await target.send(
+                    caption, files=[discord.File(png_path)], view=view
+                )
+                break
+            except OSError as _e:
+                if _attempt == 0:
+                    logger.warning(
+                        f"[SOUNDING] Connection error sending {station_id}, retrying: {_e}"
+                    )
+                    await asyncio.sleep(1)
+                else:
+                    raise
         logger.info(f"[SOUNDING] Posted {station_id} {time_label}")
 
         # Autopost AI summary if enabled and cache_key was available

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -309,9 +309,7 @@ async def send_sounding_embed(
 
         for _attempt in range(2):
             try:
-                sounding_msg = await target.send(
-                    caption, files=[discord.File(png_path)], view=view
-                )
+                sounding_msg = await target.send(caption, files=[discord.File(png_path)], view=view)
                 break
             except OSError as _e:
                 if _attempt == 0:

--- a/deploy.sh
+++ b/deploy.sh
@@ -338,6 +338,7 @@ WorkingDirectory=${INSTALL_DIR}
 ExecStart=${VENV_DIR}/bin/python main.py
 Restart=on-failure
 RestartSec=10
+TimeoutStopSec=15
 StandardOutput=journal
 StandardError=journal
 EnvironmentFile=${ENV_FILE}


### PR DESCRIPTION
## Summary

- `/sounding` would hang indefinitely on "⏳ Checking Station Availability..." when IEM had no RAOB data for nearby stations
- When `filter_stations_with_data()` returned empty, the command errored with "No Sounding Data Available" instead of offering the nearest stations anyway

## Root cause

`get_available_sounding_times()` falls through to a Wyoming probe when IEM returns nothing. That probe calls the full `fetch_sounding()` chain (Wyoming → IEM → GSL). With GSL (`rucsoundings.noaa.gov`) down, each probe call hangs waiting for the connection timeout — multiplied across 6 candidate stations running in parallel.

The Wyoming probe comment explicitly says it exists only for international stations not in IEM (e.g. `SBSM`). US/Canada domestic stations (`K`/`P`/`C` prefix ICAO, numeric WMO) are fully covered by IEM; if IEM has no data, the probe just burns time hitting down sources.

## Changes

**`cogs/sounding_utils.py`** — skip Wyoming probe for domestic stations:
```python
if station_id and (station_id[0].upper() in ("K", "P", "C") or station_id.isdigit()):
    return []
```

**`cogs/sounding.py`** — fall back to unverified candidates instead of erroring:
```python
nearest = (verified or candidates)[:3]
```
When availability can't be confirmed, the station picker still appears. The "no recent data" label shows next to each station (from the cached empty IEM result). `post_sounding()` handles the actual fetch failure gracefully if the user picks one.

## Test plan

- [ ] `/sounding Fargo` with GSL down — should respond quickly with station picker showing nearby stations, not hang
- [ ] `/sounding` for international station (e.g. SBSM) — Wyoming probe should still fire (non-K prefix)
- [ ] `/sounding` for location with good IEM data — fast path unchanged