### PR TITLE
fix: log and retry MD image recovery edits instead of silent failure

### DIFF
--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -601,7 +601,8 @@ class MesoscaleCog(commands.Cog):
                 view = MDSummaryView(md_num=str(md_num), raw_text=full_text or "")
                 await message.edit(embeds=[img_embed, text_embed], attachments=files, view=view)
                 return True
-            except Exception:
+            except Exception as e:
+                logger.warning(f"Failed to edit MD #{md_num} message: {e}")
                 return False
 
         for attempt in range(20):
@@ -639,8 +640,10 @@ class MesoscaleCog(commands.Cog):
                         logger.info(f"Recovered image for #{md_num}")
                         break
             if changed:
-                await _push_edit()
-            if cache_path and full_text:
+                edit_ok = await _push_edit()
+                if edit_ok and cache_path and full_text:
+                    break
+            elif cache_path and full_text:
                 break
 
     async def post_md_now(self, md_num: str):

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -605,6 +605,7 @@ class MesoscaleCog(commands.Cog):
                 logger.warning(f"Failed to edit MD #{md_num} message: {e}")
                 return False
 
+        edit_pending = False
         for attempt in range(20):
             delay = 10 if attempt < 6 else 30
             await asyncio.sleep(delay)
@@ -640,9 +641,13 @@ class MesoscaleCog(commands.Cog):
                         logger.info(f"Recovered image for #{md_num}")
                         break
             if changed:
+                edit_pending = True
+            if edit_pending:
                 edit_ok = await _push_edit()
-                if edit_ok and cache_path and full_text:
-                    break
+                if edit_ok:
+                    edit_pending = False
+                    if cache_path and full_text:
+                        break
             elif cache_path and full_text:
                 break
 


### PR DESCRIPTION
When a Mesoscale Discussion image arrives after the initial post (SPC/IEM are often delayed), `_upgrade_md_message` downloads it and calls `_push_edit` to edit the existing message with the image.

**Two bugs fixed:**

1. **Silent failure** — `_push_edit` caught all exceptions with bare `except Exception: return False`, swallowing the error. Now logs the exception via `logger.warning`.

2. **Edit failure never retried** — The caller ignored `_push_edit`'s return value. Even if the edit failed, the loop hit `if cache_path and full_text: break` and exited immediately. Now the loop only breaks when the edit actually succeeded; a failed edit retries on the next iteration (up to the existing 20-attempt / 8-minute limit).

**Before:** Image downloads at 15:50:17 → `_push_edit` fails silently → loop breaks → message stays image-less forever.

**After:** Image downloads → `_push_edit` failure logged → retries up to 20 attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating mesoscale messages by retrying failed edits and only proceeding after a confirmed successful edit.
  * Added clearer warning details when an edit or update attempt fails.
  * Prevented the update flow from stopping prematurely by tightening the conditions used to continue or exit retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->