### PR TITLE
fix: quick correctness fixes (M6, L3, L6)

### DIFF
--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -116,7 +116,7 @@ _STATES_LIST = [
     "NEW MEXICO",
     "NEW YORK",
     "NORTH CAROLINA",
-    "NORTH DACOTA",
+    "NORTH DAKOTA",
     "OHIO",
     "OKLAHOMA",
     "OREGON",

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -841,6 +841,11 @@ class WarningsCog(commands.Cog):
 
             count = self._absence_count.get(vtec_id, 0) + 1
             self._absence_count[vtec_id] = count
+            # Prune entries for warnings no longer in active_warnings
+            if len(self._absence_count) > 1000:
+                stale = self._absence_count.keys() - set(self.bot.state.active_warnings.keys())
+                for k in list(stale)[:500]:
+                    del self._absence_count[k]
             if count < self._ABSENCE_THRESHOLD:
                 logger.debug(
                     f"[WARN_ABSENT] {vtec_id} absent {count}/{self._ABSENCE_THRESHOLD} cycles — not cancelling yet"

--- a/lib/vad_plotter/vad_reader.py
+++ b/lib/vad_plotter/vad_reader.py
@@ -556,8 +556,8 @@ async def download_vad(
                         elif task is s3_task:
                             content = result
                         break
-                except BaseException:
-                    pass
+                except Exception:
+                    logger.debug("[VAD] Task result fetch failed", exc_info=True)
 
             # If neither succeeded, try the remaining (not cancelled)
             if not content:
@@ -576,7 +576,8 @@ async def download_vad(
                 try:
                     if tgftp_task.result() is None:
                         circuit_breaker.record_failure(host)
-                except BaseException:
+                except Exception:
+                    logger.debug("[VAD] tgftp result check failed", exc_info=True)
                     circuit_breaker.record_failure(host)
         else:
             circuit_breaker.record_failure(host)


### PR DESCRIPTION
Bundle of small fixes from the full codebase review.\n\n- **M6**: Fix 'NORTH DACOTA' typo in STATE_LIST\n- **L3**: _absence_count dict pruning for warnings removed via sweep_active\n- **L6**: Replace bare except BaseException with except Exception in VAD reader