### PR TITLE
fix: manual-override short-circuits lease renewal and dirty-write drain

### DIFF
--- a/cogs/failover.py
+++ b/cogs/failover.py
@@ -353,16 +353,21 @@ class FailoverCog(commands.Cog):
                         # is bypassed — an operator's explicit override must
                         # be able to take the lease from a currently-held node.
                         await self._promote(force=True)
-                    # Always return after handling our own manual override so the
-                    # primary/standby cycle doesn't also fire in the same tick.
-                    return
+                        return  # state changed — skip normal cycle
+                    # Already primary and matching manual override — fall
+                    # through to _primary_cycle (renews the lease) and
+                    # _drain_dirty_writes below. Without this, a long-lived
+                    # manual override silently expires the lease and strands
+                    # dirty writes in SQLite.
                 else:
                     if self.bot.state.is_primary:
                         logger.warning(
                             f"[FAILOVER] Manual override: demoting to standby (target: '{manual_primary}')"
                         )
                         await self._demote()
-                    return
+                        return  # state changed — skip normal cycle
+                    # Already standby and matching override — fall through to
+                    # _standby_cycle below for normal heartbeat monitoring.
 
             if self.bot.state.is_primary:
                 await self._primary_cycle()

--- a/tests/test_failover_coverage.py
+++ b/tests/test_failover_coverage.py
@@ -900,3 +900,37 @@ class TestPromoteSplitBrainPrevention:
         )
         # Only the winner should have loaded cogs.
         assert (bot_a.load_extension.await_count == 1) ^ (bot_b.load_extension.await_count == 1)
+
+
+class TestManualOverrideFallthrough:
+    @pytest.mark.asyncio
+    async def test_primary_override_confirm_runs_cycle_and_drain(self, monkeypatch):
+        """Already primary + manual override = our node -> fall through to
+        _primary_cycle + _drain_dirty_writes (not short-circuit return)."""
+        bot = _make_bot(is_primary=True)
+        cog = FailoverCog(bot)
+        cog._identity = "P:test-node:abc"
+
+        monkeypatch.setattr(cog, "_exec", _stub_exec({"HSET": 1, "GET": "test-node"}))
+        monkeypatch.setattr(cog, "_primary_cycle", AsyncMock())
+        monkeypatch.setattr(cog, "_drain_dirty_writes", AsyncMock())
+
+        await cog.sync_loop()
+
+        cog._primary_cycle.assert_awaited_once()
+        cog._drain_dirty_writes.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_standby_override_confirm_runs_standby_cycle(self, monkeypatch):
+        """Already standby + manual override = other node -> fall through to
+        _standby_cycle (not short-circuit return)."""
+        bot = _make_bot(is_primary=False)
+        cog = FailoverCog(bot)
+        cog._identity = "S:test-node:abc"
+
+        monkeypatch.setattr(cog, "_exec", _stub_exec({"HSET": 1, "GET": "other-host"}))
+        monkeypatch.setattr(cog, "_standby_cycle", AsyncMock())
+
+        await cog.sync_loop()
+
+        cog._standby_cycle.assert_awaited_once()


### PR DESCRIPTION
Fixes a branch regression where the manual-override block in sync_loop had unconditional return statements that skipped lease renewal and dirty-write drain when the override confirmed existing state.