### PR TITLE
fix: auto-promotion broken by != "OK" comparison against redis-py True/None contract

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -489,10 +489,11 @@ class FailoverCog(commands.Cog):
             claim_result = await self._exec(
                 "SET", LEASE_KEY, promoting_identity, "NX", "EX", str(HEARTBEAT_TTL)
             )
-            if claim_result != "OK":
+            if not claim_result:
                 # NX failed — either another node holds the lease, or Redis
-                # is unavailable. In both cases, the safe action is to
-                # remain a standby. Try to identify the holder for the log.
+                # is unavailable. redis-py's SET...NX returns True on
+                # success and None on failure (never the string "OK").
+                # In both failure cases, remain a standby.
                 holder = await self._read_lease_holder()
                 if holder:
                     logger.warning(

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -175,7 +175,7 @@ class TestPrimaryDemotion:
             if cmd == "GET":
                 return None  # Lease expired
             if cmd == "SET":
-                return "OK"  # NX succeeded
+                return True  # NX succeeded (real redis-py returns True, not "OK")
             return None
 
         monkeypatch.setattr(cog, "_exec", AsyncMock(side_effect=_exec_recorder))
@@ -405,9 +405,9 @@ def _stub_do_promote_prereqs(monkeypatch, cog):
     monkeypatch.setattr(cog, "_write_lease", AsyncMock())
     monkeypatch.setattr(cog, "_rehydrate_bot_state", AsyncMock())
 
-    # SET NX at the top of _do_promote returns "OK" so these tests exercise
-    # the cog-load path (without the stub the network call aborts promotion).
-    monkeypatch.setattr(cog, "_exec", _stub_exec({"SET": "OK"}))
+    # SET NX at the top of _do_promote returns True per redis-py contract
+    # (real redis-py returns True on success, None on failure — never "OK").
+    monkeypatch.setattr(cog, "_exec", _stub_exec({"SET": True}))
 
     import utils.state_store as state_store
 
@@ -612,9 +612,9 @@ def _stub_for_full_promotion(monkeypatch, cog):
         cog, "_build_local_redis", MagicMock(side_effect=Exception("skip redis flip"))
     )
     monkeypatch.setattr(cog, "_write_lease", AsyncMock())
-    # SET NX at top of _do_promote returns "OK" so these tests can exercise
-    # the post-claim side-effect paths.
-    monkeypatch.setattr(cog, "_exec", _stub_exec({"SET": "OK"}))
+    # SET NX at top of _do_promote returns True per redis-py contract
+    # (real redis-py returns True on success, None on failure — never "OK").
+    monkeypatch.setattr(cog, "_exec", _stub_exec({"SET": True}))
 
     import utils.events_db as events_db
 
@@ -801,10 +801,10 @@ class TestPromoteSplitBrainPrevention:
 
     @pytest.mark.asyncio
     async def test_nx_winner_completes_promotion(self, monkeypatch):
-        """If SET NX returns 'OK', the cog promotes normally."""
+        """If SET NX returns a truthy value (True in real redis-py), the cog promotes normally."""
         bot = _make_bot(is_primary=False)
         cog = FailoverCog(bot)
-        _stub_do_promote_prereqs(monkeypatch, cog)  # already stubs SET → "OK"
+        _stub_do_promote_prereqs(monkeypatch, cog)  # stubs SET → True per real redis-py contract
 
         monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", ["cog_a", "cog_b"])
         bot.load_extension = AsyncMock()
@@ -814,6 +814,36 @@ class TestPromoteSplitBrainPrevention:
         assert bot.state.is_primary is True
         assert bot.load_extension.await_count == 2
         bot.tree.sync.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_promotion_succeeds_with_real_redis_py_contract(self, monkeypatch):
+        """Regression: _do_promote must accept True (not the string "OK") as a
+        successful SET NX result. redis-py's SET ... NX response callback
+        returns True/None, never "OK". If the comparison uses `!= "OK"`, the
+        NX claim silently fails its own check and aborts promotion."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+        _stub_do_promote_prereqs(monkeypatch, cog)
+        # Override stub: explicitly return True (real redis-py success)
+        monkeypatch.setattr(
+            cog,
+            "_exec",
+            _stub_exec(
+                {
+                    "SET": True,
+                    "GET": f"P:{failover_module.socket.gethostname()}:{cog._process_uuid}",
+                }
+            ),
+        )
+        monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", ["cog_x"])
+        bot.load_extension = AsyncMock()
+
+        await cog._do_promote()
+
+        assert bot.state.is_primary is True, (
+            "promotion must succeed when _exec returns True for SET NX"
+        )
+        assert bot.load_extension.await_count == 1
 
     @pytest.mark.asyncio
     async def test_force_true_bypasses_nx_and_takes_lease(self, monkeypatch):
@@ -829,7 +859,7 @@ class TestPromoteSplitBrainPrevention:
         async def _record(*args):
             if str(args[0]).upper() == "SET":
                 set_calls.append(tuple(str(a).upper() for a in args[1:]))
-                return "OK"
+                return True
             return None
 
         monkeypatch.setattr(cog, "_exec", AsyncMock(side_effect=_record))
@@ -876,7 +906,7 @@ class TestPromoteSplitBrainPrevention:
                     if use_nx and key in shared:
                         return None
                     shared[key] = val
-                    return "OK"
+                    return True
                 if cmd == "GET":
                     return shared.get(str(args[1]))
                 return None


### PR DESCRIPTION
## Summary

Fixes a critical bug where automatic failover promotion silently aborts itself.

### The bug

`_do_promote` compares `claim_result != "OK"` — but redis-py's `SET ... NX` response callback returns `True` on success and `None` on failure, never the string `"OK"`.

Every automatic (non-forced) promotion:
1. Claims the Redis lease successfully (SET NX returns `True`)
2. Checks `True != "OK"` → `True` (they're not equal) → aborts promotion
3. Logs "Promotion aborted — lease held by 'P:ourhost:uuid'"
4. Next cycle sees lease held by itself → failure counter resets to 0 → permanent standby with orphaned lease

This is the root cause behind the failover deadlock that #555 worked around.

### The fix

Changed the comparison from `!= "OK"` to a truthiness check. redis-py returns `True` on success and `None` on failure, not the string `"OK"`. Fixed 5 test stubs that returned `"OK"` to return `True`. Added regression test.

### Verification

- 32 failover tests pass (including new regression test)
- 546 total tests pass