### PR TITLE
feat: post MD AI summaries in a Discord thread instead of standalone message

### DIFF
--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -483,8 +483,12 @@ async def autopost_outlook_summary(channel: discord.abc.Messageable, day: str, d
         logger.exception(f"Error autoposting outlook summary for Day {day}: {e}")
 
 
-async def autopost_md_summary(channel: discord.abc.Messageable, md_num: str, delay: float = 0.5):
-    """Wait for MD summary to be ready and post it as a follow-up message."""
+async def autopost_md_summary(
+    md_msg: discord.Message,
+    md_num: str,
+    delay: float = 0.5,
+):
+    """Wait for MD summary to be ready and post it in a thread on the MD message."""
     try:
         import asyncio
 
@@ -495,15 +499,26 @@ async def autopost_md_summary(channel: discord.abc.Messageable, md_num: str, del
                 f"[MD #{md_num}] AI summary returned None (text fetch or API call failed)"
             )
             return
-        if not summary:
-            return
 
         embed = discord.Embed(
             title=f"🪄 AI Summary (MD #{md_num})",
             description=summary,
             color=discord.Color.purple(),
         )
-        await channel.send(embed=embed)
+
+        thread = None
+        try:
+            thread = await md_msg.create_thread(
+                name=f"MD #{md_num}",
+                auto_archive_duration=1440,
+            )
+        except Exception as e:
+            logger.warning(f"[MD #{md_num}] Failed to create thread: {e}")
+
+        if thread:
+            await thread.send(embed=embed)
+        else:
+            await md_msg.channel.send(embed=embed)
     except Exception as e:
         logger.exception(f"Error autoposting MD summary for MD {md_num}: {e}")
 
@@ -702,7 +717,16 @@ class AISummariesCog(commands.Cog, name="AI Summaries"):
                 description=summary,
                 color=discord.Color.purple(),
             )
-            await interaction.followup.send(embed=embed)
+
+            thread = interaction.message.thread if interaction.message else None
+            if thread:
+                await thread.send(embed=embed)
+                await interaction.followup.send(
+                    f"AI analysis posted in the [thread]({thread.jump_url})!",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.followup.send(embed=embed)
         except Exception as e:
             logger.exception(f"Error in _handle_md_summary: {e}")
             try:

--- a/cogs/mesoscale.py
+++ b/cogs/mesoscale.py
@@ -707,7 +707,7 @@ class MesoscaleCog(commands.Cog):
             # Proactively trigger AI summary generation and autopost it
             from cogs.ai_summaries import autopost_md_summary
 
-            t = asyncio.create_task(autopost_md_summary(channel, str(md_num)))
+            t = asyncio.create_task(autopost_md_summary(msg, str(md_num)))
             t.add_done_callback(_log_task_exception)
 
             self.bot.state.posted_mds.add(md_num)
@@ -863,7 +863,7 @@ class MesoscaleCog(commands.Cog):
                     # Autopost AI summary
                     from cogs.ai_summaries import autopost_md_summary
 
-                    t = asyncio.create_task(autopost_md_summary(channel, str(md_num)))
+                    t = asyncio.create_task(autopost_md_summary(msg, str(md_num)))
                     t.add_done_callback(
                         lambda t: (
                             logger.debug(f"[MD {md_num}] AI summary autopost finished")


### PR DESCRIPTION
Mirrors the threading pattern used by convective outlooks and soundings: create a thread named `MD #{num}` on the MD message and post the AI summary inside it. Falls back to `channel.send()` if thread creation fails.

**Changes:**
- `cogs/ai_summaries.py`: `autopost_md_summary` now takes a `discord.Message` instead of a channel, creates a thread, and posts the summary inside. `_handle_md_summary` button handler detects `interaction.message.thread` and posts inside with ephemeral link.
- `cogs/mesoscale.py`: Both call sites (iembot/NWWS path + polling loop) now pass `msg` instead of `channel`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-generated mesoscale summaries are now posted in dedicated discussion threads when available.
  * Users receive a direct link to the summary thread after requesting a summary.
* **Bug Fixes**
  * Improved summary posting reliability with a fallback to the original channel when thread creation is unavailable.
  * Updated automatic and on-demand summary posting to use the correct message context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->