### PR TITLE
fix: failover deadlock when primary restarts with a new process uuid

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -353,6 +353,9 @@ class FailoverCog(commands.Cog):
                         # is bypassed — an operator's explicit override must
                         # be able to take the lease from a currently-held node.
                         await self._promote(force=True)
+                    # Always return after handling our own manual override so the
+                    # primary/standby cycle doesn't also fire in the same tick.
+                    return
                 else:
                     if self.bot.state.is_primary:
                         logger.warning(

--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -194,7 +194,15 @@ class FailoverCog(commands.Cog):
             self._redis = None
 
     def _is_our_node(self, target: str) -> bool:
-        return target == self._identity or target == socket.gethostname()
+        # Match exact identity, bare hostname (from manual_primary key), or the
+        # hostname embedded in a role:hostname:uuid lease value. The hostname
+        # check covers the case where a previous run of this node left a lease
+        # with a different uuid — a new boot should still be able to reclaim it.
+        my_hostname = socket.gethostname()
+        if target == self._identity or target == my_hostname:
+            return True
+        parts = target.split(":")
+        return len(parts) >= 2 and parts[1] == my_hostname
 
     # ── Low-level Redis helpers ───────────────────────────────────────────
 
@@ -289,7 +297,11 @@ class FailoverCog(commands.Cog):
 
         holder = await self._read_lease_holder()
         if holder and holder != self._identity:
-            if self._identity.startswith("P:") and holder.startswith("S:"):
+            if self._is_our_node(holder):
+                # Stale lease from a previous run of this node (different uuid) —
+                # we own the hostname so just overwrite it and boot as primary.
+                logger.warning(f"[FAILOVER] Startup: reclaiming stale self-lease '{holder}'")
+            elif self._identity.startswith("P:") and holder.startswith("S:"):
                 logger.warning(
                     f"[FAILOVER] Startup: lease held by Standby '{holder}' — pre-empting"
                 )
@@ -449,6 +461,12 @@ class FailoverCog(commands.Cog):
     async def _standby_cycle(self) -> None:
         holder = await self._read_lease_holder()
         if holder:
+            if self._is_our_node(holder):
+                # Stale lease from a previous run of this node is blocking
+                # promotion — reclaim it with force to bypass the NX check.
+                logger.warning(f"[FAILOVER] Reclaiming stale self-lease '{holder}' — promoting")
+                await self._promote(force=True)
+                return
             if self._identity.startswith("P:") and holder.startswith("S:"):
                 logger.warning(
                     f"[FAILOVER] Configured Primary reclaiming lease from Standby '{holder}'"

--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -132,22 +132,35 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
         cache_key = f"hodo_{site}_{now_str}"
         view = HodographPlotView(cache_key)
 
-    try:
-        if view:
-            await interaction.followup.send(
-                content=f"**{site}** VWP Hodograph", file=discord.File(output_path), view=view
-            )
-        else:
-            await interaction.followup.send(
-                content=f"**{site}** VWP Hodograph",
-                file=discord.File(output_path),
-            )
+    sent = False
+    for attempt in range(2):
+        try:
+            if view:
+                await interaction.followup.send(
+                    content=f"**{site}** VWP Hodograph",
+                    file=discord.File(output_path),
+                    view=view,
+                )
+            else:
+                await interaction.followup.send(
+                    content=f"**{site}** VWP Hodograph",
+                    file=discord.File(output_path),
+                )
+            sent = True
+            break
+        except discord.NotFound:
+            logger.warning(f"[HODO] Failed to send final hodograph for {site}: Interaction expired")
+            break
+        except OSError as conn_err:
+            if attempt == 0:
+                logger.warning(f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}")
+                await asyncio.sleep(1)
+            else:
+                logger.error(f"[HODO] Retry also failed for {site}: {conn_err}")
 
-        # Fire-and-forget: cache raw_text + prefetch AI summary
-        if params and cache_key:
-            asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
-    except discord.NotFound:
-        logger.warning(f"[HODO] Failed to send final hodograph for {site}: Interaction expired")
+    # Fire-and-forget: cache raw_text + prefetch AI summary
+    if sent and params and cache_key:
+        asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
 
 
 class RadarSuggestionView(discord.ui.View):

--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -153,7 +153,9 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
             break
         except OSError as conn_err:
             if attempt == 0:
-                logger.warning(f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}")
+                logger.warning(
+                    f"[HODO] Connection error sending hodograph for {site}, retrying: {conn_err}"
+                )
                 await asyncio.sleep(1)
             else:
                 logger.error(f"[HODO] Retry also failed for {site}: {conn_err}")

--- a/cogs/sounding.py
+++ b/cogs/sounding.py
@@ -1057,7 +1057,10 @@ class SoundingCog(commands.Cog):
         acars_task = asyncio.create_task(get_acars_profiles_near(lat, lon, max_dist_km=400))
         verified = await filter_stations_with_data(candidates)
         acars_profiles = await acars_task
-        nearest = verified[:3]
+        # Fall back to unverified nearest stations if availability check found nothing.
+        # Sources may be temporarily unavailable — still offer the picker so the
+        # user can attempt a fetch (post_sounding handles the "no data" case).
+        nearest = (verified or candidates)[:3]
 
         if not nearest and not acars_profiles:
             error_embed = discord.Embed(

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -1067,7 +1067,11 @@ async def get_available_sounding_times(
 
     # 2. Try Wyoming Probe for standard hours (00z/12z)
     # This is needed for international stations like SBSM that aren't in IEM.
-    # We check standard hours in the requested window.
+    # US/Canada domestic stations (K/P/C prefix) are fully covered by IEM — skip
+    # the probe for them to avoid slow full-chain fetches when IEM has no data.
+    if station_id and (station_id[0].upper() in ("K", "P", "C") or station_id.isdigit()):
+        return []
+
     probe_times = get_recent_sounding_times(n=max(2, (hours_back // 12) + 1))
 
     # Filter probe times to only those within hours_back

--- a/cogs/sounding_utils.py
+++ b/cogs/sounding_utils.py
@@ -1203,12 +1203,21 @@ async def fetch_sounding(
     if hour in ("00", "12"):
         logger.debug(f"[SOUNDING] Fetching Wyoming for {station_id} {hour}z")
         try:
-            wyo_data = await loop.run_in_executor(
-                None, lambda: spy.get_obs_data(station_id, year, month, day, hour)
+            # SounderPy retries Wyoming up to 10 times internally — cap it so
+            # we can fall through to IEM when Wyoming is unreachable.
+            wyo_data = await asyncio.wait_for(
+                loop.run_in_executor(
+                    None, lambda: spy.get_obs_data(station_id, year, month, day, hour)
+                ),
+                timeout=20.0,
             )
             if validate_sounding_data(wyo_data):
                 logger.debug(f"[SOUNDING] Wyoming success for {station_id} {hour}z")
                 return wyo_data
+        except asyncio.TimeoutError:
+            logger.debug(
+                f"[SOUNDING] Wyoming timed out for {station_id} {hour}z, falling through to IEM"
+            )
         except Exception as e:
             logger.debug(f"[SOUNDING] Wyoming failed for {station_id} {hour}z: {e}")
 

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -307,7 +307,20 @@ async def send_sounding_embed(
                             )
                         )
 
-        sounding_msg = await target.send(caption, files=[discord.File(png_path)], view=view)
+        for _attempt in range(2):
+            try:
+                sounding_msg = await target.send(
+                    caption, files=[discord.File(png_path)], view=view
+                )
+                break
+            except OSError as _e:
+                if _attempt == 0:
+                    logger.warning(
+                        f"[SOUNDING] Connection error sending {station_id}, retrying: {_e}"
+                    )
+                    await asyncio.sleep(1)
+                else:
+                    raise
         logger.info(f"[SOUNDING] Posted {station_id} {time_label}")
 
         # Autopost AI summary if enabled and cache_key was available

--- a/cogs/sounding_views.py
+++ b/cogs/sounding_views.py
@@ -309,9 +309,7 @@ async def send_sounding_embed(
 
         for _attempt in range(2):
             try:
-                sounding_msg = await target.send(
-                    caption, files=[discord.File(png_path)], view=view
-                )
+                sounding_msg = await target.send(caption, files=[discord.File(png_path)], view=view)
                 break
             except OSError as _e:
                 if _attempt == 0:

--- a/deploy.sh
+++ b/deploy.sh
@@ -338,6 +338,7 @@ WorkingDirectory=${INSTALL_DIR}
 ExecStart=${VENV_DIR}/bin/python main.py
 Restart=on-failure
 RestartSec=10
+TimeoutStopSec=15
 StandardOutput=journal
 StandardError=journal
 EnvironmentFile=${ENV_FILE}


### PR DESCRIPTION
## Summary

When a primary node restarts (e.g. after a deploy), its new bot process gets a fresh UUID suffix in its identity (`P:hostname:NEW_UUID`). The old lease key in Redis still holds `P:hostname:OLD_UUID`. The new process doesn't recognise `OLD_UUID` as itself, so it boots as STANDBY. The standby then tries `SET NX` to promote — but the key already exists with the old identity — so promotion is aborted. Both nodes loop indefinitely with no one holding primary. This is the recurring scenario that required `redis-cli DEL spcbot:primary_url` as manual intervention.

## Root cause

`_is_our_node(target)` only matched `target == self._identity` (exact match) or `target == socket.gethostname()` (bare hostname from `manual_primary` key). It did not match the hostname embedded inside the `role:hostname:uuid` format of a lease value.

## Changes

**`_is_our_node()`** — also match on `parts[1] == my_hostname` so any previous boot of this node's lease is recognised as ours:
```python
parts = target.split(":")
return len(parts) >= 2 and parts[1] == my_hostname
```

**`startup_lease_check()`** — if the lease holder is our own hostname (different uuid), log and fall through to overwrite it rather than booting STANDBY.

**`_standby_cycle()`** — if the blocking lease belongs to our own hostname, call `_promote(force=True)` to bypass the `SET NX` check and reclaim it immediately.

**`sync_loop()`** — always `return` after handling a manual override (our node or another), so the normal primary/standby cycle doesn't also fire in the same tick. Previously this only returned for the "other node is manual primary" branch, causing a double `_promote` call on the same tick.

## Test plan

- [ ] Restart primary bot — it should claim the lease within one sync cycle (30s) without manual Redis intervention
- [ ] Restart failover bot — it should stay STANDBY and not erroneously claim the primary's lease
- [ ] Both `Restart=on-failure` and manual `systemctl restart` flows covered
- [ ] All 31 failover unit tests pass