### PR TITLE
fix: configured primary cannot reclaim lease from active standby

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -453,7 +453,7 @@ class FailoverCog(commands.Cog):
                 logger.warning(
                     f"[FAILOVER] Configured Primary reclaiming lease from Standby '{holder}'"
                 )
-                await self._promote()
+                await self._promote(force=True)
                 return
             if self._primary_failures > 0:
                 logger.info(

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -900,3 +900,21 @@ class TestPromoteSplitBrainPrevention:
         )
         # Only the winner should have loaded cogs.
         assert (bot_a.load_extension.await_count == 1) ^ (bot_b.load_extension.await_count == 1)
+
+
+class TestConfiguredPrimaryReclaim:
+    @pytest.mark.asyncio
+    async def test_configured_primary_reclaims_from_standby_with_force(self, monkeypatch):
+        """When a configured primary (P:) sees a standby (S:) holding the
+        lease, it must reclaim with force=True so the SET NX doesn't fail
+        on the already-held key."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+        cog._identity = "P:test-node:abc"
+
+        monkeypatch.setattr(cog, "_exec", _stub_exec({"GET": "S:other-host:xyz"}))
+        monkeypatch.setattr(cog, "_promote", AsyncMock())
+
+        await cog._standby_cycle()
+
+        cog._promote.assert_awaited_once_with(force=True)


### PR DESCRIPTION
## Summary

Fixes a bug where a returning configured primary can never reclaim its role from an active standby.

### The bug

`_standby_cycle` calls `_promote()` (force=False) when a configured primary (P:) sees a standby (S:) holding the lease. But `_promote()` does SET...NX, which only succeeds if the key is absent. Since the standby still holds the lease, NX always fails.

There is no corresponding standby voluntarily steps down mechanism — `_demote()` is only called on manual override, lease-loss-on-renewal, or losing a lease race. So a returning configured primary can never reclaim its role from an active standby without manual intervention.

### The fix

Use `_promote(force=True)` so the unconditional SET overrides the standby's held lease. The standby detects the takeover on its next `_primary_cycle` tick (<=30s) and demotes.