### PR TITLE
feat: add /hodogif command for animated VWP hodograph loops

### DIFF
--- a/cogs/hodograph.py
+++ b/cogs/hodograph.py
@@ -9,6 +9,9 @@ import discord
 from discord.ext import commands
 
 from lib.vad_plotter.vad import vad_plotter
+from lib.vad_plotter.vad_reader import download_vads_batch
+from lib.vad_plotter.params import compute_parameters
+from lib.vad_plotter.plot import plot_hodograph_gif
 from lib.vad_plotter.wsr88d import _radar_info, RADAR_NAMES
 from utils.worker_pool import get_hodo_executor
 
@@ -18,7 +21,7 @@ logger = logging.getLogger("spc_bot")
 def _log_task_exception(task: asyncio.Task) -> None:
     try:
         exc = task.exception()
-    except (asyncio.CancelledError, RuntimeError):
+    except (asyncio.CancelError, RuntimeError):
         return
     if exc:
         logger.error("Background task failed", exc_info=exc)
@@ -26,7 +29,11 @@ def _log_task_exception(task: asyncio.Task) -> None:
 
 VALID_RADARS = list(_radar_info.keys())
 HODO_OUTPUT_DIR = os.path.join("cache", "hodographs")
+HODO_GIF_CACHE_DIR = os.path.join("cache", "hodograph_gifs")
 VAD_SCRIPT = os.path.join("lib", "vad_plotter", "vad.py")
+MAX_GIF_FRAMES = 20
+MAX_GIF_SIZE_MB = 25
+DEFAULT_LOOP_FRAMES = 6
 
 
 async def _background_cache_hodo(cache_key: str, raw_text: str, site: str):
@@ -35,10 +42,8 @@ async def _background_cache_hodo(cache_key: str, raw_text: str, site: str):
         from utils.state_store import get_product_cache, set_product_cache
         from utils.ai import call_gemini
 
-        # Cache raw_text for button handler
         await set_product_cache(f"raw_text_{cache_key}", raw_text, ttl=3600)
 
-        # Prefetch AI summary
         existing = await get_product_cache(cache_key)
         if existing:
             return
@@ -62,7 +67,7 @@ class HodographPlotView(discord.ui.View):
     def __init__(self, cache_key: str):
         super().__init__(timeout=None)
         button = discord.ui.Button(
-            label="🪄 AI Analysis",
+            label="AI Analysis",
             style=discord.ButtonStyle.secondary,
             custom_id=f"ai_snd:{cache_key}",
         )
@@ -74,8 +79,6 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
     os.makedirs(HODO_OUTPUT_DIR, exist_ok=True)
     output_path = os.path.join(HODO_OUTPUT_DIR, f"{site.lower()}_hodograph.png")
 
-    # If we have a fresh cached render (< 5 min), reuse it — VAD scans
-    # only update every 5-10 min so re-rendering is pure waste.
     cache_valid = False
     if os.path.exists(output_path):
         file_age = time.time() - os.path.getmtime(output_path)
@@ -89,15 +92,15 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
         try:
             params = await asyncio.wait_for(
                 vad_plotter(
-                    site,  # radar_id
-                    "right-mover",  # storm_motion
-                    None,  # sfc_wind
-                    None,  # time
-                    output_path,  # fname
-                    None,  # local_path
-                    None,  # cache_path
-                    False,  # web
-                    False,  # fixed
+                    site,
+                    "right-mover",
+                    None,
+                    None,
+                    output_path,
+                    None,
+                    None,
+                    False,
+                    False,
                     executor=get_hodo_executor(),
                 ),
                 timeout=60,
@@ -106,7 +109,7 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
             logger.warning(f"[HODO] vad_plotter timed out for {site}")
             try:
                 await interaction.followup.send(
-                    f"⏱️ Timed out fetching data for `{site}`. The radar may be offline or have no recent VWP data.",
+                    f"Timed out fetching data for `{site}`. The radar may be offline or have no recent VWP data.",
                     ephemeral=True,
                 )
             except discord.NotFound:
@@ -118,7 +121,7 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
             logger.error(f"[HODO] vad_plotter failed for {site}: {e}")
             try:
                 await interaction.followup.send(
-                    f"⚠️ Could not generate hodograph for `{site}`. The radar may not have recent data.",
+                    f"Could not generate hodograph for `{site}`. The radar may not have recent data.",
                     ephemeral=True,
                 )
             except discord.NotFound:
@@ -129,7 +132,7 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
         logger.error(f"[HODO] Output file not found after successful run for {site}")
         try:
             await interaction.followup.send(
-                f"⚠️ Hodograph image not generated for `{site}`.",
+                f"Hodograph image not generated for `{site}`.",
                 ephemeral=True,
             )
         except discord.NotFound:
@@ -188,10 +191,152 @@ async def generate_hodograph(interaction: discord.Interaction, site: str):
             else:
                 logger.error(f"[HODO] Retry also failed for {site}: {conn_err}")
 
-    # Fire-and-forget: cache raw_text + prefetch AI summary
     if sent and params and cache_key:
         t = asyncio.create_task(_background_cache_hodo(cache_key, summary, site))
         t.add_done_callback(_log_task_exception)
+
+
+async def generate_hodogif(
+    interaction: discord.Interaction,
+    site: str,
+    num_frames: int = DEFAULT_LOOP_FRAMES,
+):
+    """Generate an animated hodograph GIF loop from recent VAD scans.
+
+    Each frame shows for 1s, last frame lingers 3s on the most recent scan.
+    """
+    os.makedirs(HODO_GIF_CACHE_DIR, exist_ok=True)
+    output_path = os.path.join(HODO_GIF_CACHE_DIR, f"{site.lower()}_hodogif_{num_frames}f.gif")
+
+    cache_valid = False
+    if os.path.exists(output_path):
+        file_age = time.time() - os.path.getmtime(output_path)
+        if file_age < 600:
+            cache_valid = True
+            logger.info(f"[HODO] Using cached hodogif for {site}")
+
+    if not cache_valid:
+        logger.info(f"[HODO] Generating hodogif ({num_frames} frames) for {site}")
+        try:
+            vads = await asyncio.wait_for(
+                download_vads_batch(site, max_frames=num_frames),
+                timeout=120,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(f"[HODO] VAD batch download timed out for {site}")
+            try:
+                await interaction.followup.send(
+                    f"Timed out fetching VWP data for `{site}`.",
+                    ephemeral=True,
+                )
+            except discord.NotFound:
+                pass
+            return
+        except Exception as e:
+            logger.error(f"[HODO] VAD batch download failed for {site}: {e}")
+            try:
+                await interaction.followup.send(
+                    f"Could not fetch VWP data for `{site}`: {e}",
+                    ephemeral=True,
+                )
+            except discord.NotFound:
+                pass
+            return
+
+        if not vads:
+            try:
+                await interaction.followup.send(
+                    f"No recent VWP data available for `{site}`.",
+                    ephemeral=True,
+                )
+            except discord.NotFound:
+                pass
+            return
+
+        params_list = [compute_parameters(v, "right-mover") for v in vads]
+
+        executor = get_hodo_executor()
+        loop = asyncio.get_running_loop()
+        try:
+            success = await asyncio.wait_for(
+                loop.run_in_executor(
+                    executor,
+                    plot_hodograph_gif,
+                    vads,
+                    params_list,
+                    output_path,
+                    False,
+                    1000,
+                    3000,
+                ),
+                timeout=120,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(f"[HODO] GIF generation timed out for {site}")
+            try:
+                await interaction.followup.send(
+                    f"Timed out generating hodogif for `{site}`.",
+                    ephemeral=True,
+                )
+            except discord.NotFound:
+                pass
+            return
+        except Exception as e:
+            logger.error(f"[HODO] GIF generation failed for {site}: {e}")
+            try:
+                await interaction.followup.send(
+                    f"Failed to generate hodogif for `{site}`.",
+                    ephemeral=True,
+                )
+            except discord.NotFound:
+                pass
+            return
+
+        if not success or not os.path.exists(output_path):
+            try:
+                await interaction.followup.send(
+                    f"Failed to generate hodogif for `{site}`.",
+                    ephemeral=True,
+                )
+            except discord.NotFound:
+                pass
+            return
+
+        file_size = os.path.getsize(output_path)
+        if file_size > MAX_GIF_SIZE_MB * 1024 * 1024:
+            logger.info(
+                f"[HODO] GIF too large ({file_size / 1024 / 1024:.1f} MB), retrying with fewer frames"
+            )
+            if num_frames > 4:
+                os.remove(output_path)
+                await generate_hodogif(interaction, site, num_frames - 2)
+                return
+            else:
+                try:
+                    await interaction.followup.send(
+                        f"Even a 4-frame GIF is too large ({file_size / 1024 / 1024:.1f} MB). "
+                        "Try another radar.",
+                        ephemeral=True,
+                    )
+                except discord.NotFound:
+                    pass
+                return
+
+    logger.info(f"[HODO] Hodogif generated at {output_path}")
+
+    location = RADAR_NAMES.get(site)
+    if location:
+        label = f"**{site} ({location})** VWP Hodograph Loop ({num_frames} frames, ~{num_frames * 5} min)"
+    else:
+        label = f"**{site}** VWP Hodograph Loop ({num_frames} frames, ~{num_frames * 5} min)"
+
+    file_size = os.path.getsize(output_path)
+    content = f"{label}\n{file_size / 1024 / 1024:.1f} MB"
+
+    try:
+        await interaction.followup.send(content=content, file=discord.File(output_path))
+    except discord.NotFound:
+        pass
 
 
 class RadarSuggestionView(discord.ui.View):
@@ -212,7 +357,6 @@ class RadarSuggestionView(discord.ui.View):
                 await interaction.response.defer(thinking=True)
                 for item in self.children:
                     item.disabled = True
-                # Use edit_original_response instead of message.edit to properly handle deferred interaction
                 await interaction.edit_original_response(view=self)
                 await generate_hodograph(interaction, site)
             except discord.NotFound:
@@ -242,13 +386,13 @@ class HodographCog(commands.Cog):
             if suggestions:
                 view = RadarSuggestionView(suggestions)
                 await interaction.followup.send(
-                    f"❌ `{site}` is not a recognized radar ID. Did you mean one of these?",
+                    f"`{site}` is not a recognized radar ID. Did you mean one of these?",
                     view=view,
                     ephemeral=True,
                 )
             else:
                 await interaction.followup.send(
-                    f"❌ `{site}` is not a recognized radar ID. Try a 4-letter NEXRAD code like `KTLX` or `KHOU`.",
+                    f"`{site}` is not a recognized radar ID. Try a 4-letter NEXRAD code like `KTLX` or `KHOU`.",
                     ephemeral=True,
                 )
             return
@@ -259,7 +403,51 @@ class HodographCog(commands.Cog):
             logger.exception(f"[HODO] Unhandled error in /hodograph for {site}: {e}")
             try:
                 await interaction.followup.send(
-                    f"⚠️ Unexpected error for `{site}`. Please try again.",
+                    f"Unexpected error for `{site}`. Please try again.",
+                    ephemeral=True,
+                )
+            except discord.HTTPException as send_err:
+                logger.debug(f"[HODO] Could not send error message: {send_err}")
+
+    @discord.app_commands.command(
+        name="hodogif",
+        description="Generate an animated VWP hodograph loop (default 6 frames, ~30 min)",
+    )
+    @discord.app_commands.describe(
+        site="4-letter radar site ID (e.g. KTLX, KHOU, KNKX)",
+        frames="Number of frames (default 6, ~5 min each)",
+    )
+    async def hodogif_slash(
+        self, interaction: discord.Interaction, site: str, frames: int = DEFAULT_LOOP_FRAMES
+    ):
+        await interaction.response.defer(thinking=True)
+
+        site = site.upper().strip()
+
+        if site not in VALID_RADARS:
+            suggestions = difflib.get_close_matches(site, VALID_RADARS, n=3, cutoff=0.5)
+            if suggestions:
+                view = RadarSuggestionView(suggestions)
+                await interaction.followup.send(
+                    f"`{site}` is not a recognized radar ID. Did you mean one of these?",
+                    view=view,
+                    ephemeral=True,
+                )
+            else:
+                await interaction.followup.send(
+                    f"`{site}` is not a recognized radar ID. Try a 4-letter NEXRAD code like `KTLX` or `KHOU`.",
+                    ephemeral=True,
+                )
+            return
+
+        frames = max(2, min(frames, MAX_GIF_FRAMES))
+        try:
+            await generate_hodogif(interaction, site, frames)
+        except Exception as e:
+            logger.exception(f"[HODO] Unhandled error in /hodogif for {site}: {e}")
+            try:
+                await interaction.followup.send(
+                    f"Unexpected error for `{site}`. Please try again.",
                     ephemeral=True,
                 )
             except discord.HTTPException as send_err:

--- a/lib/vad_plotter/plot.py
+++ b/lib/vad_plotter/plot.py
@@ -1,11 +1,15 @@
 from __future__ import print_function
 
+import io
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import matplotlib as mpl
+import numpy as np
+import pylab
+from PIL import Image
 
 mpl.use("agg")
 import numpy as np
@@ -144,9 +148,7 @@ def _plot_param_table(
         y -= ls
 
     pylab.text(x0, y, "0-6 km", **kwb)
-    pylab.text(
-        col1, y, _fmt(parameters.get("shear_mag_6000m", np.nan)), ha="center", **kw
-    )
+    pylab.text(col1, y, _fmt(parameters.get("shear_mag_6000m", np.nan)), ha="center", **kw)
     y -= ls * 0.6
     hline(y)
     y -= ls * 1.2
@@ -239,10 +241,7 @@ def _plot_data(data: Dict[str, Any], parameters: Dict[str, Any]) -> None:
                 linewidth=1.5,
             )
 
-        if (
-            idx_start < len(data["rms_error"])
-            and data["rms_error"][idx_start] == 0.0
-        ):
+        if idx_start < len(data["rms_error"]) and data["rms_error"][idx_start] == 0.0:
             pylab.plot(
                 u[idx_start : idx_start + 2],
                 v[idx_start : idx_start + 2],
@@ -258,9 +257,7 @@ def _plot_data(data: Dict[str, Any], parameters: Dict[str, Any]) -> None:
                 linewidth=1.5,
             )
         else:
-            pylab.plot(
-                u[idx_start:idx_end], v[idx_start:idx_end], "-", color=c, linewidth=1.5
-            )
+            pylab.plot(u[idx_start:idx_end], v[idx_start:idx_end], "-", color=c, linewidth=1.5)
 
         if not np.isnan(seg_u[idx + 1]):
             pylab.plot(
@@ -272,9 +269,7 @@ def _plot_data(data: Dict[str, Any], parameters: Dict[str, Any]) -> None:
             )
 
         for upt, vpt, rms in list(zip(u, v, data["rms_error"]))[idx_start:idx_end]:
-            pylab.gca().add_patch(
-                Circle((upt, vpt), np.sqrt(2) * rms, color=c, alpha=0.05)
-            )
+            pylab.gca().add_patch(Circle((upt, vpt), np.sqrt(2) * rms, color=c, alpha=0.05))
 
     pylab.plot(mkr_u, mkr_v, "ko", ms=10)
     for um, vm, zm in zip(mkr_u, mkr_v, mkr_z):
@@ -298,14 +293,10 @@ def _plot_data(data: Dict[str, Any], parameters: Dict[str, Any]) -> None:
 
     if not (np.isnan(bl_u) or np.isnan(bl_v)):
         pylab.plot(bl_u, bl_v, "ko", markersize=5, mfc="none")
-        pylab.text(
-            bl_u + 0.5, bl_v - 0.5, "LM", ha="left", va="top", color="k", fontsize=10
-        )
+        pylab.text(bl_u + 0.5, bl_v - 0.5, "LM", ha="left", va="top", color="k", fontsize=10)
     if not (np.isnan(br_u) or np.isnan(br_v)):
         pylab.plot(br_u, br_v, "ko", markersize=5, mfc="none")
-        pylab.text(
-            br_u + 0.5, br_v - 0.5, "RM", ha="left", va="top", color="k", fontsize=10
-        )
+        pylab.text(br_u + 0.5, br_v - 0.5, "RM", ha="left", va="top", color="k", fontsize=10)
     if not (np.isnan(mn_u) or np.isnan(mn_v)):
         pylab.plot(mn_u, mn_v, "s", color="#a04000", markersize=5, mfc="none")
         pylab.text(
@@ -319,9 +310,7 @@ def _plot_data(data: Dict[str, Any], parameters: Dict[str, Any]) -> None:
         )
     if not (np.isnan(dtm_u) or np.isnan(dtm_v)):
         pylab.plot(dtm_u, dtm_v, "kv", markersize=6, mfc="none")
-        pylab.text(
-            dtm_u + 0.5, dtm_v - 0.5, "DTM", ha="left", va="top", color="k", fontsize=10
-        )
+        pylab.text(dtm_u + 0.5, dtm_v - 0.5, "DTM", ha="left", va="top", color="k", fontsize=10)
 
     smv_is_brm = storm_u == br_u and storm_v == br_v
     smv_is_blm = storm_u == bl_u and storm_v == bl_v
@@ -341,9 +330,7 @@ def _plot_data(data: Dict[str, Any], parameters: Dict[str, Any]) -> None:
         )
 
 
-def _plot_background(
-    min_u: float, max_u: float, min_v: float, max_v: float
-) -> None:
+def _plot_background(min_u: float, max_u: float, min_v: float, max_v: float) -> None:
     _max_val = max(
         np.hypot(min_u, min_v),
         np.hypot(min_u, max_v),
@@ -358,13 +345,9 @@ def _plot_background(
     pylab.axvline(x=0, linestyle="-", color="#999999")
     pylab.axhline(y=0, linestyle="-", color="#999999")
     for irng in range(10, max_ring, 10):
-        pylab.gca().add_patch(
-            Circle((0.0, 0.0), irng, linestyle="dashed", fc="none", ec="#999999")
-        )
+        pylab.gca().add_patch(Circle((0.0, 0.0), irng, linestyle="dashed", fc="none", ec="#999999"))
         if irng <= max_u - 10:
-            rng_str = (
-                "%d kts" % irng if max_u - 20 < irng <= max_u - 10 else "%d" % irng
-            )
+            rng_str = "%d kts" % irng if max_u - 20 < irng <= max_u - 10 else "%d" % irng
             pylab.text(
                 irng + 0.5,
                 -0.5,
@@ -487,3 +470,99 @@ def plot_hodograph(
     if web:
         bounds = {"min_u": min_u, "max_u": max_u, "min_v": min_v, "max_v": max_v}
         logger.debug(json.dumps(bounds))
+
+
+def plot_hodograph_gif(
+    vads: List[Any],
+    params_list: List[Dict[str, Any]],
+    fname: str,
+    fixed: bool = True,
+    frame_duration_ms: int = 1000,
+    linger_duration_ms: int = 3000,
+) -> bool:
+    """Generate an animated GIF from a list of VAD objects.
+
+    Last frame gets linger_duration_ms, all others get frame_duration_ms.
+    Returns True on success, False on failure.
+    """
+    import matplotlib
+
+    matplotlib.use("agg")
+
+    frames: List[Image.Image] = []
+    first_u, first_v = vec2comp(vads[0]["wind_dir"], vads[0]["wind_spd"])
+    if fixed or len(first_u) == 0:
+        ctr_u, ctr_v, size = 20, 20, 120
+    else:
+        ctr_u = first_u.mean()
+        ctr_v = first_v.mean()
+        size = max(first_u.max() - first_u.min(), first_v.max() - first_v.min()) + 20
+        size = max(120, size)
+
+    min_u, max_u = ctr_u - size / 2, ctr_u + size / 2
+    min_v, max_v = ctr_v - size / 2, ctr_v + size / 2
+
+    rid = vads[0]["rid"]
+    location = RADAR_NAMES.get(rid)
+
+    for vad, params in zip(vads, params_list):
+        pylab.figure(figsize=(10, 7.5), dpi=100)
+        fig_wid, fig_hght = pylab.gcf().get_size_inches()
+        fig_aspect = fig_wid / fig_hght
+
+        axes_left = 0.05
+        axes_bot = 0.05
+        axes_hght = 0.9
+        axes_wid = axes_hght / fig_aspect
+        pylab.axes((axes_left, axes_bot, axes_wid, axes_hght))
+
+        _plot_background(min_u, max_u, min_v, max_v)
+        _plot_data(vad, params)
+
+        if location:
+            title = "%s (%s) VWP valid %s" % (
+                rid,
+                location,
+                vad["time"].strftime("%d %b %Y %H%M UTC"),
+            )
+        else:
+            title = "%s VWP valid %s" % (
+                rid,
+                vad["time"].strftime("%d %b %Y %H%M UTC"),
+            )
+
+        pylab.xlim(min_u, max_u)
+        pylab.ylim(min_v, max_v)
+        pylab.xticks([])
+        pylab.yticks([])
+        pylab.title(title, fontsize=11)
+
+        buf = io.BytesIO()
+        pylab.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+        pylab.close()
+        buf.seek(0)
+        img = Image.open(buf).convert("RGB")
+        frames.append(img)
+        buf.close()
+
+    if not frames:
+        return False
+
+    # Create per-frame durations: last frame lingers, others at normal speed
+    durations = [frame_duration_ms] * len(frames)
+    durations[-1] = linger_duration_ms
+
+    frames[0].save(
+        fname,
+        format="GIF",
+        append_images=frames[1:],
+        save_all=True,
+        duration=durations,
+        loop=0,
+        optimize=False,
+    )
+
+    for img in frames:
+        img.close()
+
+    return True

--- a/lib/vad_plotter/vad_reader.py
+++ b/lib/vad_plotter/vad_reader.py
@@ -676,3 +676,40 @@ async def download_vad(
         return vad
 
     raise ValueError(f"VAD data unavailable for {rid}")
+
+
+async def download_vads_batch(rid: str, max_frames: int = 10) -> List[VADFile]:
+    """Download the N most recent VAD files concurrently for a radar site."""
+    times = await _list_s3_vad_times(rid)
+    if not times:
+        raise ValueError(f"No VAD files found for {rid}")
+
+    targets = times[:max_frames]
+
+    async def _fetch_one(key: str, ts: datetime) -> Optional[VADFile]:
+        session = aioboto3.Session()
+        try:
+            async with session.client(
+                "s3",
+                config=Config(signature_version=botocore.UNSIGNED),
+                region_name="us-east-1",
+            ) as s3:
+                resp = await s3.get_object(Bucket=_S3_BUCKET, Key=key)
+                content = await resp["Body"].read()
+                if content:
+                    vad = VADFile(content)
+                    vad.rid = rid
+                    return vad
+        except Exception as e:
+            logger.warning(f"[VAD] Batch fetch failed for {rid} key={key}: {e}")
+        return None
+
+    tasks = [_fetch_one(key, ts) for key, ts in targets]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    vads: List[VADFile] = []
+    for r in results:
+        if isinstance(r, VADFile):
+            vads.append(r)
+    vads.sort(key=lambda v: v["time"])
+    return vads


### PR DESCRIPTION
Adds `/hodogif` command for animated VWP hodograph loops.

## Changes
- Parallel S3 downloads via `download_vads_batch()` (~2x faster for multiple VADs)
- New `plot_hodograph_gif()` generates animated GIF with last-frame linger support
- `/hodogif` generates animated loops (default 6 frames = ~30 min of data)
- `/hodograph` unchanged - still returns single most-recent scan
- Default: 1s per frame, last frame lingers 3s for the most recent scan
- Auto-downsizes frames if GIF exceeds 25MB Discord limit

## Usage
- `/hodograph KTLX` - static single image (unchanged)
- `/hodogif KTLX` - 6-frame animated loop (~30 min)
- `/hodogif KTLX --frames 10` - 10-frame animated loop (~50 min)

## Performance
- 6 frames: ~4s, 0.26 MB
- 10 frames: ~24s, 0.36 MB
