### PR TITLE
fix: dangling create_task in promotion can garbage-collect silently

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -52,6 +52,17 @@ from utils import state_store
 
 logger = logging.getLogger("spc_bot")
 
+
+def _log_task_exception(task: asyncio.Task) -> None:
+    """Log any exception raised in a background fire-and-forget task."""
+    try:
+        exc = task.exception()
+    except (asyncio.CancelledError, RuntimeError):
+        return
+    if exc:
+        logger.error("Background task failed", exc_info=exc)
+
+
 FAILOVER_TOKEN = os.getenv("FAILOVER_TOKEN", "")
 
 # On standby nodes, point this at the PRIMARY node's Redis (via Tailscale).
@@ -593,7 +604,8 @@ class FailoverCog(commands.Cog):
 
         nwws = self.bot.get_cog("NWWSCog")
         if nwws:
-            asyncio.create_task(nwws.trigger_connection())
+            t = asyncio.create_task(nwws.trigger_connection())
+            t.add_done_callback(_log_task_exception)
 
         try:
             synced = await self.bot.tree.sync()

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -900,3 +900,28 @@ class TestPromoteSplitBrainPrevention:
         )
         # Only the winner should have loaded cogs.
         assert (bot_a.load_extension.await_count == 1) ^ (bot_b.load_extension.await_count == 1)
+
+
+class TestPromotionTaskCallback:
+    @pytest.mark.asyncio
+    async def test_trigger_connection_task_has_exception_callback(self, monkeypatch):
+        """The fire-and-forget create_task on promotion must have a
+        done_callback so exceptions don't vanish silently."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+        _stub_do_promote_prereqs(monkeypatch, cog)
+
+        nwws_mock = MagicMock()
+        nwws_mock.trigger_connection = AsyncMock()
+
+        fake_task = MagicMock()
+        fake_task.add_done_callback = MagicMock()
+        monkeypatch.setattr(asyncio, "create_task", MagicMock(return_value=fake_task))
+        monkeypatch.setattr(failover_module, "ALL_EXTENSIONS", ["cog_x"])
+        monkeypatch.setattr(bot, "get_cog", MagicMock(return_value=nwws_mock))
+
+        await cog._do_promote()
+
+        fake_task.add_done_callback.assert_called_once_with(
+            failover_module._log_task_exception,
+        )


### PR DESCRIPTION
## Summary\n\nThe fire-and-forget `asyncio.create_task(nwws.trigger_connection())` on the promotion hot path keeps no reference to the task. It can be garbage-collected mid-flight and any exception vanishes silently (no traceback, no log).\n\n## The fix\n\nWrap the task with `_log_task_exception` helper and hold a `t` reference so the callback fires.