### PR TITLE
perf: parallel GIF frames + hodo pool skips SounderPy

### DIFF
--- a/cogs/recorder.py
+++ b/cogs/recorder.py
@@ -198,17 +198,21 @@ class RecorderCog(commands.Cog):
 
         frame_paths = []
         try:
+            frame_tasks = []
             for filename in files:
                 input_path = os.path.join(mission.dir, filename)
                 output_path = os.path.join(mission.dir, f"{filename}.png")
-                await loop.run_in_executor(
-                    self.executor,
-                    self._render_frame_worker,
-                    input_path,
-                    output_path,
-                    mission.site_id,
+                frame_tasks.append(
+                    loop.run_in_executor(
+                        self.executor,
+                        self._render_frame_worker,
+                        input_path,
+                        output_path,
+                        mission.site_id,
+                    )
                 )
                 frame_paths.append(output_path)
+            await asyncio.gather(*frame_tasks)
 
             if frame_paths:
                 gif_name = f"{mission.site_id}_{int(mission.trigger_ts)}_evolution.gif"

--- a/utils/worker_pool.py
+++ b/utils/worker_pool.py
@@ -21,13 +21,27 @@ _MAX_SOUNDING_WORKERS = 4
 _sounding_semaphore: Optional[asyncio.Semaphore] = None
 
 
+def _hodo_worker_init():
+    """Hodo-only init — skips SounderPy (hodo renders never touch it)."""
+    import logging as _logging
+
+    for name in ("spc_bot", None):
+        log_obj = _logging.getLogger(name)
+        for h in log_obj.handlers[:]:
+            log_obj.removeHandler(h)
+    _logging.getLogger().setLevel(_logging.WARNING)
+
+    import matplotlib as _mpl
+
+    _mpl.use("Agg")
+
+
 def _worker_init():
     """Initialize each worker process by pre-importing heavy libraries."""
     import io as _io
     import logging as _logging
     import sys as _sys
 
-    # Silence inherited loggers to prevent double-logging to stdout
     for name in ("spc_bot", None):
         log_obj = _logging.getLogger(name)
         for h in log_obj.handlers[:]:
@@ -58,7 +72,7 @@ def get_hodo_executor() -> concurrent.futures.ProcessPoolExecutor:
         _logging.getLogger("spc_bot").info(f"Initializing Hodo Pool ({_MAX_HODO_WORKERS} workers)")
         _HODO_EXECUTOR = concurrent.futures.ProcessPoolExecutor(
             max_workers=_MAX_HODO_WORKERS,
-            initializer=_worker_init,
+            initializer=_hodo_worker_init,
             mp_context=multiprocessing.get_context("forkserver"),
         )
     return _HODO_EXECUTOR


### PR DESCRIPTION
P5+P6 from the full codebase review.\n\n**P5**: Recorder GIF frames rendered sequentially despite 4-worker pool. Submit all frames concurrently via asyncio.gather.\n\n**P6**: Hodo pool imported SounderPy unnecessarily (verified — hodo rendering path never touches it). Split into _hodo_worker_init (matplotlib only) vs _worker_init (full).