### PR TITLE
Post outlook text and analysis in a thread from images

### DIFF
--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -710,17 +710,25 @@ class AISummariesCog(commands.Cog, name="AI Summaries"):
                 return
 
             if isinstance(summary, list) and len(summary) > 0:
-                # Paginated view
                 view = RegionalAnalysisView(day, summary, current_page=0)
-                await interaction.followup.send(embed=view._create_embed(), view=view)
+                embed = view._create_embed()
             else:
-                # Fallback for old cache or string response
                 embed = discord.Embed(
                     title=f"🪄 AI Analysis (Day {day} Outlook)",
                     description=str(summary),
                     color=discord.Color.blue(),
                 )
-                await interaction.followup.send(embed=embed)
+                view = None
+
+            thread = interaction.message.thread if interaction.message else None
+            if thread:
+                await thread.send(embed=embed, view=view)
+                await interaction.followup.send(
+                    f"AI analysis posted in the [thread]({thread.jump_url})!",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.followup.send(embed=embed, view=view)
         except Exception as e:
             logger.exception(f"Error in _handle_outlook_summary: {e}")
             try:

--- a/cogs/outlooks.py
+++ b/cogs/outlooks.py
@@ -150,7 +150,7 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
         if files:
             try:
                 view = OutlookSummaryView(day=str(day))
-                await channel.send(
+                msg = await channel.send(
                     f"**Latest SPC Day {day} Outlooks**",
                     files=[discord.File(fp) for fp in files],
                     view=view,
@@ -160,10 +160,31 @@ async def check_and_post_day(channel: discord.TextChannel, day: int, state):
                 await set_posted_urls(day_key, urls)
                 logger.info(f"[Day {day}] Posted {len(files)} images. URLs: {urls}")
 
-                # Proactively trigger AI summary generation and autopost it
+                # Create thread for outlook text and AI summary
+                thread = None
+                try:
+                    thread = await msg.create_thread(
+                        name=f"SPC Day {day} Outlook",
+                        auto_archive_duration=1440,
+                    )
+                    from cogs.ai_summaries import _fetch_outlook_text
+
+                    raw_text = await _fetch_outlook_text(str(day))
+                    if raw_text:
+                        text_embed = discord.Embed(
+                            title=f"SPC Day {day} Outlook Discussion",
+                            description=raw_text[:6000],
+                            color=discord.Color.dark_gray(),
+                        )
+                        await thread.send(embed=text_embed)
+                except Exception as e:
+                    logger.warning(f"[Day {day}] Failed to create thread: {e}")
+
+                # Proactively trigger AI summary in thread (or channel as fallback)
                 from cogs.ai_summaries import autopost_outlook_summary
 
-                t = asyncio.create_task(autopost_outlook_summary(channel, str(day)))
+                target = thread or channel
+                t = asyncio.create_task(autopost_outlook_summary(target, str(day)))
                 t.add_done_callback(
                     lambda t: (
                         logger.debug(f"[Day {day}] AI summary autopost finished")
@@ -273,7 +294,7 @@ class OutlooksCog(commands.Cog):
             if files:
                 try:
                     view = OutlookSummaryView(day="48")
-                    await channel.send(
+                    msg = await channel.send(
                         "**Latest SPC Day 4-8 Outlook**",
                         files=[discord.File(fp) for fp in files],
                         view=view,
@@ -282,10 +303,31 @@ class OutlooksCog(commands.Cog):
                     self.bot.state.last_posted_urls["day48"] = urls
                     await set_posted_urls("day48", urls)
 
-                    # Autopost AI summary
+                    # Create thread for outlook text and AI summary
+                    thread = None
+                    try:
+                        thread = await msg.create_thread(
+                            name="SPC Day 4-8 Outlook",
+                            auto_archive_duration=1440,
+                        )
+                        from cogs.ai_summaries import _fetch_outlook_text
+
+                        raw_text = await _fetch_outlook_text("48")
+                        if raw_text:
+                            text_embed = discord.Embed(
+                                title="SPC Day 4-8 Outlook Discussion",
+                                description=raw_text[:6000],
+                                color=discord.Color.dark_gray(),
+                            )
+                            await thread.send(embed=text_embed)
+                    except Exception as e:
+                        logger.warning(f"[Day 48] Failed to create thread: {e}")
+
+                    # Autopost AI summary in thread (or channel as fallback)
                     from cogs.ai_summaries import autopost_outlook_summary
 
-                    t = asyncio.create_task(autopost_outlook_summary(channel, "48"))
+                    target = thread or channel
+                    t = asyncio.create_task(autopost_outlook_summary(target, "48"))
                     t.add_done_callback(
                         lambda t: (
                             logger.debug("[Day 48] AI summary autopost finished")


### PR DESCRIPTION
After posting the 4 outlook images (categorical, tor, wind, hail) to the channel, the bot now creates a public thread and posts the full outlook discussion text as an embed, followed by the analysis summary — keeping the main channel clean while making the full text one click away.

**Changes:**
- `cogs/outlooks.py`: Captures the image message, creates a thread (`SPC Day N Outlook`, 24h auto-archive), posts outlook text embed, and passes the thread to the analysis poster
- `cogs/ai_summaries.py`: The analysis button checks for a thread on the message — if found, it posts the analysis in the thread (with an ephemeral link to it) instead of cluttering the channel
- Falls back gracefully to channel posting if thread creation fails (e.g. missing permissions)
- Applies to Days 1–3 and Day 4–8 auto-posts

**Flow:**
1. Main channel → 4 images (glanceable)
2. Thread → outlook discussion text expandable
3. Same thread → analysis summary

Closes #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SPC outlook posts now receive dedicated discussion threads.
  - Outlook discussion text and AI-generated summaries are posted directly in the related thread.
  - Summary messages include pagination controls when multiple regional analyses are available.
  - Users receive a link to the discussion thread after requesting an AI summary.
  - Improved fallback behavior sends summaries directly to the channel when a thread cannot be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->