### PR TITLE
feat: systemd watchdog to detect and recover zombie processes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -339,6 +339,7 @@ ExecStart=${VENV_DIR}/bin/python main.py
 Restart=on-failure
 RestartSec=10
 TimeoutStopSec=15
+WatchdogSec=300
 StandardOutput=journal
 StandardError=journal
 EnvironmentFile=${ENV_FILE}

--- a/main.py
+++ b/main.py
@@ -446,11 +446,37 @@ async def on_app_command_error(
         )
 
 
+# ── Systemd notify helper ─────────────────────────────────────────────────────
+
+
+def _sd_notify(msg: str) -> None:
+    """Write a sd_notify message to the systemd socket (no-op if not supervised)."""
+    import socket as _sock
+
+    path = os.environ.get("NOTIFY_SOCKET", "")
+    if not path:
+        return
+    try:
+        with _sock.socket(_sock.AF_UNIX, _sock.SOCK_DGRAM) as s:
+            # Abstract sockets use a NUL prefix instead of '@'
+            if path.startswith("@"):
+                path = "\0" + path[1:]
+            s.connect(path)
+            s.sendall(msg.encode())
+    except Exception:
+        pass
+
+
 # ── Watchdog ─────────────────────────────────────────────────────────────────
 @tasks.loop(minutes=2)
 async def watchdog_task():
     global _session_probe_failures
     await bot.wait_until_ready()
+    # Ping the systemd watchdog so it knows the event loop is alive.
+    # WatchdogSec in the service file must be > 2 min (we use 5 min).
+    # If the asyncio loop dies but the process lingers (zombie threads),
+    # this ping stops and systemd kills+restarts the service automatically.
+    _sd_notify("WATCHDOG=1")
 
     # Probe two independent endpoints. We only count a failure if BOTH fail —
     # a single-endpoint outage (e.g. NWS maintenance) shouldn't trigger a


### PR DESCRIPTION
## Summary

- Adds `WatchdogSec=300` to the service template in `deploy.sh`
- Pings the systemd watchdog from inside the existing `watchdog_task` every 2 minutes via `sd_notify("WATCHDOG=1")`
- Applied `WatchdogSec=300` to the live service file on 3cape immediately

## The problem this solves

When a deploy restart (SIGTERM) is sent while a SounderPy thread is running in `run_in_executor()`, the asyncio event loop exits cleanly — the bot disconnects from Discord, logs "Bot exited.", and `finally:` runs. But Python can't exit the process while non-daemon threads are still alive. systemd sees a living PID and considers the service healthy. No commands work, no XMPP, no alerts for however long the thread stays alive (or indefinitely if the thread hangs).

Tonight this caused a 1.5-hour outage. `Restart=on-failure` never fires because the process is still alive (non-zero exit isn't triggered).

## How the watchdog fixes it

```
asyncio loop alive → watchdog_task fires every 2 min → sd_notify("WATCHDOG=1") → systemd resets 5-min timer
asyncio loop dead  → pings stop → 5-min timer expires → systemd sends SIGKILL → Restart=on-failure kicks in
```

systemd's `WATCHDOG_USEC` env var is set automatically when `WatchdogSec` is configured. `_sd_notify()` writes to the Unix datagram socket at `$NOTIFY_SOCKET`. No-op if running outside systemd (dev environments, tests).

## Test plan

- [ ] Confirm `WATCHDOG_USEC` shows up in process env after next deploy: `sudo cat /proc/$(pgrep -f main.py)/environ | tr '\0' '\n' | grep WATCHDOG`
- [ ] In a non-prod scenario: kill the asyncio loop manually (send SIGTERM without stopping systemd) — within 5 min systemd should restart