### PR TITLE
fix: cross-source area-format mismatch causes spurious partial-cancellation posts

### DIFF
--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -574,6 +574,24 @@ def _area_with_state(
         return ", ".join(parts[:-1]) + f" and {parts[-1]}"
 
 
+def _canonical_county_set(area_str: str) -> set[str]:
+    """Extract county names from an area-description string into a canonical
+    set for comparison across data sources.
+
+    The iembot fast path stores ``"Caddo, Grady [OK]"`` while the NWS API
+    returns ``"Caddo; Grady"`` from ``props.areaDesc``.  Normalising both
+    to ``{"Caddo", "Grady"}`` lets us detect real area changes (partial
+    cancellations) without being fooled by formatting differences.
+    """
+    if not area_str:
+        return set()
+    # Strip state brackets: "Caddo [OK]" → "Caddo"
+    cleaned = re.sub(r"\s*\[[A-Z]{2}\]", "", area_str)
+    # Split on commas, semicolons, or " and "
+    parts = re.split(r"[,;]|\s+and\s+", cleaned)
+    return {p.strip() for p in parts if p.strip()}
+
+
 _DESCRIPTION_LIMIT = 4000
 
 

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -30,6 +30,7 @@ from discord.ext import commands, tasks
 
 from cogs.warning_format import (
     _area_with_state,
+    _canonical_county_set,
     _vtec_unix_ts,
     _vtec_url,
     _WARNING_STYLE,
@@ -929,7 +930,11 @@ class WarningsCog(commands.Cog):
                     prev_area = stored_info.get("area", "")
                     curr_area = props.areaDesc or ""
 
-                    if prev_area and curr_area and prev_area != curr_area:
+                    if (
+                        prev_area
+                        and curr_area
+                        and _canonical_county_set(prev_area) != _canonical_county_set(curr_area)
+                    ):
                         # Area changed - likely a partial cancellation
                         if issuance_id not in self._in_flight_vtecs:
                             self._in_flight_vtecs.add(issuance_id)


### PR DESCRIPTION
H3 from the full codebase review.\n\nThe iembot fast path stores county lists as "Caddo, Grady [OK]" while the NWS API returns "Caddo; Grady". These never matched as raw strings, causing every iembot-sourced warning that later appeared as CON via the NWS API to trigger a spurious partial-cancellation update post, then the next SVS would rewrite it back.\n\nAdd `_canonical_county_set()` to normalize both formats to a canonical county set for comparison.