### PR TITLE
fix: forced promotion ignores SET result allowing split-brain on Redis outage

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -483,7 +483,15 @@ class FailoverCog(commands.Cog):
         # currently-held primary.
         promoting_identity = self._node_identity(True)
         if force:
-            await self._exec("SET", LEASE_KEY, promoting_identity, "EX", str(HEARTBEAT_TTL))
+            result = await self._exec(
+                "SET", LEASE_KEY, promoting_identity, "EX", str(HEARTBEAT_TTL)
+            )
+            if result is None:
+                logger.error(
+                    "[FAILOVER] Forced promotion failed — Redis unreachable, cannot claim "
+                    "lease. Aborting promotion to avoid split-brain."
+                )
+                return
             logger.warning("[FAILOVER] !!! PROMOTING TO PRIMARY (forced) !!!")
         else:
             claim_result = await self._exec(

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -900,3 +900,44 @@ class TestPromoteSplitBrainPrevention:
         )
         # Only the winner should have loaded cogs.
         assert (bot_a.load_extension.await_count == 1) ^ (bot_b.load_extension.await_count == 1)
+
+
+class TestForcedPromotionLeaseCheck:
+    @pytest.mark.asyncio
+    async def test_force_true_aborts_when_redis_unreachable(self, monkeypatch):
+        """If the forced SET returns None (Redis connection error), promotion
+        must abort — no is_primary flip, no cog load."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+
+        async def _exec_fail(*args):
+            return None
+
+        monkeypatch.setattr(cog, "_exec", AsyncMock(side_effect=_exec_fail))
+        monkeypatch.setattr(cog, "_cleanup_own_stale_entries", AsyncMock())
+        monkeypatch.setattr(cog, "_build_local_redis", MagicMock(side_effect=Exception("skip")))
+        monkeypatch.setattr(cog, "_write_lease", AsyncMock())
+        monkeypatch.setattr(cog, "_rehydrate_bot_state", AsyncMock())
+
+        import utils.state_store as state_store
+
+        monkeypatch.setattr(state_store, "invalidate_all_caches", MagicMock())
+        monkeypatch.setattr(state_store, "mirror_to_sqlite", AsyncMock())
+        monkeypatch.setattr(state_store, "resync_to_redis", AsyncMock())
+
+        import utils.events_db as events_db
+
+        monkeypatch.setattr(events_db, "restore_from_sync", MagicMock())
+        monkeypatch.setattr(events_db, "set_syncthing_folder_mode", AsyncMock())
+
+        import asyncio as _asyncio
+
+        monkeypatch.setattr(_asyncio, "sleep", AsyncMock())
+
+        monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", ["cog_x"])
+        bot.load_extension = AsyncMock()
+
+        await cog._do_promote(force=True)
+
+        assert bot.state.is_primary is False, "forced promotion must abort when lease write fails"
+        bot.load_extension.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes a bug where forced promotion ignores the SET result, allowing split-brain on Redis outage.

### The bug

`_do_promote(force=True)` called `_exec("SET", ...)` and ignored the return value. `_exec` returns `None` on a Redis connection error, but the code proceeded to set `is_primary=True`, load all cogs, and start posting with no actual lease held. If this coincided with a transient Redis outage while the real primary was still alive, the result was split-brain (duplicate posts to Discord).

### The fix

Check the `_exec` result on the forced path and abort/return if `None`.

### Test

`test_force_true_aborts_when_redis_unreachable` mocks `_exec` to return `None` and asserts promotion aborts cleanly.