### PR TITLE
fix: use fetch_thread() fallback when resolving message thread

### DIFF
--- a/cogs/ai_summaries.py
+++ b/cogs/ai_summaries.py
@@ -418,6 +418,21 @@ async def ensure_outlook_summary(day: str, raw_text: str = None) -> Any | None:
         return None
 
 
+async def _resolve_message_thread(
+    message: discord.Message | None,
+) -> discord.Thread | None:
+    """Resolve the thread attached to a message, with API fallback for cache misses."""
+    if not message:
+        return None
+    thread = message.thread
+    if thread is not None:
+        return thread
+    try:
+        return await message.fetch_thread()
+    except (discord.NotFound, discord.HTTPException):
+        return None
+
+
 async def autopost_outlook_summary(channel: discord.abc.Messageable, day: str, delay: float = 0.5):
     """Wait for outlook summary to be ready and post it as a follow-up message."""
     try:
@@ -680,7 +695,7 @@ class AISummariesCog(commands.Cog, name="AI Summaries"):
                 color=discord.Color.teal(),
             )
 
-            thread = interaction.message.thread if interaction.message else None
+            thread = await _resolve_message_thread(interaction.message)
             if thread:
                 await thread.send(embed=embed)
                 await interaction.followup.send(
@@ -718,7 +733,7 @@ class AISummariesCog(commands.Cog, name="AI Summaries"):
                 color=discord.Color.purple(),
             )
 
-            thread = interaction.message.thread if interaction.message else None
+            thread = await _resolve_message_thread(interaction.message)
             if thread:
                 await thread.send(embed=embed)
                 await interaction.followup.send(
@@ -761,7 +776,7 @@ class AISummariesCog(commands.Cog, name="AI Summaries"):
                 )
                 view = None
 
-            thread = interaction.message.thread if interaction.message else None
+            thread = await _resolve_message_thread(interaction.message)
             if thread:
                 await thread.send(embed=embed, view=view)
                 await interaction.followup.send(


### PR DESCRIPTION
Addresses CodeRabbit review on PR #613 — `interaction.message.thread` is a lazy property that may not be populated in Discord's cache. Adds `_resolve_message_thread()` helper that checks the cached property first, then falls back to `fetch_thread()` from the API. Applies to all three button handlers (sounding, MD, outlook).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved summary interactions by reliably locating associated message threads.
  * Added graceful handling when a thread is unavailable or cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->