### PR TITLE
fix: non-blocking worker-pool shutdown to prevent SIGKILL on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Fast Worker-Pool Shutdown**: `shutdown_executors()` no longer blocks on an in-flight plot. It previously called `ProcessPoolExecutor.shutdown(wait=True)`, which waited for the worker currently rendering a sounding/hodograph to finish — up to tens of seconds — overrunning systemd's `TimeoutStopSec` and getting the process SIGKILLed with orphaned workers left behind. It now drops queued work and force-terminates running workers, returning in well under a second. The `main.py` shutdown call is also wrapped in a 3s timeout backstop.
+
 ## [5.39.0] - 2026-06-27
 
 ### Fixed

--- a/main.py
+++ b/main.py
@@ -675,7 +675,12 @@ async def _shutdown():
     try:
         from utils.worker_pool import shutdown_executor
 
-        shutdown_executor()
+        # shutdown_executor() force-terminates workers and should return in
+        # well under a second; the timeout is a backstop so a wedged worker
+        # can never stall graceful shutdown into a systemd SIGKILL.
+        await asyncio.wait_for(asyncio.to_thread(shutdown_executor), timeout=3.0)
+    except asyncio.TimeoutError:
+        logger.warning("Worker pool shutdown timed out — relying on systemd cgroup kill")
     except Exception:
         pass
     try:

--- a/tests/test_worker_pool_shutdown.py
+++ b/tests/test_worker_pool_shutdown.py
@@ -1,0 +1,75 @@
+"""Tests for utils/worker_pool.shutdown_executors fast/non-blocking shutdown.
+
+Regression guard: a graceful ``shutdown(wait=True)`` used to block until the
+worker currently rendering a plot finished, overrunning systemd's
+TimeoutStopSec and getting the process SIGKILLed with orphaned workers left
+behind. shutdown_executors() must now return quickly and terminate in-flight
+workers.
+"""
+
+import time
+
+import pytest
+
+import utils.worker_pool as wp
+
+
+def _busy(seconds: float) -> str:
+    """Worker task that blocks far longer than the shutdown should wait."""
+    time.sleep(seconds)
+    return "done"
+
+
+@pytest.fixture(autouse=True)
+def _reset_pools():
+    """Ensure module globals start and end clean so tests don't leak pools."""
+    wp._HODO_EXECUTOR = None
+    wp._SOUNDING_EXECUTOR = None
+    yield
+    wp.shutdown_executors()
+
+
+def test_shutdown_returns_fast_with_inflight_worker():
+    """A worker mid-render must not hold shutdown_executors() open."""
+    executor = wp.get_hodo_executor()
+    # Kick off a task that would block for 30s if we waited for it.
+    future = executor.submit(_busy, 30.0)
+    # Let the worker actually pick the task up.
+    time.sleep(0.5)
+
+    start = time.monotonic()
+    wp.shutdown_executors()
+    elapsed = time.monotonic() - start
+
+    # Force-terminate path should be near-instant, never the 30s render.
+    assert elapsed < 5.0, f"shutdown blocked for {elapsed:.1f}s on in-flight worker"
+    # Globals reset so the next get_*_executor() rebuilds a fresh pool.
+    assert wp._HODO_EXECUTOR is None
+    assert wp._SOUNDING_EXECUTOR is None
+    # The in-flight future never completes successfully (worker was killed).
+    assert not (future.done() and future.exception() is None and future.result() == "done")
+
+
+def test_shutdown_noop_when_no_pools():
+    """Safe to call when nothing was ever forked (idempotent)."""
+    assert wp._HODO_EXECUTOR is None
+    assert wp._SOUNDING_EXECUTOR is None
+    wp.shutdown_executors()  # must not raise
+    wp.shutdown_executors()  # idempotent
+
+
+def test_terminates_worker_processes():
+    """Worker processes are actually killed, not left orphaned."""
+    executor = wp.get_sounding_executor()
+    executor.submit(_busy, 30.0)
+    time.sleep(0.5)
+    procs = [p for p in executor._processes.values()]
+    assert any(p.is_alive() for p in procs)
+
+    wp.shutdown_executors()
+
+    # Give terminate()+join() a beat to reap.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and any(p.is_alive() for p in procs):
+        time.sleep(0.1)
+    assert all(not p.is_alive() for p in procs), "worker processes survived shutdown"

--- a/utils/worker_pool.py
+++ b/utils/worker_pool.py
@@ -111,15 +111,39 @@ def get_executor() -> concurrent.futures.ProcessPoolExecutor:
     return get_hodo_executor()
 
 
-def shutdown_executors():
-    """Cleanly shut down all worker pools."""
+def shutdown_executors(join_timeout: float = 1.0):
+    """Stop all worker pools quickly, without blocking on in-flight renders.
+
+    A graceful ``shutdown(wait=True)`` blocks until the worker currently
+    rendering a plot finishes — a sounding can take tens of seconds, which
+    overruns systemd's ``TimeoutStopSec`` and gets the whole process SIGKILLed
+    (leaving orphaned worker processes behind). Instead we drop queued work
+    (``cancel_futures=True``) without waiting (``wait=False``) and then forcibly
+    terminate any worker still alive, so shutdown returns near-instantly. A
+    half-drawn plot on shutdown is throwaway, so losing it is harmless.
+    """
     global _HODO_EXECUTOR, _SOUNDING_EXECUTOR
-    if _HODO_EXECUTOR is not None:
-        _HODO_EXECUTOR.shutdown(wait=True, cancel_futures=True)
-        _HODO_EXECUTOR = None
-    if _SOUNDING_EXECUTOR is not None:
-        _SOUNDING_EXECUTOR.shutdown(wait=True, cancel_futures=True)
-        _SOUNDING_EXECUTOR = None
+    for executor in (_HODO_EXECUTOR, _SOUNDING_EXECUTOR):
+        if executor is None:
+            continue
+        # Capture worker handles BEFORE shutdown() — shutdown(wait=False)
+        # clears the executor's internal ``_processes`` map, so grabbing it
+        # afterwards would leave in-flight workers un-terminated. ``_processes``
+        # is None/empty if no worker forked yet.
+        procs = list((getattr(executor, "_processes", None) or {}).values())
+        # Drop queued (not-yet-started) work and don't block on a worker
+        # mid-render.
+        executor.shutdown(wait=False, cancel_futures=True)
+        # Hard-stop any worker still running so an in-flight plot can't hold
+        # us past TimeoutStopSec.
+        for proc in procs:
+            if proc.is_alive():
+                proc.terminate()
+        for proc in procs:
+            if proc.is_alive():
+                proc.join(join_timeout)
+    _HODO_EXECUTOR = None
+    _SOUNDING_EXECUTOR = None
 
 
 def shutdown_executor():


### PR DESCRIPTION
## Problem

Stopping the bot frequently hangs and ends in `Failed with result 'timeout'` (the unit goes `failed`, not `dead`), with orphaned worker processes lingering after the kill — observed fleet-wide.

Root cause: `_shutdown()` calls `shutdown_executors()`, which did:

```python
_HODO_EXECUTOR.shutdown(wait=True, cancel_futures=True)
_SOUNDING_EXECUTOR.shutdown(wait=True, cancel_futures=True)
```

`cancel_futures=True` only drops **queued** work; `wait=True` then **blocks until the worker currently rendering a plot finishes**. A sounding/hodograph render takes several-to-tens of seconds, which overruns systemd's `TimeoutStopSec` → `SIGKILL` → orphaned forked workers. Same code on every node, so the stall is fleet-wide.

## Fix

- `shutdown_executors()` now captures the worker process handles **before** calling `shutdown(wait=False, cancel_futures=True)` (which clears the executor's internal `_processes` map), then `terminate()`s any worker still running. Graceful stop returns in well under a second; a half-drawn plot on shutdown is throwaway.
- The `main.py` call site is wrapped in `asyncio.wait_for(..., timeout=3.0)` as a backstop so cleanup can never stall shutdown.

## Tests

New `tests/test_worker_pool_shutdown.py`:
- a worker stuck mid-render does not hold `shutdown_executors()` open (returns < 5s, not 30s);
- worker processes are actually terminated, not orphaned;
- calling shutdown with no pools is a safe no-op / idempotent.

## Deploy note (not in this PR)

The repo doesn't track the systemd unit. To fully reap any stragglers, also add `KillMode=mixed` to `/etc/systemd/system/spcbot.service` on each node so the SIGKILL fallback covers the whole cgroup. The code fix alone removes the normal-path stall.