### PR TITLE
fix: add exception callbacks to all dangling create_task calls

### DIFF
--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -13,6 +13,16 @@ from utils.worker_pool import get_hodo_executor
 
 logger = logging.getLogger("spc_bot")
 
+
+def _log_task_exception(task: asyncio.Task) -> None:
+    try:
+        exc = task.exception()
+    except (asyncio.CancelledError, RuntimeError):
+        return
+    if exc:
+        logger.error("Background task failed", exc_info=exc)
+
+
 VALID_RADARS = list(_radar_info.keys())
 HODO_OUTPUT_DIR = os.path.join("cache", "hodographs")
 VAD_SCRIPT = os.path.join("lib", "vad_plotter", "vad.py")
@@ -162,7 +172,8 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
 
     # Fire-and-forget: cache raw_text + prefetch AI summary
     if sent and params and cache_key:
-        asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
+        t = asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
+        t.add_done_callback(_log_task_exception)
 
 
 class RadarSuggestionView(discord.ui.View):

--- a/cogs/recorder.py
+++ b/cogs/recorder.py
@@ -17,6 +17,16 @@ from utils.worker_pool import get_executor
 
 logger = logging.getLogger("spc_bot.recorder")
 
+
+def _log_task_exception(task: asyncio.Task) -> None:
+    try:
+        exc = task.exception()
+    except (asyncio.CancelledError, RuntimeError):
+        return
+    if exc:
+        logger.error("Background task failed", exc_info=exc)
+
+
 STATE_KEY = "vad_active_missions"
 
 
@@ -139,7 +149,8 @@ class RecorderCog(commands.Cog):
         if to_finalize:
             for site_id in to_finalize:
                 mission = self.active_missions.pop(site_id)
-                asyncio.create_task(self._finalize_mission(mission))
+                t = asyncio.create_task(self._finalize_mission(mission))
+                t.add_done_callback(_log_task_exception)
             await self._persist_missions()
 
     async def _record_step(self, mission: VADRecordingMission):

--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -17,6 +17,16 @@ from utils.state_store import (
 
 logger = logging.getLogger("spc_bot")
 
+
+def _log_task_exception(task: asyncio.Task) -> None:
+    try:
+        exc = task.exception()
+    except (asyncio.CancelledError, RuntimeError):
+        return
+    if exc:
+        logger.error("Background task failed", exc_info=exc)
+
+
 _LSR_SPLIT_RE = re.compile(r"\n\n(?=\d{4}\s+[A-Z])")
 _LSR_LINE1_RE = re.compile(r"^(\d{4}\s+[AP]M)\s+(.{16})\s+(.{24})\s+(\d+\.\d+N\s+\d+\.\d+W)", re.M)
 _LSR_LINE2_RE = re.compile(r"^(\d{2}/\d{2}/\d{4})\s+(.{24})\s+([A-Z]{2})\s+(.*)$", re.M)
@@ -430,7 +440,8 @@ class ReportsCog(commands.Cog):
 
         if event_date:
             logger.info(f"[REPORTS] Detected event date {event_date} in PNS, checking for tracks")
-            asyncio.create_task(self._check_for_surveys(event_date))
+            t = asyncio.create_task(self._check_for_surveys(event_date))
+            t.add_done_callback(_log_task_exception)
 
     async def _check_for_surveys(self, event_date: str):
         """Poll IEM metadata API for Autoplot 253 tracks on a specific date."""
@@ -520,7 +531,7 @@ class ReportsCog(commands.Cog):
                 if match_result:
                     event_id, location, magnitude, coords = match_result
                     # Pre-cache photos in the background
-                    asyncio.create_task(
+                    t = asyncio.create_task(
                         cache_dat_photos(
                             event_id=event_id,
                             location=location,
@@ -528,6 +539,7 @@ class ReportsCog(commands.Cog):
                             coords=coords or "",
                         )
                     )
+                    t.add_done_callback(_log_task_exception)
 
         except Exception as e:
             logger.warning(f"[REPORTS] Survey check failed for {event_date}: {e}")

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -990,10 +990,11 @@ class WarningsCog(commands.Cog):
                 continue
 
             self._in_flight_vtecs.add(issuance_id)
-            asyncio.create_task(
+            t = asyncio.create_task(
                 self._discover_and_post_warning(issuance_id, feature, vtec_dict, event, props),
                 name=f"warn-discover-{issuance_id}",
             )
+            t.add_done_callback(_log_task_exception)
 
         await self._handle_disappeared_warnings(current_vtec_ids, current_vtec_data)
         self._backoff.success()

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -28,6 +28,16 @@ from utils.http import http_get_bytes
 
 logger = logging.getLogger("spc_bot")
 
+
+def _log_task_exception(task: asyncio.Task) -> None:
+    try:
+        exc = task.exception()
+    except (asyncio.CancelledError, RuntimeError):
+        return
+    if exc:
+        logger.error("Background task failed", exc_info=exc)
+
+
 _WATCH_FAST_POLL_INTERVAL_SEC = (
     5  # Stage 1: poll every 5s for image + probs (aggressive for probabilities)
 )
@@ -364,7 +374,8 @@ class WatchesCog(commands.Cog):
         # Run diagnostic to test all sources
         from cogs.watch_fetch import log_watch_source_timing
 
-        asyncio.create_task(log_watch_source_timing(watch_num))
+        t = asyncio.create_task(log_watch_source_timing(watch_num))
+        t.add_done_callback(_log_task_exception)
 
         logger.info(f"iembot-triggered post for #{watch_num} ({wtype})")
         image_url, text_summary, probs, is_pds = await fetch_watch_details(watch_num)
@@ -399,9 +410,10 @@ class WatchesCog(commands.Cog):
             logger.info(f"iembot-triggered: posted watch #{watch_num}")
             sounding_cog = self.bot.cogs.get("SoundingCog")
             if sounding_cog and isinstance(nws_info, dict) and nws_info.get("affected_zones"):
-                asyncio.create_task(
+                t = asyncio.create_task(
                     sounding_cog.post_soundings_for_watch(watch_num, nws_info, channel)
                 )
+                t.add_done_callback(_log_task_exception)
             # Schedule upgrade edit once SPC data is available
             has_prelim = probs and "preliminary" in probs
             if not cache_path or has_prelim:


### PR DESCRIPTION
L2 from the full codebase review.\n\nAdded `_log_task_exception` helper and `add_done_callback` wrappers to all fire-and-forget `create_task` calls across hodograph, reports, recorder, warnings, and watches cogs — 8 call sites total. Exceptions in these background tasks previously vanished silently.