### PR TITLE
fix: warning classification gaps and related bugs

### DIFF
--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -346,7 +346,6 @@ class AnalyticsCog(commands.Cog):
             f"**{tor['total']}** total\n"
             f"🚨 TORE: {tor['emergency']}\n"
             f"⚠️ TORP: {tor['pds']}\n"
-            f"✅ Confirmed: {tor['observed']}\n"
             f"📡 TORR: {tor['observed']}\n"
             f"TOR: {tor['radar_indicated']}"
         )

--- a/cogs/warning_format.py
+++ b/cogs/warning_format.py
@@ -278,7 +278,6 @@ def get_tornado_attributes(
         "TORNADO...OBSERVED" in text_upper
         or "CONFIRMED TORNADO" in text_upper
         or "CONFIRMED LARGE" in text_upper
-        or "CONFIRMED TORNADO WAS" in text_upper
     ):
         confidence = "observed"
 

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -485,7 +485,6 @@ class WarningsCog(commands.Cog):
             "TORNADO...OBSERVED" in text_upper
             or "CONFIRMED TORNADO" in text_upper
             or "CONFIRMED LARGE" in text_upper
-            or "CONFIRMED TORNADO WAS" in text_upper
             or "TORNADO EMERGENCY" in text_upper
         ):
             is_confirmed = True
@@ -498,7 +497,10 @@ class WarningsCog(commands.Cog):
         # Trigger on Tornado Warning, Tornado Emergency, or SVS with confirmed tornado
         is_tornado = event in ("Tornado Warning", "Tornado Emergency")
         is_svs_with_tornado = event == "Severe Weather Statement" and (
-            "TORNADO...OBSERVED" in text_upper or "CONFIRMED TORNADO" in text_upper
+            "TORNADO...OBSERVED" in text_upper
+            or "CONFIRMED TORNADO" in text_upper
+            or "CONFIRMED LARGE" in text_upper
+            or "TORNADO EMERGENCY" in text_upper
         )
 
         if is_confirmed and (is_tornado or is_svs_with_tornado):
@@ -1069,6 +1071,13 @@ class WarningsCog(commands.Cog):
                         )
                     except Exception as e:
                         logger.warning(f"Failed to persist {issuance_id}: {e}")
+                        # Message already sent — register in-memory to prevent
+                        # re-discovery on next poll (duplicate post)
+                        self.bot.state.posted_warnings[issuance_id] = {
+                            "message_id": msg.id,
+                            "channel_id": msg.channel.id,
+                            "area": area_desc,
+                        }
             except Exception as e:
                 logger.exception(f"Unhandled error discovering {issuance_id}: {e}")
             finally:

--- a/models/nws.py
+++ b/models/nws.py
@@ -15,6 +15,7 @@ class NWSAlertParameters(BaseModel):
     maxWindGust: Optional[List[str]] = None
     tornadoDetection: Optional[List[str]] = None
     tornadoDamageThreat: Optional[List[str]] = None
+    tornadoPossible: Optional[List[str]] = None
     thunderstormDamageThreat: Optional[List[str]] = None
     flashFloodDamageThreat: Optional[List[str]] = None
     flashFloodDetection: Optional[List[str]] = None

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -417,7 +417,7 @@ class TestGetWarningStyle:
         emoji, display_event, color, footer_id = get_warning_style(
             "Tornado Warning",
             "",
-            params={"tornadoDamageThreat": "CATASTROPHIC"},
+            params={"tornadoDamageThreat": ["CATASTROPHIC"]},
         )
         assert "Tornado Emergency" in display_event
         assert emoji == "🚨🚨"
@@ -427,7 +427,7 @@ class TestGetWarningStyle:
         emoji, display_event, _, footer_id = get_warning_style(
             "Severe Thunderstorm Warning",
             "",
-            params={"thunderstormDamageThreat": "DESTRUCTIVE"},
+            params={"thunderstormDamageThreat": ["DESTRUCTIVE"]},
         )
         assert "DESTRUCTIVE" in display_event
         assert footer_id == "EWX"


### PR DESCRIPTION

**Summary**
Five fixes addressing gaps in tornado classification, duplicate warning posts, and stale/inconsistent patterns.

**Changes**

1. **`models/nws.py`** — Added `tornadoPossible: Optional[List[str]] = None` to `NWSAlertParameters`. Without this, Pydantic silently stripped the field on parse, making the `tornado: POSSIBLE` tag dead code via the NWS API path.

2. **`cogs/warning_format.py`** — Removed redundant `"CONFIRMED TORNADO WAS"` check (substring of `"CONFIRMED TORNADO"`, never independently reached).

3. **`cogs/warnings.py`** — Three fixes:
   - `_check_and_log_significant_event`: Added `"CONFIRMED LARGE"` and `"TORNADO EMERGENCY"` to the SVS path so Severe Weather Statements with those patterns register for `/recenttornadoes`.
   - Removed redundant `"CONFIRMED TORNADO WAS"` check in `is_confirmed`.
   - `_discover_and_post_warning`: On `claim.confirm()` failure after the Discord message was sent, keeps the warning in the in-memory `posted_warnings` dict to prevent re-discovery and duplicate post on the next poll cycle. The claim's `__aexit__` only removes empty-dict placeholders, so writing a minimal real entry (`message_id`, `channel_id`, `area`) prevents rollback.

4. **`cogs/analytics.py`** — Removed duplicate `"Confirmed"` line that displayed `tor['observed']` under two labels. The `TORR` label now covers it.

5. **`tests/test_warnings.py`** — Fixed `params` test data to use lists (`["CATASTROPHIC"]`, `["DESTRUCTIVE"]`) matching the NWS API response format, instead of bare strings.

**Testing**
All 557 tests pass.
