### PR TITLE
perf: post warning text immediately, attach image in background

### DIFF
--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -1000,3 +1000,39 @@ async def _download_warning_image(image_url: str, filename: str) -> discord.File
             logger.warning(f"[IMG_DL_FAIL] {filename}: Exception after 8 attempts: {e}")
         break
     return None
+
+
+async def _attach_warning_image_async(
+    msg,
+    vtec: dict,
+    vtec_id: str,
+) -> None:
+    """Post-then-edit pattern: download the IEM autoplot image in the
+    background and attach it to an already-sent warning message.
+
+    By sending the text embed first and upgrading with the image later,
+    the safety-critical warning text is never delayed by IEM's autoplot
+    generation latency (up to 60s of 404 retries).
+    """
+    has_etn = vtec.get("etn") and vtec["etn"] != "0"
+    if not has_etn and vtec.get("phenom") != "SPS":
+        return
+
+    image_url = iem_autoplot_url(vtec)
+    filename = f"warning_{vtec_id.replace('.', '_')}.png"
+    file = await _download_warning_image(image_url, filename)
+    if file is None:
+        logger.warning(f"[WARN_IMG_FAIL] {vtec_id}: image download returned None")
+        return
+
+    new_embed = msg.embeds[0].copy() if msg.embeds else None
+    if new_embed:
+        new_embed.set_image(url=f"attachment://{filename}")
+
+    try:
+        if new_embed:
+            await msg.edit(embed=new_embed, attachments=[file])
+        else:
+            await msg.edit(attachments=[file])
+    except Exception:
+        logger.debug(f"[WARN_IMG_UPGRADE] Edit failed for {vtec_id}", exc_info=True)

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -30,7 +30,6 @@ from discord.ext import commands, tasks
 
 from cogs.warning_format import (
     _area_with_state,
-    _download_warning_image,
     _vtec_unix_ts,
     _vtec_url,
     _WARNING_STYLE,
@@ -415,34 +414,27 @@ class WarningsCog(commands.Cog):
                 if event == "Tornado Warning" and event_id:
                     view = EnvironmentalView()
 
-                # Download IEM Autoplot image (only if we have a real ETN, or it's an SPS)
-                files = []
-                has_etn = vtec.get("etn") and vtec["etn"] != "0"
-                logger.debug(
-                    f"[WARN_IMG_CHECK] {vtec['vtec_id']}: has_etn={has_etn} phenom={vtec.get('phenom')}"
-                )
-                if has_etn or vtec.get("phenom") == "SPS":
-                    image_url = iem_autoplot_url(vtec)
-                    logger.debug(f"[WARN_IMG_IEMBOT] {vtec['vtec_id']}: {image_url}")
-                    filename = f"warning_{vtec_id.replace('.', '_')}.png"
-                    f = await _download_warning_image(image_url, filename)
-                    if f:
-                        files.append(f)
-                        embed.set_image(url=f"attachment://{filename}")
-                    else:
-                        logger.warning(
-                            f"[WARN_IMG_FAIL] {vtec['vtec_id']}: image download returned None"
-                        )
-                else:
-                    logger.debug(
-                        f"[WARN_IMG_SKIP] {vtec['vtec_id']}: no ETN, not downloading image"
-                    )
+                # Download IEM Autoplot image (only if we have a real ETN, or it's an SPS).
+                # Launched in background after the message is sent so the safety-critical
+                # warning text is never delayed by IEM's autoplot generation latency.
+                should_image = (vtec.get("etn") and vtec["etn"] != "0") or vtec.get(
+                    "phenom"
+                ) == "SPS"
 
                 try:
-                    msg = await channel.send(embed=embed, files=files, view=view)
+                    msg = await channel.send(embed=embed, view=view)
                     logger.info(
                         f"Posted (iembot) {event} {vtec_id} ({'Update' if is_update else 'Issuance'})"
                     )
+
+                    if should_image:
+                        from cogs.warning_format import _attach_warning_image_async
+
+                        t = asyncio.create_task(
+                            _attach_warning_image_async(msg, vtec, vtec_id),
+                            name=f"warn-img-{vtec_id}",
+                        )
+                        t.add_done_callback(_log_task_exception)
 
                     # Simple area extraction for persistence
                     area_m = re.search(r"for (.+?) till", concise_text)
@@ -1106,25 +1098,23 @@ class WarningsCog(commands.Cog):
             footer_text += f" | {footer_id}"
         embed.set_footer(text=footer_text)
 
-        # Download IEM Autoplot image (only if we have a real ETN, or it's an SPS)
-        files = []
-        has_etn = vtec.get("etn") and vtec["etn"] != "0"
-        logger.debug(f"[WARN_IMG_CHECK] {vtec_id}: has_etn={has_etn} phenom={vtec.get('phenom')}")
-        if has_etn or vtec.get("phenom") == "SPS":
-            image_url = iem_autoplot_url(vtec)
-            logger.debug(f"[WARN_IMG_NWSAPI] {vtec_id}: {image_url}")
-            filename = f"warning_{vtec_id.replace('.', '_')}.png"
-            f = await _download_warning_image(image_url, filename)
-            if f:
-                files.append(f)
-                embed.set_image(url=f"attachment://{filename}")
-            else:
-                logger.warning(f"[WARN_IMG_FAIL] {vtec_id}: image download returned None")
-        else:
-            logger.debug(f"[WARN_IMG_SKIP] {vtec_id}: no ETN, not downloading image")
+        # Download IEM Autoplot image (only if we have a real ETN, or it's an SPS).
+        # Launched in background after the message is sent so the safety-critical
+        # warning text is never delayed by IEM's autoplot generation latency.
+        should_image = (vtec.get("etn") and vtec["etn"] != "0") or vtec.get("phenom") == "SPS"
 
-        msg = await channel.send(embed=embed, files=files)
+        msg = await channel.send(embed=embed)
         logger.info(f"Posted {event} {vtec_id}")
+
+        if should_image:
+            from cogs.warning_format import _attach_warning_image_async
+
+            t = asyncio.create_task(
+                _attach_warning_image_async(msg, vtec, vtec_id),
+                name=f"warn-img-{vtec_id}",
+            )
+            t.add_done_callback(_log_task_exception)
+
         return msg, area_desc
 
     @auto_poll_warnings.before_loop

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
+import cogs.warnings as warnings_mod
+import cogs.warning_format as warning_format_mod
 from cogs.warnings import WarningsCog
 from cogs.warning_format import _extract_narrative, get_warning_style
 from lib.vtec_parser import parse_vtec, parse_warning_polygon
@@ -224,9 +226,8 @@ async def test_post_warning_now_dedups_against_posted_set(monkeypatch):
 
     cog.bot.state.add_posted_warning = AsyncMock()
     cog.bot.state.add_posted_product_id = AsyncMock(side_effect=_mock_add_product_id)
-    import cogs.warnings as warnings_mod
 
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
 
     await cog.post_warning_now(
@@ -247,9 +248,8 @@ async def test_post_warning_now_posts_CON_updates(monkeypatch):
 
     cog.bot.state.add_posted_warning = AsyncMock()
     cog.bot.state.add_posted_product_id = AsyncMock()
-    import cogs.warnings as warnings_mod
 
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
 
     con_text = SAMPLE_RAW.replace("/O.NEW.KOUN.SV.W.0042.", "/O.CON.KOUN.SV.W.0042.")
     await cog.post_warning_now(
@@ -300,9 +300,8 @@ async def test_post_warning_now_claims_key_before_send(monkeypatch):
         cog.bot.state.posted_warnings[vtec_id] = {"message_id": msg_id, "channel_id": chan_id}
 
     cog.bot.state.add_posted_warning = AsyncMock(side_effect=_mock_add_warning)
-    import cogs.warnings as warnings_mod
 
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
 
     # Stash the membership state observed at the moment of send.
@@ -336,9 +335,8 @@ async def test_post_warning_now_dedups_by_product_id(monkeypatch):
 
     cog.bot.state.add_posted_warning = AsyncMock()
     cog.bot.state.add_posted_product_id = AsyncMock(side_effect=_mock_add_product_id)
-    import cogs.warnings as warnings_mod
 
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
 
     # First post (e.g. from IEMBot)
     await cog.post_warning_now(
@@ -365,19 +363,12 @@ async def test_post_warning_now_race_dedup(monkeypatch):
     the second one must return early due to in-flight set."""
     cog = _make_cog()
 
-    import cogs.warnings as warnings_mod
-
     async def _mock_add_product_id(pid):
         cog.bot.state.posted_product_ids.append(pid)
 
     cog.bot.state.add_posted_product_id.side_effect = _mock_add_product_id
 
-    # Mock image download to be slow to create a race window
-    async def _slow_download(*args, **kwargs):
-        await asyncio.sleep(0.1)
-        return None
-
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", _slow_download)
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
 
     # Launch two concurrent tasks for different product IDs but same VTEC ID
     await asyncio.gather(
@@ -606,12 +597,11 @@ async def test_tick_disappeared_warning_triggers_cancellation(monkeypatch):
     content = _nws_response([])
     cog.bot.state.add_posted_warning = AsyncMock()
     cog.bot.state.add_posted_product_id = AsyncMock()
-    import cogs.warnings as warnings_mod
 
     monkeypatch.setattr(
         warnings_mod, "http_get_bytes_conditional", AsyncMock(return_value=(content, 200, {}))
     )
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
 
     await cog._tick()
@@ -644,12 +634,11 @@ async def test_tick_disappeared_warning_debounce(monkeypatch):
     content = _nws_response([])
     cog.bot.state.add_posted_warning = AsyncMock()
     cog.bot.state.add_posted_product_id = AsyncMock()
-    import cogs.warnings as warnings_mod
 
     monkeypatch.setattr(
         warnings_mod, "http_get_bytes_conditional", AsyncMock(return_value=(content, 200, {}))
     )
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
 
     await cog._tick()
@@ -687,12 +676,11 @@ async def test_tick_initial_discovery_posts_active_warning_missed_at_startup(mon
 
     cog.bot.state.add_posted_warning = AsyncMock()
     cog.bot.state.add_posted_product_id = AsyncMock()
-    import cogs.warnings as warnings_mod
 
     monkeypatch.setattr(
         warnings_mod, "http_get_bytes_conditional", AsyncMock(return_value=(content, 200, {}))
     )
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
     monkeypatch.setattr(warnings_mod, "add_significant_event", AsyncMock(), raising=False)
 
@@ -743,12 +731,11 @@ async def test_tick_con_area_change_posts_partial_update(monkeypatch):
 
     cog.bot.state.add_posted_warning = AsyncMock(side_effect=_mock_add_warning)
     cog.bot.state.add_posted_product_id = AsyncMock()
-    import cogs.warnings as warnings_mod
 
     monkeypatch.setattr(
         warnings_mod, "http_get_bytes_conditional", AsyncMock(return_value=(content, 200, {}))
     )
-    monkeypatch.setattr(warnings_mod, "_download_warning_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
     monkeypatch.setattr(warnings_mod, "add_significant_event", AsyncMock(), raising=False)
 
@@ -763,8 +750,6 @@ async def test_tick_con_area_change_posts_partial_update(monkeypatch):
 async def test_tick_304_returns_early(monkeypatch):
     """HTTP 304 (Not Modified) skips all processing and clears backoff."""
     cog, channel = _make_tick_cog()
-
-    import cogs.warnings as warnings_mod
 
     monkeypatch.setattr(
         warnings_mod, "http_get_bytes_conditional", AsyncMock(return_value=(None, 304, {}))
@@ -786,8 +771,6 @@ async def test_tick_cancelled_warning_not_reactivated(monkeypatch):
     vtec_str = "/O.CON.KOUN.SV.W.0042.260429T2018Z-260429T2115Z/"
     feature = _nws_feature(vtec_str)
     content = _nws_response([feature])
-
-    import cogs.warnings as warnings_mod
 
     monkeypatch.setattr(
         warnings_mod, "http_get_bytes_conditional", AsyncMock(return_value=(content, 200, {}))


### PR DESCRIPTION
P3 from the full codebase review.\n\nWarning image downloads blocked the warning text post for up to 60s while IEM's autoplot map was being generated (exponential backoff over 8 retries). This defeated the sub-15s NWWS/iembot fast path for tornado warnings.\n\nAdd `_attach_warning_image_async` helper that downloads the image in the background and edits the already-sent message via `message.edit`. Both warning posting paths send the text embed immediately.