### PR TITLE
fix: CON updates skip tornado confirmation check, NULL confidence in stats

### DIFF
--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -975,6 +975,9 @@ class WarningsCog(commands.Cog):
                                 # Update stored area so we don't spam updates for every poll
                                 description = props.description or ""
                                 params = props.parameters.model_dump() if props.parameters else {}
+                                await self._check_and_log_significant_event(
+                                    event, description, vtec_dict, params
+                                )
                                 _, corrected_event, _, _ = get_warning_style(
                                     event, description, params, vtec=vtec_dict
                                 )

--- a/cogs/warnings.py
+++ b/cogs/warnings.py
@@ -960,24 +960,29 @@ class WarningsCog(commands.Cog):
                         if issuance_id not in self._in_flight_vtecs:
                             self._in_flight_vtecs.add(issuance_id)
                             try:
+                                description = props.description or ""
+                                params = props.parameters.model_dump() if props.parameters else {}
                                 try:
                                     event_ch = await self._resolve_warning_channel(
                                         event, vtec_phenom=vtec_dict.get("phenom")
                                     )
                                     if event_ch is None:
+                                        # No channel to post to (disabled/misconfigured), but
+                                        # still log confirmed tornadoes to /recenttornadoes —
+                                        # _post_warning (which normally does this) never runs.
+                                        await self._check_and_log_significant_event(
+                                            event, description, vtec_dict, params
+                                        )
                                         continue
                                     await self._post_warning(
                                         feature, event_ch, vtec_dict, event, is_update=True
                                     )
                                 except discord.HTTPException as e:
                                     logger.exception(f"Update send failed for {issuance_id}: {e}")
+                                    # _post_warning already logged significant events before
+                                    # the send failed, so nothing more to do here.
 
                                 # Update stored area so we don't spam updates for every poll
-                                description = props.description or ""
-                                params = props.parameters.model_dump() if props.parameters else {}
-                                await self._check_and_log_significant_event(
-                                    event, description, vtec_dict, params
-                                )
                                 _, corrected_event, _, _ = get_warning_style(
                                     event, description, params, vtec=vtec_dict
                                 )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -44,6 +44,26 @@ async def test_prune_posted_warnings_keeps_most_recent(isolated_db):
     assert "ID:7" in remaining
 
 
+async def test_get_warning_stats_null_confidence_counts_as_radar_indicated(isolated_db):
+    """Legacy rows with NULL tornado_confidence must still land in a
+    subcategory bucket instead of being dropped (observed + radar_indicated
+    should equal total)."""
+    await db.add_posted_warning(
+        "KOUN.TO.W.0001", 1, 2, posted_at=1.0, tornado_confidence="observed"
+    )
+    await db.add_posted_warning(
+        "KOUN.TO.W.0002", 2, 2, posted_at=2.0, tornado_confidence="radar_indicated"
+    )
+    await db.add_posted_warning("KOUN.TO.W.0003", 3, 2, posted_at=3.0, tornado_confidence=None)
+
+    stats = await db.get_warning_stats()
+
+    assert stats["tor"]["total"] == 3
+    assert stats["tor"]["observed"] == 1
+    assert stats["tor"]["radar_indicated"] == 2
+    assert stats["tor"]["observed"] + stats["tor"]["radar_indicated"] == stats["tor"]["total"]
+
+
 # ── Integrity & Serialization ──────────────────────────────────────────────
 
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -796,9 +796,7 @@ async def test_tick_con_area_change_logs_confirmed_tornado(monkeypatch):
     )
     monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
-    monkeypatch.setattr(
-        "utils.state_store.find_matching_tornado", AsyncMock(return_value=None)
-    )
+    monkeypatch.setattr("utils.state_store.find_matching_tornado", AsyncMock(return_value=None))
     mock_add_sig_event = AsyncMock()
     monkeypatch.setattr(warnings_mod, "add_significant_event", mock_add_sig_event)
 
@@ -850,9 +848,7 @@ async def test_tick_con_area_change_logs_tornado_when_channel_disabled(monkeypat
     )
     monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
     monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
-    monkeypatch.setattr(
-        "utils.state_store.find_matching_tornado", AsyncMock(return_value=None)
-    )
+    monkeypatch.setattr("utils.state_store.find_matching_tornado", AsyncMock(return_value=None))
     monkeypatch.setattr(cog, "_resolve_warning_channel", AsyncMock(return_value=None))
     mock_add_sig_event = AsyncMock()
     monkeypatch.setattr(warnings_mod, "add_significant_event", mock_add_sig_event)

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -473,6 +473,7 @@ def _nws_feature(
     event: str = "Severe Thunderstorm Warning",
     area: str = "Noble, Garfield",
     ugc: list | None = None,
+    description: str = "Test description.",
 ) -> dict:
     """Build a minimal NWS GeoJSON feature dict."""
     return {
@@ -483,7 +484,7 @@ def _nws_feature(
             "areaDesc": area,
             "event": event,
             "headline": f"{event} until 9:00 PM CDT",
-            "description": "Test description.",
+            "description": description,
             "instruction": None,
             "response": "Shelter",
             "parameters": {
@@ -744,6 +745,125 @@ async def test_tick_con_area_change_posts_partial_update(monkeypatch):
     channel.send.assert_called_once()
     # Stored area should be updated to current area
     assert cog.bot.state.posted_warnings[vtec_id]["area"] == "Noble, Garfield"
+
+
+@pytest.mark.asyncio
+async def test_tick_con_area_change_logs_confirmed_tornado(monkeypatch):
+    """A CON area-change update carrying newly-confirmed tornado wording must
+    be logged to the significant-events table (regression for the CON path
+    previously skipping _check_and_log_significant_event)."""
+    vtec_id = "KOUN.TO.W.0042"
+    active = {
+        vtec_id: {
+            "office": "KOUN",
+            "phenom": "TO",
+            "sig": "W",
+            "etn": "0042",
+            "vtec_id": vtec_id,
+            "action": "CON",
+        }
+    }
+    posted = {vtec_id: {"message_id": 1, "channel_id": 2, "area": "Noble, Garfield, Grant"}}
+
+    cog, channel = _make_tick_cog(active=active, posted=posted)
+
+    vtec_str = "/O.CON.KOUN.TO.W.0042.260429T2018Z-260429T2115Z/"
+    feature = _nws_feature(
+        vtec_str,
+        event="Tornado Warning",
+        area="Noble, Garfield",
+        description="TORNADO...OBSERVED near Norman, moving east at 35 mph.",
+    )
+    content = _nws_response([feature])
+
+    msg_mock = AsyncMock()
+    msg_mock.id = 1
+    msg_mock.channel.id = 2
+    channel.send.return_value = msg_mock
+
+    async def _mock_add_warning(vtec_id, msg_id, chan_id, *args, **kwargs):
+        cog.bot.state.posted_warnings[vtec_id] = {
+            "message_id": msg_id,
+            "channel_id": chan_id,
+            "area": kwargs.get("area", ""),
+        }
+
+    cog.bot.state.add_posted_warning = AsyncMock(side_effect=_mock_add_warning)
+    cog.bot.state.add_posted_product_id = AsyncMock()
+
+    monkeypatch.setattr(
+        warnings_mod, "http_get_bytes_conditional", AsyncMock(return_value=(content, 200, {}))
+    )
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
+    monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
+    monkeypatch.setattr(
+        "utils.state_store.find_matching_tornado", AsyncMock(return_value=None)
+    )
+    mock_add_sig_event = AsyncMock()
+    monkeypatch.setattr(warnings_mod, "add_significant_event", mock_add_sig_event)
+
+    await cog._tick()
+
+    # _post_warning already logs significant events internally; the CON
+    # branch must not log it a second time on the success path.
+    mock_add_sig_event.assert_awaited_once()
+    _, kwargs = mock_add_sig_event.call_args
+    assert kwargs["event_type"] == "Tornado"
+    assert kwargs["vtec_id"] == vtec_id
+
+
+@pytest.mark.asyncio
+async def test_tick_con_area_change_logs_tornado_when_channel_disabled(monkeypatch):
+    """If the target channel is disabled/misconfigured, _resolve_warning_channel
+    returns None and _post_warning (which normally logs significant events)
+    never runs — the CON branch must still log the confirmed tornado so it
+    isn't silently dropped from /recenttornadoes."""
+    vtec_id = "KOUN.TO.W.0042"
+    active = {
+        vtec_id: {
+            "office": "KOUN",
+            "phenom": "TO",
+            "sig": "W",
+            "etn": "0042",
+            "vtec_id": vtec_id,
+            "action": "CON",
+        }
+    }
+    posted = {vtec_id: {"message_id": 1, "channel_id": 2, "area": "Noble, Garfield, Grant"}}
+
+    cog, channel = _make_tick_cog(active=active, posted=posted)
+
+    vtec_str = "/O.CON.KOUN.TO.W.0042.260429T2018Z-260429T2115Z/"
+    feature = _nws_feature(
+        vtec_str,
+        event="Tornado Warning",
+        area="Noble, Garfield",
+        description="TORNADO...OBSERVED near Norman, moving east at 35 mph.",
+    )
+    content = _nws_response([feature])
+
+    cog.bot.state.add_posted_warning = AsyncMock()
+    cog.bot.state.add_posted_product_id = AsyncMock()
+
+    monkeypatch.setattr(
+        warnings_mod, "http_get_bytes_conditional", AsyncMock(return_value=(content, 200, {}))
+    )
+    monkeypatch.setattr(warning_format_mod, "_attach_warning_image_async", AsyncMock())
+    monkeypatch.setattr(warnings_mod, "http_get_bytes", AsyncMock(return_value=(None, 404)))
+    monkeypatch.setattr(
+        "utils.state_store.find_matching_tornado", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(cog, "_resolve_warning_channel", AsyncMock(return_value=None))
+    mock_add_sig_event = AsyncMock()
+    monkeypatch.setattr(warnings_mod, "add_significant_event", mock_add_sig_event)
+
+    await cog._tick()
+
+    channel.send.assert_not_called()
+    mock_add_sig_event.assert_awaited_once()
+    _, kwargs = mock_add_sig_event.call_args
+    assert kwargs["event_type"] == "Tornado"
+    assert kwargs["vtec_id"] == vtec_id
 
 
 @pytest.mark.asyncio

--- a/utils/db.py
+++ b/utils/db.py
@@ -729,7 +729,7 @@ async def get_warning_stats(
                         stats["tor"]["standard"] += 1
                     if confidence == "observed":
                         stats["tor"]["observed"] += 1
-                    elif confidence == "radar_indicated":
+                    else:
                         stats["tor"]["radar_indicated"] += 1
 
                 elif phenom == "SV":


### PR DESCRIPTION

**Changes**

1. **`cogs/warnings.py`** — CON area-change (partial cancellation) now calls `_check_and_log_significant_event` before updating the stored area. Previously, tornado confirmations in CON text were not logged for `/recenttornadoes`.

2. **`utils/db.py`** — `get_warning_stats` now defaults NULL `tornado_confidence` to `radar_indicated` instead of silently dropping the warning from subcategory counts. This could cause `observed + radar_indicated < total` for older records with missing data.

**Testing**
All 557 tests pass.
