### PR TITLE
fix: _handled_watches snapshot stale + recorder mission dir leak

### DIFF
--- a/cogs/recorder.py
+++ b/cogs/recorder.py
@@ -230,6 +230,12 @@ class RecorderCog(commands.Cog):
                 logger.info(f"Cleaned up temporary data for {mission.site_id}")
         except Exception as e:
             logger.error(f"Finalization failed for {mission.site_id}: {e}")
+            # Clean up temp files even on failure so the mission doesn't leak
+            # disk space indefinitely.
+            try:
+                await loop.run_in_executor(None, self._cleanup_worker, mission.dir)
+            except Exception:
+                pass
 
     async def _post_forensic_summary(
         self, mission: VADRecordingMission, gif_path: str, peak_srh: float

--- a/cogs/watches.py
+++ b/cogs/watches.py
@@ -487,7 +487,7 @@ class WatchesCog(commands.Cog):
                         sounding_cog
                         and isinstance(nws_info, dict)
                         and nws_info.get("affected_zones")
-                        and watch_num not in sounding_cog._handled_watches
+                        and watch_num not in self.bot.state.sounding_handled_watches
                     ):
                         asyncio.create_task(
                             sounding_cog.post_soundings_for_watch(watch_num, nws_info, channel)


### PR DESCRIPTION
L5+L7 from the full codebase review.\n\n- **L5**: The poll path read `sounding_cog._handled_watches`, a snapshot taken at cog load never updated. Switch to `bot.state.sounding_handled_watches`.\n- **L7**: _finalize_mission leaked temp directory on exception. Add cleanup in except handler.