### PR TITLE
fix: strip query strings from logged URLs

### DIFF
--- a/utils/http.py
+++ b/utils/http.py
@@ -257,7 +257,7 @@ async def http_get_bytes_conditional(
     host = parsed.netloc
 
     if circuit_breaker.is_open(host):
-        logger.debug(f"Circuit open for {host}, failing fast: {url.split('?')[0]}")
+        logger.debug(f"Circuit open for {host}, failing fast: {url}")
         raise CircuitOpenError(f"Circuit breaker is open for {host}")
 
     headers: Dict[str, str] = dict(extra_headers) if extra_headers else {}
@@ -319,7 +319,7 @@ async def http_get_bytes_conditional(
         if status == 0 or status >= 500 or status == 429:
             circuit_breaker.record_failure(host)
 
-        logger.warning(f"Request failed for {url.split('?')[0]} after {retries} retries: {e}")
+        logger.warning(f"Request failed for {url} after {retries} retries: {e}")
         return None, status, None
 
 
@@ -352,7 +352,7 @@ async def http_head_ok(url: str, timeout: int = 20) -> bool:
     except Exception as e:
         # Standard exceptions (timeout, conn error) always count as failure
         circuit_breaker.record_failure(host)
-        logger.warning(f"HEAD check failed for {url}: {type(e).__name__}: {e}")
+        logger.warning(f"HEAD check failed for {url.split('?')[0]}: {type(e).__name__}: {e}")
         return False
 
 
@@ -377,7 +377,7 @@ async def http_head_meta(url: str, timeout: int = 20) -> Optional[Dict[str, str]
             }
     except Exception as e:
         circuit_breaker.record_failure(host)
-        logger.warning(f"HEAD meta failed for {url}: {type(e).__name__}: {e}")
+        logger.warning(f"HEAD meta failed for {url.split('?')[0]}: {type(e).__name__}: {e}")
         return None
 
 
@@ -404,7 +404,7 @@ async def http_get_json(
                     message="Server returned retryable error",
                 )
             if r.status != 200:
-                logger.warning(f"JSON fetch failed for {url}: {r.status}")
+                logger.warning(f"JSON fetch failed for {url.split('?')[0]}: {r.status}")
                 # Only trip the circuit on server-side / rate-limit errors.
                 # 4xx responses (including the 404s IEM emits during
                 # availability probing) are expected and should not open
@@ -421,7 +421,7 @@ async def http_get_json(
         status = getattr(e, "status", None)
         if status is None or status >= 500 or status == 429:
             circuit_breaker.record_failure(host)
-        logger.warning(f"JSON fetch error for {url}: {type(e).__name__}: {e}")
+        logger.warning(f"JSON fetch error for {url.split('?')[0]}: {type(e).__name__}: {e}")
         return None
 
 
@@ -457,7 +457,7 @@ async def http_post_json(
                 )
             if r.status != 200:
                 text = await r.text()
-                logger.warning(f"JSON POST failed for {url.split('?')[0]}: {r.status} {text}")
+                logger.warning(f"JSON POST failed for {url}: {r.status} {text}")
                 if r.status >= 500 or r.status == 429:
                     circuit_breaker.record_failure(host)
                 return None
@@ -470,5 +470,5 @@ async def http_post_json(
         status = getattr(e, "status", None)
         if status is None or status >= 500 or status == 429:
             circuit_breaker.record_failure(host)
-        logger.warning(f"JSON POST error for {url.split('?')[0]}: {type(e).__name__}: {e}")
+        logger.warning(f"JSON POST error for {url}: {type(e).__name__}: {e}")
         return None

--- a/utils/http.py
+++ b/utils/http.py
@@ -257,7 +257,7 @@ async def http_get_bytes_conditional(
     host = parsed.netloc
 
     if circuit_breaker.is_open(host):
-        logger.debug(f"Circuit open for {host}, failing fast: {url}")
+        logger.debug(f"Circuit open for {host}, failing fast: {url.split('?')[0]}")
         raise CircuitOpenError(f"Circuit breaker is open for {host}")
 
     headers: Dict[str, str] = dict(extra_headers) if extra_headers else {}
@@ -319,7 +319,7 @@ async def http_get_bytes_conditional(
         if status == 0 or status >= 500 or status == 429:
             circuit_breaker.record_failure(host)
 
-        logger.warning(f"Request failed for {url} after {retries} retries: {e}")
+        logger.warning(f"Request failed for {url.split('?')[0]} after {retries} retries: {e}")
         return None, status, None
 
 
@@ -457,7 +457,7 @@ async def http_post_json(
                 )
             if r.status != 200:
                 text = await r.text()
-                logger.warning(f"JSON POST failed for {url}: {r.status} {text}")
+                logger.warning(f"JSON POST failed for {url.split('?')[0]}: {r.status} {text}")
                 if r.status >= 500 or r.status == 429:
                     circuit_breaker.record_failure(host)
                 return None
@@ -470,5 +470,5 @@ async def http_post_json(
         status = getattr(e, "status", None)
         if status is None or status >= 500 or status == 429:
             circuit_breaker.record_failure(host)
-        logger.warning(f"JSON POST error for {url}: {type(e).__name__}: {e}")
+        logger.warning(f"JSON POST error for {url.split('?')[0]}: {type(e).__name__}: {e}")
         return None


### PR DESCRIPTION
Strips query parameters from URLs before logging in `utils/http.py` to prevent API keys (like the Gemini key in `?key=...`) from appearing in plain-text logs.

- Line 260: circuit breaker debug log
- Line 322/460: request failure warnings  
- Line 473: JSON POST error log

Previously, if a Gemini API call failed, the full URL including `?key=AIza...` was written to the journal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request/response failure logging by omitting query parameters from URLs, reducing exposure of sensitive URL details in logs.
  * Preserved existing request behavior, retry handling, and circuit-breaker functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->